### PR TITLE
feat: include the application operation field in the ManifestWork payload.

### DIFF
--- a/controllers/application/helper.go
+++ b/controllers/application/helper.go
@@ -110,6 +110,7 @@ func getAppSetOwnerName(ownerRefs []metav1.OwnerReference) string {
 // - reset the meta
 // - set the namespace value
 // - ensures the Application Destination is set to in-cluster resource deployment
+// - ensures the operation field is also set if present
 func prepareApplicationForWorkPayload(application *unstructured.Unstructured) unstructured.Unstructured {
 	newApp := &unstructured.Unstructured{}
 	newApp.SetGroupVersionKind(schema.GroupVersionKind{
@@ -120,6 +121,13 @@ func prepareApplicationForWorkPayload(application *unstructured.Unstructured) un
 	newApp.SetNamespace(generateAppNamespace(application.GetNamespace(), application.GetAnnotations()))
 	newApp.SetName(application.GetName())
 	newApp.SetFinalizers(application.GetFinalizers())
+
+	// set the operation field
+	if operation, ok := application.Object["operation"].(map[string]interface{}); ok {
+		newApp.Object["operation"] = operation
+	}
+
+	// set the spec field
 	if newSpec, ok := application.Object["spec"].(map[string]interface{}); ok {
 		if destination, ok := newSpec["destination"].(map[string]interface{}); ok {
 			// empty the name

--- a/controllers/application/helper_test.go
+++ b/controllers/application/helper_test.go
@@ -311,6 +311,24 @@ func Test_prepareApplicationForWorkPayload(t *testing.T) {
 			"server": "originalServer",
 		},
 	}
+	app.Object["operation"] = map[string]interface{}{
+		"info": []interface{}{
+			map[string]interface{}{
+				"name":  "Reason",
+				"value": "ApplicationSet RollingSync triggered a sync of this Application resource.",
+			},
+		},
+		"initiatedBy": map[string]interface{}{
+			"automated": true,
+			"username":  "applicationset-controller",
+		},
+		"retry": map[string]interface{}{},
+		"sync": map[string]interface{}{
+			"syncOptions": []interface{}{
+				"CreateNamespace=true",
+			},
+		},
+	}
 
 	type args struct {
 		application *unstructured.Unstructured
@@ -345,6 +363,24 @@ func Test_prepareApplicationForWorkPayload(t *testing.T) {
 						"server": KubernetesInternalAPIServerAddr,
 					},
 				}
+				expectedApp.Object["operation"] = map[string]interface{}{
+					"info": []interface{}{
+						map[string]interface{}{
+							"name":  "Reason",
+							"value": "ApplicationSet RollingSync triggered a sync of this Application resource.",
+						},
+					},
+					"initiatedBy": map[string]interface{}{
+						"automated": true,
+						"username":  "applicationset-controller",
+					},
+					"retry": map[string]interface{}{},
+					"sync": map[string]interface{}{
+						"syncOptions": []interface{}{
+							"CreateNamespace=true",
+						},
+					},
+				}
 				return expectedApp
 			}(),
 		},
@@ -365,6 +401,11 @@ func Test_prepareApplicationForWorkPayload(t *testing.T) {
 			wantSpec, _, _ := unstructured.NestedMap(tt.want.Object, "spec")
 			if !reflect.DeepEqual(gotSpec, wantSpec) {
 				t.Errorf("prepareApplicationForWorkPayload() Spec = %v, want %v", gotSpec, wantSpec)
+			}
+			gotOperation, _, _ := unstructured.NestedMap(got.Object, "operation")
+			wantOperation, _, _ := unstructured.NestedMap(tt.want.Object, "operation")
+			if !reflect.DeepEqual(gotOperation, wantOperation) {
+				t.Errorf("prepareApplicationForWorkPayload() Operation = %v, want %v", gotOperation, wantOperation)
 			}
 			if !reflect.DeepEqual(got.GetLabels(), tt.want.GetLabels()) {
 				t.Errorf("prepareApplicationForWorkPayload() Labels = %v, want %v", got.GetLabels(), tt.want.GetLabels())


### PR DESCRIPTION
multicloud-integration repo changes to come.

I've tested this change locally and I was able to see the operation field in the ManifestWork payload and when I head over to the managedcluster, the operation field is in the Application CR as well.