### PR TITLE
feat: Update ArgoCD Operator API with restructured Agent/Principal specs

### DIFF
--- a/charts/argocd-agent-addon/Chart.yaml
+++ b/charts/argocd-agent-addon/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.1.0
 description: Argo CD Agent Addon for Open Cluster Management
 name: argocd-agent-addon
 type: application
-version: 0.23.0
+version: 0.24.0

--- a/charts/argocd-agent-addon/crds/argocd-operator-crds.yaml
+++ b/charts/argocd-agent-addon/crds/argocd-operator-crds.yaml
@@ -24275,6 +24275,17 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: argocds.argoproj.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: system
+          path: /convert
+      conversionReviewVersions:
+      - v1alpha1
+      - v1beta1
   group: argoproj.io
   names:
     kind: ArgoCD
@@ -24716,10 +24727,6 @@ spec:
                         description: Client defines the client options for the Agent
                           component.
                         properties:
-                          creds:
-                            description: Creds is the credential identifier for the
-                              agent authentication
-                            type: string
                           enableCompression:
                             description: EnableCompression is the flag to enable compression
                               while sending data between Principal and Agent using
@@ -24729,142 +24736,9 @@ spec:
                             description: EnableWebSocket is the flag to enable WebSocket
                               for event streaming
                             type: boolean
-                          env:
-                            description: Env lets you specify environment for agent
-                              pods
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          image:
-                            description: Image is the name of Argo CD Agent image
-                            type: string
                           keepAliveInterval:
                             description: KeepAliveInterval is the interval for keep-alive
                               pings to the principal
-                            type: string
-                          logFormat:
-                            description: LogFormat refers to the log format used by
-                              the Agent component.
-                            type: string
-                          logLevel:
-                            description: LogLevel refers to the log level used by
-                              the Agent component.
                             type: string
                           mode:
                             description: Mode is the operational mode for the agent
@@ -24879,10 +24753,145 @@ spec:
                               the principal server to connect to.
                             type: string
                         type: object
+                      creds:
+                        description: Creds is the credential identifier for the agent
+                          authentication
+                        type: string
                       enabled:
                         description: Enabled is the flag to enable the Agent component
                           during Argo CD installation. (optional, default `false`)
                         type: boolean
+                      env:
+                        description: Env lets you specify environment for agent pods
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image is the name of Argo CD Agent image
+                        type: string
+                      logFormat:
+                        description: LogFormat refers to the log format used by the
+                          Agent component.
+                        type: string
+                      logLevel:
+                        description: LogLevel refers to the log level used by the
+                          Agent component.
+                        type: string
                       redis:
                         description: Redis defines the Redis options for the Agent
                           component.
@@ -24914,10 +24923,138 @@ spec:
                     description: Principal defines configurations for the Principal
                       component of Argo CD Agent.
                     properties:
+                      auth:
+                        description: Auth is the authentication method for the Principal
+                          component.
+                        type: string
                       enabled:
                         description: Enabled is the flag to enable the Principal component
                           during Argo CD installation. (optional, default `false`)
                         type: boolean
+                      env:
+                        description: Env lets you specify environment for principal
+                          pods
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image is the name of Argo CD Agent image
+                        type: string
                       jwt:
                         description: JWT defines the JWT options for the Principal
                           component.
@@ -24932,6 +25069,14 @@ spec:
                               the JWT signing key.
                             type: string
                         type: object
+                      logFormat:
+                        description: LogFormat refers to the log format used by the
+                          Principal component.
+                        type: string
+                      logLevel:
+                        description: LogLevel refers to the log level used by the
+                          Principal component.
+                        type: string
                       namespace:
                         description: Namespace is the configuration for the Principal
                           component namespace.
@@ -24988,152 +25133,39 @@ spec:
                         description: Server defines the server options for the Principal
                           component.
                         properties:
-                          auth:
-                            description: Auth is the authentication method for the
-                              Principal component.
-                            type: string
                           enableWebSocket:
                             description: EnableWebSocket is the flag to enable the
                               WebSocket on gRPC to stream events to the Agent.
                             type: boolean
-                          env:
-                            description: Env lets you specify environment for principal
-                              pods
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          image:
-                            description: Image is the name of Argo CD Agent image
-                            type: string
                           keepAliveMinInterval:
                             description: KeepAliveMinInterval is the minimum interval
                               between keep-alive messages sent by the Agent to the
                               Principal.
                             type: string
-                          logFormat:
-                            description: LogFormat refers to the log format used by
-                              the Principal component.
-                            type: string
-                          logLevel:
-                            description: LogLevel refers to the log level used by
-                              the Principal component.
-                            type: string
+                          route:
+                            description: |-
+                              Route defines the options for the Route backing the ArgoCD Agent component.
+                              Route is disabled only when explicitly configured with Enabled: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled will toggle the creation of the OpenShift Route, ignored in case of non OpenShift cluster.
+                                  Route is disabled only when explicitly configured with false
+                                type: boolean
+                            type: object
+                          service:
+                            description: |-
+                              Service defines the options for the Service backing the ArgoCD Agent component.
+                              If not set, type ClusterIP will be used by default.
+                            properties:
+                              type:
+                                description: |-
+                                  Type is the ServiceType to use for the Service resource.
+                                  If not set, type ClusterIP will be used by default.
+                                type: string
+                            required:
+                            - type
+                            type: object
                         type: object
                       tls:
                         description: TLS defines the TLS options for the Principal
@@ -25884,6 +25916,15 @@ spec:
                 type: string
               image:
                 description: Image is the ArgoCD container image for all ArgoCD components.
+                type: string
+              imagePullPolicy:
+                description: |-
+                  ImagePullPolicy is the image pull policy for all ArgoCD components.
+                  Valid values are Always, IfNotPresent, Never. If not specified, defaults to the operator's global setting.
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
                 type: string
               import:
                 description: Import is the import/restore options for ArgoCD.
@@ -34875,10 +34916,6 @@ spec:
                         description: Client defines the client options for the Agent
                           component.
                         properties:
-                          creds:
-                            description: Creds is the credential identifier for the
-                              agent authentication
-                            type: string
                           enableCompression:
                             description: EnableCompression is the flag to enable compression
                               while sending data between Principal and Agent using
@@ -34888,142 +34925,9 @@ spec:
                             description: EnableWebSocket is the flag to enable WebSocket
                               for event streaming
                             type: boolean
-                          env:
-                            description: Env lets you specify environment for agent
-                              pods
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          image:
-                            description: Image is the name of Argo CD Agent image
-                            type: string
                           keepAliveInterval:
                             description: KeepAliveInterval is the interval for keep-alive
                               pings to the principal
-                            type: string
-                          logFormat:
-                            description: LogFormat refers to the log format used by
-                              the Agent component.
-                            type: string
-                          logLevel:
-                            description: LogLevel refers to the log level used by
-                              the Agent component.
                             type: string
                           mode:
                             description: Mode is the operational mode for the agent
@@ -35038,10 +34942,145 @@ spec:
                               the principal server to connect to.
                             type: string
                         type: object
+                      creds:
+                        description: Creds is the credential identifier for the agent
+                          authentication
+                        type: string
                       enabled:
                         description: Enabled is the flag to enable the Agent component
                           during Argo CD installation. (optional, default `false`)
                         type: boolean
+                      env:
+                        description: Env lets you specify environment for agent pods
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image is the name of Argo CD Agent image
+                        type: string
+                      logFormat:
+                        description: LogFormat refers to the log format used by the
+                          Agent component.
+                        type: string
+                      logLevel:
+                        description: LogLevel refers to the log level used by the
+                          Agent component.
+                        type: string
                       redis:
                         description: Redis defines the Redis options for the Agent
                           component.
@@ -35073,10 +35112,138 @@ spec:
                     description: Principal defines configurations for the Principal
                       component of Argo CD Agent.
                     properties:
+                      auth:
+                        description: Auth is the authentication method for the Principal
+                          component.
+                        type: string
                       enabled:
                         description: Enabled is the flag to enable the Principal component
                           during Argo CD installation. (optional, default `false`)
                         type: boolean
+                      env:
+                        description: Env lets you specify environment for principal
+                          pods
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image is the name of Argo CD Agent image
+                        type: string
                       jwt:
                         description: JWT defines the JWT options for the Principal
                           component.
@@ -35091,6 +35258,14 @@ spec:
                               the JWT signing key.
                             type: string
                         type: object
+                      logFormat:
+                        description: LogFormat refers to the log format used by the
+                          Principal component.
+                        type: string
+                      logLevel:
+                        description: LogLevel refers to the log level used by the
+                          Principal component.
+                        type: string
                       namespace:
                         description: Namespace is the configuration for the Principal
                           component namespace.
@@ -35147,152 +35322,39 @@ spec:
                         description: Server defines the server options for the Principal
                           component.
                         properties:
-                          auth:
-                            description: Auth is the authentication method for the
-                              Principal component.
-                            type: string
                           enableWebSocket:
                             description: EnableWebSocket is the flag to enable the
                               WebSocket on gRPC to stream events to the Agent.
                             type: boolean
-                          env:
-                            description: Env lets you specify environment for principal
-                              pods
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          image:
-                            description: Image is the name of Argo CD Agent image
-                            type: string
                           keepAliveMinInterval:
                             description: KeepAliveMinInterval is the minimum interval
                               between keep-alive messages sent by the Agent to the
                               Principal.
                             type: string
-                          logFormat:
-                            description: LogFormat refers to the log format used by
-                              the Principal component.
-                            type: string
-                          logLevel:
-                            description: LogLevel refers to the log level used by
-                              the Principal component.
-                            type: string
+                          route:
+                            description: |-
+                              Route defines the options for the Route backing the ArgoCD Agent component.
+                              Route is disabled only when explicitly configured with Enabled: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled will toggle the creation of the OpenShift Route, ignored in case of non OpenShift cluster.
+                                  Route is disabled only when explicitly configured with false
+                                type: boolean
+                            type: object
+                          service:
+                            description: |-
+                              Service defines the options for the Service backing the ArgoCD Agent component.
+                              If not set, type ClusterIP will be used by default.
+                            properties:
+                              type:
+                                description: |-
+                                  Type is the ServiceType to use for the Service resource.
+                                  If not set, type ClusterIP will be used by default.
+                                type: string
+                            required:
+                            - type
+                            type: object
                         type: object
                       tls:
                         description: TLS defines the TLS options for the Principal
@@ -40725,6 +40787,15 @@ spec:
                 type: string
               image:
                 description: Image is the ArgoCD container image for all ArgoCD components.
+                type: string
+              imagePullPolicy:
+                description: |-
+                  ImagePullPolicy is the image pull policy for all ArgoCD components.
+                  Valid values are Always, IfNotPresent, Never. If not specified, defaults to the operator's global setting.
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
                 type: string
               imageUpdater:
                 description: ImageUpdater defines whether the Argo CD ImageUpdater

--- a/charts/argocd-agent-addon/templates/argocd-operator/argocd.yaml
+++ b/charts/argocd-agent-addon/templates/argocd-operator/argocd.yaml
@@ -11,9 +11,15 @@ spec:
   argoCDAgent:
     principal:
       enabled: true
+      auth: "mtls:CN=system:open-cluster-management:cluster:([^:]+):addon:argocd-agent-addon:agent:argocd-agent-addon-agent"
+      image: {{ .Values.argoCDAgentImage }}:{{ .Values.argoCDAgentTag }}
       server:
-        auth: "mtls:CN=system:open-cluster-management:cluster:([^:]+):addon:argocd-agent-addon:agent:argocd-agent-addon-agent"
-        image: {{ .Values.argoCDAgentImage }}:{{ .Values.argoCDAgentTag }}
+        enableWebSocket: false
+        keepAliveMinInterval: "30s"
+        service:
+          type: LoadBalancer
+        route:
+          enabled: false
       namespace:
         allowedNamespaces:
           - "*"

--- a/charts/argocd-agent-addon/values.yaml
+++ b/charts/argocd-agent-addon/values.yaml
@@ -9,7 +9,7 @@ addonTag: latest
 
 # ArgoCD operator image
 argoCDOperatorImage: quay.io/mikeshng/argocd-operator
-argoCDOperatorTag: latest
+argoCDOperatorTag: latest-api
 
 # ArgoCD agent image
 argoCDAgentImage: ghcr.io/argoproj-labs/argocd-agent/argocd-agent

--- a/examples/gitopscluster.yaml
+++ b/examples/gitopscluster.yaml
@@ -10,5 +10,5 @@ spec:
     name: placement
   argoCDAgentAddon:
     mode: managed
-    operatorImage: quay.io/mikeshng/argocd-operator:latest
+    operatorImage: quay.io/mikeshng/argocd-operator:latest-api
     agentImage: ghcr.io/argoproj-labs/argocd-agent/argocd-agent:latest

--- a/internal/addon/addon_install.go
+++ b/internal/addon/addon_install.go
@@ -30,7 +30,7 @@ import (
 
 // Default images (used when not specified)
 const (
-	defaultOperatorImage = "quay.io/mikeshng/argocd-operator:latest"
+	defaultOperatorImage = "quay.io/mikeshng/argocd-operator:latest-api"
 	defaultAgentImage    = "ghcr.io/argoproj-labs/argocd-agent/argocd-agent:latest"
 )
 
@@ -170,10 +170,11 @@ func ParseImageReference(imageRef string) (string, string, error) {
 			repository := imageRef[:lastColonIndex]
 			tag := imageRef[lastColonIndex+1:]
 
-			// Check if this might be a port number instead of a tag
-			// Port numbers are typically numeric and shorter
-			if !strings.Contains(tag, "/") && len(tag) < 10 {
-				// This looks like it could be a tag
+			// Check if this is a tag (not a port number in the registry URL)
+			// Tags don't contain slashes and are typically shorter than paths
+			// Port numbers would be numeric-only
+			if !strings.Contains(tag, "/") {
+				// This looks like a tag
 				return repository, tag, nil
 			}
 		}

--- a/internal/addon/addon_install_integration_test.go
+++ b/internal/addon/addon_install_integration_test.go
@@ -396,10 +396,10 @@ func TestParseImageReferenceEdgeCases(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:     "very long tag defaults to latest",
+			name:     "very long tag is parsed correctly",
 			imageRef: "myimage:this-is-a-very-long-tag-name-with-many-characters",
-			wantRepo: "myimage:this-is-a-very-long-tag-name-with-many-characters",
-			wantTag:  "latest",
+			wantRepo: "myimage",
+			wantTag:  "this-is-a-very-long-tag-name-with-many-characters",
 			wantErr:  false,
 		},
 		{

--- a/internal/addon/charts/argocd-agent-addon/Chart.yaml
+++ b/internal/addon/charts/argocd-agent-addon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: argocd-agent-addon
 description: Argo CD Agent Addon
 type: application
-version: 0.23.0
-appVersion: "0.23.0"
+version: 0.24.0
+appVersion: "0.24.0"

--- a/internal/addon/charts/argocd-agent-addon/crds/argocd-operator-crds.yaml
+++ b/internal/addon/charts/argocd-agent-addon/crds/argocd-operator-crds.yaml
@@ -24275,6 +24275,17 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: argocds.argoproj.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: system
+          path: /convert
+      conversionReviewVersions:
+      - v1alpha1
+      - v1beta1
   group: argoproj.io
   names:
     kind: ArgoCD
@@ -24716,10 +24727,6 @@ spec:
                         description: Client defines the client options for the Agent
                           component.
                         properties:
-                          creds:
-                            description: Creds is the credential identifier for the
-                              agent authentication
-                            type: string
                           enableCompression:
                             description: EnableCompression is the flag to enable compression
                               while sending data between Principal and Agent using
@@ -24729,142 +24736,9 @@ spec:
                             description: EnableWebSocket is the flag to enable WebSocket
                               for event streaming
                             type: boolean
-                          env:
-                            description: Env lets you specify environment for agent
-                              pods
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          image:
-                            description: Image is the name of Argo CD Agent image
-                            type: string
                           keepAliveInterval:
                             description: KeepAliveInterval is the interval for keep-alive
                               pings to the principal
-                            type: string
-                          logFormat:
-                            description: LogFormat refers to the log format used by
-                              the Agent component.
-                            type: string
-                          logLevel:
-                            description: LogLevel refers to the log level used by
-                              the Agent component.
                             type: string
                           mode:
                             description: Mode is the operational mode for the agent
@@ -24879,10 +24753,145 @@ spec:
                               the principal server to connect to.
                             type: string
                         type: object
+                      creds:
+                        description: Creds is the credential identifier for the agent
+                          authentication
+                        type: string
                       enabled:
                         description: Enabled is the flag to enable the Agent component
                           during Argo CD installation. (optional, default `false`)
                         type: boolean
+                      env:
+                        description: Env lets you specify environment for agent pods
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image is the name of Argo CD Agent image
+                        type: string
+                      logFormat:
+                        description: LogFormat refers to the log format used by the
+                          Agent component.
+                        type: string
+                      logLevel:
+                        description: LogLevel refers to the log level used by the
+                          Agent component.
+                        type: string
                       redis:
                         description: Redis defines the Redis options for the Agent
                           component.
@@ -24914,10 +24923,138 @@ spec:
                     description: Principal defines configurations for the Principal
                       component of Argo CD Agent.
                     properties:
+                      auth:
+                        description: Auth is the authentication method for the Principal
+                          component.
+                        type: string
                       enabled:
                         description: Enabled is the flag to enable the Principal component
                           during Argo CD installation. (optional, default `false`)
                         type: boolean
+                      env:
+                        description: Env lets you specify environment for principal
+                          pods
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image is the name of Argo CD Agent image
+                        type: string
                       jwt:
                         description: JWT defines the JWT options for the Principal
                           component.
@@ -24932,6 +25069,14 @@ spec:
                               the JWT signing key.
                             type: string
                         type: object
+                      logFormat:
+                        description: LogFormat refers to the log format used by the
+                          Principal component.
+                        type: string
+                      logLevel:
+                        description: LogLevel refers to the log level used by the
+                          Principal component.
+                        type: string
                       namespace:
                         description: Namespace is the configuration for the Principal
                           component namespace.
@@ -24988,152 +25133,39 @@ spec:
                         description: Server defines the server options for the Principal
                           component.
                         properties:
-                          auth:
-                            description: Auth is the authentication method for the
-                              Principal component.
-                            type: string
                           enableWebSocket:
                             description: EnableWebSocket is the flag to enable the
                               WebSocket on gRPC to stream events to the Agent.
                             type: boolean
-                          env:
-                            description: Env lets you specify environment for principal
-                              pods
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          image:
-                            description: Image is the name of Argo CD Agent image
-                            type: string
                           keepAliveMinInterval:
                             description: KeepAliveMinInterval is the minimum interval
                               between keep-alive messages sent by the Agent to the
                               Principal.
                             type: string
-                          logFormat:
-                            description: LogFormat refers to the log format used by
-                              the Principal component.
-                            type: string
-                          logLevel:
-                            description: LogLevel refers to the log level used by
-                              the Principal component.
-                            type: string
+                          route:
+                            description: |-
+                              Route defines the options for the Route backing the ArgoCD Agent component.
+                              Route is disabled only when explicitly configured with Enabled: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled will toggle the creation of the OpenShift Route, ignored in case of non OpenShift cluster.
+                                  Route is disabled only when explicitly configured with false
+                                type: boolean
+                            type: object
+                          service:
+                            description: |-
+                              Service defines the options for the Service backing the ArgoCD Agent component.
+                              If not set, type ClusterIP will be used by default.
+                            properties:
+                              type:
+                                description: |-
+                                  Type is the ServiceType to use for the Service resource.
+                                  If not set, type ClusterIP will be used by default.
+                                type: string
+                            required:
+                            - type
+                            type: object
                         type: object
                       tls:
                         description: TLS defines the TLS options for the Principal
@@ -25884,6 +25916,15 @@ spec:
                 type: string
               image:
                 description: Image is the ArgoCD container image for all ArgoCD components.
+                type: string
+              imagePullPolicy:
+                description: |-
+                  ImagePullPolicy is the image pull policy for all ArgoCD components.
+                  Valid values are Always, IfNotPresent, Never. If not specified, defaults to the operator's global setting.
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
                 type: string
               import:
                 description: Import is the import/restore options for ArgoCD.
@@ -34875,10 +34916,6 @@ spec:
                         description: Client defines the client options for the Agent
                           component.
                         properties:
-                          creds:
-                            description: Creds is the credential identifier for the
-                              agent authentication
-                            type: string
                           enableCompression:
                             description: EnableCompression is the flag to enable compression
                               while sending data between Principal and Agent using
@@ -34888,142 +34925,9 @@ spec:
                             description: EnableWebSocket is the flag to enable WebSocket
                               for event streaming
                             type: boolean
-                          env:
-                            description: Env lets you specify environment for agent
-                              pods
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          image:
-                            description: Image is the name of Argo CD Agent image
-                            type: string
                           keepAliveInterval:
                             description: KeepAliveInterval is the interval for keep-alive
                               pings to the principal
-                            type: string
-                          logFormat:
-                            description: LogFormat refers to the log format used by
-                              the Agent component.
-                            type: string
-                          logLevel:
-                            description: LogLevel refers to the log level used by
-                              the Agent component.
                             type: string
                           mode:
                             description: Mode is the operational mode for the agent
@@ -35038,10 +34942,145 @@ spec:
                               the principal server to connect to.
                             type: string
                         type: object
+                      creds:
+                        description: Creds is the credential identifier for the agent
+                          authentication
+                        type: string
                       enabled:
                         description: Enabled is the flag to enable the Agent component
                           during Argo CD installation. (optional, default `false`)
                         type: boolean
+                      env:
+                        description: Env lets you specify environment for agent pods
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image is the name of Argo CD Agent image
+                        type: string
+                      logFormat:
+                        description: LogFormat refers to the log format used by the
+                          Agent component.
+                        type: string
+                      logLevel:
+                        description: LogLevel refers to the log level used by the
+                          Agent component.
+                        type: string
                       redis:
                         description: Redis defines the Redis options for the Agent
                           component.
@@ -35073,10 +35112,138 @@ spec:
                     description: Principal defines configurations for the Principal
                       component of Argo CD Agent.
                     properties:
+                      auth:
+                        description: Auth is the authentication method for the Principal
+                          component.
+                        type: string
                       enabled:
                         description: Enabled is the flag to enable the Principal component
                           during Argo CD installation. (optional, default `false`)
                         type: boolean
+                      env:
+                        description: Env lets you specify environment for principal
+                          pods
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image is the name of Argo CD Agent image
+                        type: string
                       jwt:
                         description: JWT defines the JWT options for the Principal
                           component.
@@ -35091,6 +35258,14 @@ spec:
                               the JWT signing key.
                             type: string
                         type: object
+                      logFormat:
+                        description: LogFormat refers to the log format used by the
+                          Principal component.
+                        type: string
+                      logLevel:
+                        description: LogLevel refers to the log level used by the
+                          Principal component.
+                        type: string
                       namespace:
                         description: Namespace is the configuration for the Principal
                           component namespace.
@@ -35147,152 +35322,39 @@ spec:
                         description: Server defines the server options for the Principal
                           component.
                         properties:
-                          auth:
-                            description: Auth is the authentication method for the
-                              Principal component.
-                            type: string
                           enableWebSocket:
                             description: EnableWebSocket is the flag to enable the
                               WebSocket on gRPC to stream events to the Agent.
                             type: boolean
-                          env:
-                            description: Env lets you specify environment for principal
-                              pods
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          image:
-                            description: Image is the name of Argo CD Agent image
-                            type: string
                           keepAliveMinInterval:
                             description: KeepAliveMinInterval is the minimum interval
                               between keep-alive messages sent by the Agent to the
                               Principal.
                             type: string
-                          logFormat:
-                            description: LogFormat refers to the log format used by
-                              the Principal component.
-                            type: string
-                          logLevel:
-                            description: LogLevel refers to the log level used by
-                              the Principal component.
-                            type: string
+                          route:
+                            description: |-
+                              Route defines the options for the Route backing the ArgoCD Agent component.
+                              Route is disabled only when explicitly configured with Enabled: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled will toggle the creation of the OpenShift Route, ignored in case of non OpenShift cluster.
+                                  Route is disabled only when explicitly configured with false
+                                type: boolean
+                            type: object
+                          service:
+                            description: |-
+                              Service defines the options for the Service backing the ArgoCD Agent component.
+                              If not set, type ClusterIP will be used by default.
+                            properties:
+                              type:
+                                description: |-
+                                  Type is the ServiceType to use for the Service resource.
+                                  If not set, type ClusterIP will be used by default.
+                                type: string
+                            required:
+                            - type
+                            type: object
                         type: object
                       tls:
                         description: TLS defines the TLS options for the Principal
@@ -40725,6 +40787,15 @@ spec:
                 type: string
               image:
                 description: Image is the ArgoCD container image for all ArgoCD components.
+                type: string
+              imagePullPolicy:
+                description: |-
+                  ImagePullPolicy is the image pull policy for all ArgoCD components.
+                  Valid values are Always, IfNotPresent, Never. If not specified, defaults to the operator's global setting.
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
                 type: string
               imageUpdater:
                 description: ImageUpdater defines whether the Argo CD ImageUpdater

--- a/internal/addon/charts/argocd-agent-addon/templates/argocd.yaml
+++ b/internal/addon/charts/argocd-agent-addon/templates/argocd.yaml
@@ -9,14 +9,16 @@ spec:
   argoCDAgent:
     agent:
       enabled: true
+      creds: "mtls:open-cluster-management:cluster:([^:]+):addon:argocd-agent"
+      logLevel: "info"
+      logFormat: "text"
+      image: {{ .Values.global.argoCDAgent.image }}:{{ .Values.global.argoCDAgent.tag }}
       client:
         principalServerAddress: {{ .Values.global.argoCDAgent.serverAddress }}
         principalServerPort: "{{ .Values.global.argoCDAgent.serverPort }}"
-        logLevel: "info"
-        logFormat: "text"
-        image: {{ .Values.global.argoCDAgent.image }}:{{ .Values.global.argoCDAgent.tag }}
         mode: {{ .Values.global.argoCDAgent.mode }}
-        creds: "mtls:open-cluster-management:cluster:([^:]+):addon:argocd-agent"
+        enableWebSocket: false
+        enableCompression: false
         keepAliveInterval: "50s"
       tls:
         secretName: "argocd-agent-open-cluster-management.io-argocd-agent-addon-client-cert"

--- a/internal/controller/addon_template_management.go
+++ b/internal/controller/addon_template_management.go
@@ -77,7 +77,7 @@ func (r *GitOpsClusterReconciler) EnsureAddOnTemplate(ctx context.Context, gitOp
 	// Get operator and agent images from GitOpsCluster spec or use defaults
 	operatorImage := gitOpsCluster.Spec.ArgoCDAgentAddon.OperatorImage
 	if operatorImage == "" {
-		operatorImage = "quay.io/mikeshng/argocd-operator:latest"
+		operatorImage = "quay.io/mikeshng/argocd-operator:latest-api"
 	}
 
 	agentImage := gitOpsCluster.Spec.ArgoCDAgentAddon.AgentImage


### PR DESCRIPTION
### Summary
This PR updates the ArgoCD Operator integration to align with the latest upstream API changes, including a significant restructuring of the Agent and Principal component specifications.

### Changes

#### API Restructuring
- **Principal component**: Moved 5 fields (`auth`, `image`, `env`, `logLevel`, `logFormat`) from nested `server` spec to top-level `principal` spec
- **Agent component**: Moved 5 fields (`creds`, `image`, `env`, `logLevel`, `logFormat`) from nested `client` spec to top-level `agent` spec
- This aligns with the upstream operator's API redesign for better clarity and consistency

#### CRD Updates
- Updated ArgoCD CRD with latest API definitions 

#### Service Configuration
- Configured Principal to use `LoadBalancer` service type instead of default ClusterIP
- Explicitly disabled OpenShift Route creation for Principal component
- Added `route` and `service` configuration options to Principal server spec
