### PR TITLE
feat: Support custom ArgoCD namespace configuration

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,3 +136,62 @@ jobs:
         env:
           KUBECONFIG: /home/runner/.kube/config
         run: make test-e2e-cleanup
+
+  e2e-custom-namespace:
+    name: e2e-custom-namespace
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: go/src/open-cluster-management.io/argocd-pull-integration
+
+      - name: install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Add GOPATH/bin to PATH
+        run: echo "$GOPATH/bin" >> "$GITHUB_PATH"
+
+      - name: install imagebuilder
+        run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.15.2
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.29.0
+
+      - name: build-images
+        run: make build-images
+
+      - name: setup kind (cluster1)
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: v0.14.0
+          name: cluster1
+
+      - name: setup kind (hub)
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: v0.14.0
+          name: hub
+
+      - name: Load image on the nodes of the hub
+        run: |
+          kind load docker-image --name=hub quay.io/open-cluster-management/argocd-pull-integration:latest
+
+      - name: Load image on the nodes of the cluster1
+        run: |
+          kind load docker-image --name=cluster1 quay.io/open-cluster-management/argocd-pull-integration:latest
+
+      - name: Run e2e custom namespace test
+        env:
+          KUBECONFIG: /home/runner/.kube/config
+        run: make test-e2e-custom-namespace

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ For detailed argocd-agent architecture and operational modes, see [argocd-agent 
 helm repo add ocm https://open-cluster-management.io/helm-charts
 helm repo update
 helm search repo ocm
-helm install argocd-agent-addon ocm/argocd-agent-addon
+helm install argocd-agent-addon ocm/argocd-agent-addon --namespace argocd --create-namespace
 ```
 
 This installs the GitOpsCluster controller and creates a GitOpsCluster resource that automatically deploys argocd-agent to your managed clusters.

--- a/charts/argocd-agent-addon/templates/argocd-operator/operator.yaml
+++ b/charts/argocd-agent-addon/templates/argocd-operator/operator.yaml
@@ -8,14 +8,6 @@ metadata:
   name: {{ .Values.global.argoCDOperatorNamespace }}
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: argocd-operator
-    app.kubernetes.io/managed-by: argocd-agent-addon
-  name: {{ .Values.global.argoCDNamespace }}
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argocd-operator-controller-manager

--- a/internal/addon/addon_cleanup_test.go
+++ b/internal/addon/addon_cleanup_test.go
@@ -56,7 +56,7 @@ func TestUninstallArgoCDAgentInternal(t *testing.T) {
 						"kind":       "ArgoCD",
 						"metadata": map[string]interface{}{
 							"name":      "argocd",
-							"namespace": argoCDNamespace,
+							"namespace": "argocd",
 						},
 					},
 				},
@@ -95,7 +95,7 @@ func TestDeleteOperatorResourcesInternal(t *testing.T) {
 			"kind":       "Deployment",
 			"metadata": map[string]interface{}{
 				"name":      "test-operator",
-				"namespace": operatorNamespace,
+				"namespace": "argocd-operator-system",
 				"labels": map[string]interface{}{
 					"app.kubernetes.io/managed-by": "argocd-agent-addon",
 				},
@@ -130,7 +130,7 @@ func TestDeleteOperatorResourcesInternal(t *testing.T) {
 				Build()
 
 			ctx := context.Background()
-			err := deleteOperatorResourcesInternal(ctx, c)
+			err := deleteOperatorResourcesInternal(ctx, c, "argocd-operator-system")
 			if (err != nil) != tt.expectError {
 				t.Errorf("deleteOperatorResourcesInternal() error = %v, expectError %v", err, tt.expectError)
 			}
@@ -142,7 +142,7 @@ func TestDeleteOperatorResourcesInternal(t *testing.T) {
 				deployment.SetKind("Deployment")
 				err := c.Get(ctx, types.NamespacedName{
 					Name:      "test-operator",
-					Namespace: operatorNamespace,
+					Namespace: "argocd-operator-system",
 				}, deployment)
 				// Should be not found after deletion
 				if err == nil {
@@ -167,19 +167,19 @@ func TestCreatePauseMarker(t *testing.T) {
 	}{
 		{
 			name:          "create pause marker in empty namespace",
-			namespace:     operatorNamespace,
+			namespace:     "argocd-operator-system",
 			existingObjs:  []runtime.Object{},
 			expectError:   false,
 			expectCreated: true,
 		},
 		{
 			name:      "pause marker already exists",
-			namespace: operatorNamespace,
+			namespace: "argocd-operator-system",
 			existingObjs: []runtime.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      PauseMarkerName,
-						Namespace: operatorNamespace,
+						Namespace: "argocd-operator-system",
 					},
 					Data: map[string]string{
 						"paused": "true",
@@ -240,18 +240,18 @@ func TestIsPaused(t *testing.T) {
 	}{
 		{
 			name:         "no pause marker exists",
-			namespace:    operatorNamespace,
+			namespace:    "argocd-operator-system",
 			existingObjs: []runtime.Object{},
 			expectPaused: false,
 		},
 		{
 			name:      "pause marker exists with paused=true",
-			namespace: operatorNamespace,
+			namespace: "argocd-operator-system",
 			existingObjs: []runtime.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      PauseMarkerName,
-						Namespace: operatorNamespace,
+						Namespace: "argocd-operator-system",
 					},
 					Data: map[string]string{
 						"paused": "true",
@@ -263,12 +263,12 @@ func TestIsPaused(t *testing.T) {
 		},
 		{
 			name:      "pause marker exists with paused=false",
-			namespace: operatorNamespace,
+			namespace: "argocd-operator-system",
 			existingObjs: []runtime.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      PauseMarkerName,
-						Namespace: operatorNamespace,
+						Namespace: "argocd-operator-system",
 					},
 					Data: map[string]string{
 						"paused": "false",
@@ -279,12 +279,12 @@ func TestIsPaused(t *testing.T) {
 		},
 		{
 			name:      "pause marker exists without paused field",
-			namespace: operatorNamespace,
+			namespace: "argocd-operator-system",
 			existingObjs: []runtime.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      PauseMarkerName,
-						Namespace: operatorNamespace,
+						Namespace: "argocd-operator-system",
 					},
 					Data: map[string]string{
 						"reason": "test",
@@ -324,14 +324,14 @@ func TestVerifyNamespaceCleanup(t *testing.T) {
 	}{
 		{
 			name:                 "no resources exist",
-			namespace:            operatorNamespace,
+			namespace:            "argocd-operator-system",
 			existingObjs:         []runtime.Object{},
 			expectResourcesExist: false,
 			expectError:          false,
 		},
 		{
 			name:      "deployment exists with addon label",
-			namespace: operatorNamespace,
+			namespace: "argocd-operator-system",
 			existingObjs: []runtime.Object{
 				&unstructured.Unstructured{
 					Object: map[string]interface{}{
@@ -339,7 +339,7 @@ func TestVerifyNamespaceCleanup(t *testing.T) {
 						"kind":       "Deployment",
 						"metadata": map[string]interface{}{
 							"name":      "test-operator",
-							"namespace": operatorNamespace,
+							"namespace": "argocd-operator-system",
 							"labels": map[string]interface{}{
 								"app.kubernetes.io/managed-by": "argocd-agent-addon",
 							},
@@ -352,7 +352,7 @@ func TestVerifyNamespaceCleanup(t *testing.T) {
 		},
 		{
 			name:      "deployment exists without addon label",
-			namespace: operatorNamespace,
+			namespace: "argocd-operator-system",
 			existingObjs: []runtime.Object{
 				&unstructured.Unstructured{
 					Object: map[string]interface{}{
@@ -360,7 +360,7 @@ func TestVerifyNamespaceCleanup(t *testing.T) {
 						"kind":       "Deployment",
 						"metadata": map[string]interface{}{
 							"name":      "other-deployment",
-							"namespace": operatorNamespace,
+							"namespace": "argocd-operator-system",
 							"labels": map[string]interface{}{
 								"app": "other",
 							},

--- a/internal/addon/addon_controller.go
+++ b/internal/addon/addon_controller.go
@@ -105,6 +105,9 @@ func (r *ArgoCDAgentAddonReconciler) Start(ctx context.Context) error {
 func (r *ArgoCDAgentAddonReconciler) reconcile(ctx context.Context) {
 	klog.V(2).Info("Reconciling ArgoCD Agent Addon")
 
+	// Get namespace configuration from environment
+	operatorNamespace, _ := getNamespaceConfig()
+
 	// Check if controller is paused (during cleanup)
 	if IsPaused(ctx, r.Client, operatorNamespace) {
 		klog.Info("ArgoCD Agent Addon controller is paused, skipping reconciliation")

--- a/internal/addon/addon_install_integration_test.go
+++ b/internal/addon/addon_install_integration_test.go
@@ -61,14 +61,14 @@ func TestEnsureNamespace(t *testing.T) {
 		},
 		{
 			name:          "creates operator namespace",
-			namespaceName: operatorNamespace,
+			namespaceName: "argocd-operator-system",
 			existingObjs:  []runtime.Object{},
 			wantErr:       false,
 			checkLabels:   true,
 		},
 		{
 			name:          "creates argocd namespace",
-			namespaceName: argoCDNamespace,
+			namespaceName: "argocd",
 			existingObjs:  []runtime.Object{},
 			wantErr:       false,
 			checkLabels:   true,
@@ -171,7 +171,7 @@ func TestCopyClientCertificate(t *testing.T) {
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "argocd-agent-ca",
-						Namespace: argoCDNamespace,
+						Namespace: "argocd",
 					},
 					Data: map[string][]byte{
 						"tls.crt": []byte("ca-cert"),
@@ -268,7 +268,7 @@ func TestUninstallArgoCDAgent(t *testing.T) {
 			existingObjs: []runtime.Object{
 				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: operatorNamespace,
+						Name: "argocd-operator-system",
 					},
 				},
 			},
@@ -311,7 +311,7 @@ func TestDeleteOperatorResources(t *testing.T) {
 			existingObjs: []runtime.Object{
 				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: operatorNamespace,
+						Name: "argocd-operator-system",
 					},
 				},
 			},

--- a/internal/addon/addon_utils_test.go
+++ b/internal/addon/addon_utils_test.go
@@ -492,12 +492,13 @@ func TestApplyCRDIfNotExistsValidation(t *testing.T) {
 }
 
 func TestConstants(t *testing.T) {
-	// Verify addon constants are defined correctly
-	if operatorNamespace != "argocd-operator-system" {
-		t.Errorf("operatorNamespace = %v, want argocd-operator-system", operatorNamespace)
+	// Verify namespace configuration reads defaults correctly
+	operatorNS, argoCDNS := getNamespaceConfig()
+	if operatorNS != "argocd-operator-system" {
+		t.Errorf("operatorNamespace = %v, want argocd-operator-system", operatorNS)
 	}
-	if argoCDNamespace != "argocd" {
-		t.Errorf("argoCDNamespace = %v, want argocd", argoCDNamespace)
+	if argoCDNS != "argocd" {
+		t.Errorf("argoCDNamespace = %v, want argocd", argoCDNS)
 	}
 	// Verify centralized image defaults are defined for external dependencies
 	if images.DefaultOperatorImage == "" {

--- a/internal/controller/addon_template_management.go
+++ b/internal/controller/addon_template_management.go
@@ -173,6 +173,14 @@ func buildAddonManifests(addonImage, operatorImage, agentImage string) []workv1.
 												Name:  "ARGOCD_AGENT_IMAGE",
 												Value: agentImage,
 											},
+											{
+												Name:  "ARGOCD_NAMESPACE",
+												Value: "{{ARGOCD_NAMESPACE}}",
+											},
+											{
+												Name:  "ARGOCD_OPERATOR_NAMESPACE",
+												Value: "{{ARGOCD_OPERATOR_NAMESPACE}}",
+											},
 										},
 									},
 								},
@@ -280,6 +288,14 @@ func buildAddonManifests(addonImage, operatorImage, agentImage string) []workv1.
 											{
 												Name:  "ARGOCD_AGENT_MODE",
 												Value: "{{ARGOCD_AGENT_MODE}}",
+											},
+											{
+												Name:  "ARGOCD_NAMESPACE",
+												Value: "{{ARGOCD_NAMESPACE}}",
+											},
+											{
+												Name:  "ARGOCD_OPERATOR_NAMESPACE",
+												Value: "{{ARGOCD_OPERATOR_NAMESPACE}}",
 											},
 										},
 										SecurityContext: &corev1.SecurityContext{

--- a/internal/controller/gitopscluster_controller.go
+++ b/internal/controller/gitopscluster_controller.go
@@ -472,6 +472,12 @@ func (r *GitOpsClusterReconciler) buildAddonVariables(
 		variables["ARGOCD_AGENT_MODE"] = gitOpsCluster.Spec.ArgoCDAgentAddon.Mode
 	}
 
+	// Add namespace configuration - use GitOpsCluster's namespace as the ArgoCD namespace on spoke
+	// This is the namespace where the ArgoCD CR will be deployed on the managed/spoke cluster
+	variables["ARGOCD_NAMESPACE"] = gitOpsCluster.Namespace
+	// Default operator namespace
+	variables["ARGOCD_OPERATOR_NAMESPACE"] = "argocd-operator-system"
+
 	// Add operator image if specified
 	if gitOpsCluster.Spec.ArgoCDAgentAddon.OperatorImage != "" {
 		variables["ARGOCD_OPERATOR_IMAGE"] = gitOpsCluster.Spec.ArgoCDAgentAddon.OperatorImage

--- a/internal/controller/gitopscluster_controller_test.go
+++ b/internal/controller/gitopscluster_controller_test.go
@@ -104,6 +104,8 @@ func TestBuildAddonVariables(t *testing.T) {
 				"ARGOCD_AGENT_SERVER_ADDRESS": "argocd-server.argocd.svc",
 				"ARGOCD_AGENT_SERVER_PORT":    "8080",
 				"ARGOCD_AGENT_MODE":           "managed",
+				"ARGOCD_NAMESPACE":            "argocd",
+				"ARGOCD_OPERATOR_NAMESPACE":   "argocd-operator-system",
 			},
 		},
 		{
@@ -129,6 +131,8 @@ func TestBuildAddonVariables(t *testing.T) {
 				"ARGOCD_AGENT_MODE":           "autonomous",
 				"ARGOCD_OPERATOR_IMAGE":       "quay.io/operator:v1.0.0",
 				"ARGOCD_AGENT_IMAGE":          "quay.io/agent:v2.0.0",
+				"ARGOCD_NAMESPACE":            "argocd",
+				"ARGOCD_OPERATOR_NAMESPACE":   "argocd-operator-system",
 			},
 		},
 		{
@@ -147,6 +151,8 @@ func TestBuildAddonVariables(t *testing.T) {
 			wantVars: map[string]string{
 				"ARGOCD_AGENT_SERVER_ADDRESS": "argocd-server.argocd.svc",
 				"ARGOCD_AGENT_SERVER_PORT":    "8080",
+				"ARGOCD_NAMESPACE":            "argocd",
+				"ARGOCD_OPERATOR_NAMESPACE":   "argocd-operator-system",
 			},
 		},
 	}

--- a/test/e2e/addon_e2e_custom_namespace_test.go
+++ b/test/e2e/addon_e2e_custom_namespace_test.go
@@ -1,0 +1,299 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025 Open Cluster Management.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"open-cluster-management.io/argocd-pull-integration/test/utils"
+)
+
+var _ = Describe("ArgoCD Agent Addon Custom Namespace E2E", Label("custom-namespace"), Ordered, func() {
+	SetDefaultEventuallyTimeout(5 * time.Minute)
+	SetDefaultEventuallyPollingInterval(5 * time.Second)
+
+	var (
+		hubArgoCDNamespace   string
+		spokeArgoCDNamespace string
+	)
+
+	BeforeAll(func() {
+		By("Getting custom namespace configuration from environment")
+		hubArgoCDNamespace = os.Getenv("HUB_ARGOCD_NAMESPACE")
+		if hubArgoCDNamespace == "" {
+			hubArgoCDNamespace = "notargocd"
+		}
+		spokeArgoCDNamespace = os.Getenv("SPOKE_ARGOCD_NAMESPACE")
+		if spokeArgoCDNamespace == "" {
+			// Spoke uses the same namespace as the GitOpsCluster namespace (hub namespace)
+			spokeArgoCDNamespace = hubArgoCDNamespace
+		}
+
+		fmt.Fprintf(GinkgoWriter, "Using custom namespaces - Hub: %s, Spoke: %s\n", hubArgoCDNamespace, spokeArgoCDNamespace)
+
+		By("Verifying test environment is ready")
+		// Environment setup is done by Makefile
+		cmd := exec.Command("kubectl", "config", "get-contexts", hubContext)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Hub context should exist")
+
+		cmd = exec.Command("kubectl", "config", "get-contexts", cluster1Context)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Spoke context should exist")
+	})
+
+	AfterAll(func() {
+		By("Test complete - clusters preserved for inspection")
+		fmt.Fprintf(GinkgoWriter, "\n")
+		fmt.Fprintf(GinkgoWriter, "Clusters have been preserved for inspection:\n")
+		fmt.Fprintf(GinkgoWriter, "  Hub: kubectl config use-context kind-hub (ArgoCD in %s namespace)\n", hubArgoCDNamespace)
+		fmt.Fprintf(GinkgoWriter, "  Spoke: kubectl config use-context kind-cluster1 (ArgoCD in %s namespace - same as GitOpsCluster namespace)\n", spokeArgoCDNamespace)
+		fmt.Fprintf(GinkgoWriter, "\n")
+	})
+
+	Context("Custom Namespace Deployment", func() {
+		It("should deploy the GitOpsCluster controller on hub in custom namespace", func() {
+			By("verifying controller deployment exists on hub")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "deployment", "argocd-pull-integration-controller",
+					"-n", hubArgoCDNamespace,
+					"-o", "jsonpath={.status.availableReplicas}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("1"))
+			}).Should(Succeed())
+
+			By("verifying controller pod is running on hub")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "pods",
+					"-l", "app.kubernetes.io/name=argocd-pull-integration-controller",
+					"-n", hubArgoCDNamespace,
+					"-o", "jsonpath={.items[0].status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Running"))
+			}).Should(Succeed())
+		})
+
+		It("should verify GitOpsCluster status conditions on hub", func() {
+			By("verifying GitOpsCluster exists")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "gitopscluster", "gitops-cluster",
+					"-n", hubArgoCDNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("verifying GitOpsCluster RBACReady condition")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "gitopscluster", "gitops-cluster",
+					"-n", hubArgoCDNamespace,
+					"-o", "jsonpath={.status.conditions[?(@.type=='RBACReady')].status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"))
+			}).Should(Succeed())
+
+			By("verifying GitOpsCluster ServerDiscovered condition")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "gitopscluster", "gitops-cluster",
+					"-n", hubArgoCDNamespace,
+					"-o", "jsonpath={.status.conditions[?(@.type=='ServerDiscovered')].status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"))
+			}).Should(Succeed())
+		})
+
+		It("should verify all ArgoCD pods running on hub in custom namespace", func() {
+			By("verifying ArgoCD principal pod is running")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "pods",
+					"-n", hubArgoCDNamespace,
+					"-l", "app.kubernetes.io/name=argocd-agent-principal",
+					"-o", "jsonpath={.items[0].status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Running"))
+			}).Should(Succeed())
+
+			By("verifying ArgoCD redis pod is running on hub")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "pods",
+					"-n", hubArgoCDNamespace,
+					"-l", "app.kubernetes.io/name=argocd-redis",
+					"-o", "jsonpath={.items[0].status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Running"))
+			}).Should(Succeed())
+
+			By("verifying ArgoCD repo-server pod is running on hub")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "pods",
+					"-n", hubArgoCDNamespace,
+					"-l", "app.kubernetes.io/name=argocd-repo-server",
+					"-o", "jsonpath={.items[0].status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Running"))
+			}).Should(Succeed())
+
+			By("verifying ArgoCD server pod is running on hub")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "pods",
+					"-n", hubArgoCDNamespace,
+					"-l", "app.kubernetes.io/name=argocd-server",
+					"-o", "jsonpath={.items[0].status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Running"))
+			}).Should(Succeed())
+		})
+
+		It("should deploy addon agent on spoke cluster", func() {
+			By("verifying addon deployment exists on cluster1")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "deployment", "argocd-agent-addon",
+					"-n", addonNamespace,
+					"-o", "jsonpath={.status.availableReplicas}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("1"))
+			}).Should(Succeed())
+
+			By("verifying addon pod is running on cluster1")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "pods",
+					"-l", "app=argocd-agent-addon",
+					"-n", addonNamespace,
+					"-o", "jsonpath={.items[0].status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Running"))
+			}).Should(Succeed())
+		})
+
+		It("should deploy ArgoCD agent on spoke cluster in custom namespace", func() {
+			By("verifying ArgoCD namespace exists")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "namespace", spokeArgoCDNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("verifying ArgoCD CR is created in custom namespace")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "argocd", "argocd",
+					"-n", spokeArgoCDNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("verifying ArgoCD agent pod is running in custom namespace")
+			var agentPodName string
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "pods",
+					"-n", spokeArgoCDNamespace,
+					"-l", "app.kubernetes.io/name=argocd-agent-agent",
+					"-o", "jsonpath={.items[0].metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty())
+				agentPodName = output
+			}).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "pod", agentPodName,
+					"-n", spokeArgoCDNamespace,
+					"-o", "jsonpath={.status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Running"))
+			}).Should(Succeed())
+
+			By("verifying ArgoCD application-controller pod is running in custom namespace")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "pods",
+					"-n", spokeArgoCDNamespace,
+					"-l", "app.kubernetes.io/name=argocd-application-controller",
+					"-o", "jsonpath={.items[0].status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Running"))
+			}).Should(Succeed())
+
+			By("verifying ArgoCD redis pod is running on cluster1 in custom namespace")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "pods",
+					"-n", spokeArgoCDNamespace,
+					"-l", "app.kubernetes.io/name=argocd-redis",
+					"-o", "jsonpath={.items[0].status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Running"))
+			}).Should(Succeed())
+
+			By("verifying ArgoCD repo-server pod is running on cluster1 in custom namespace")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "pods",
+					"-n", spokeArgoCDNamespace,
+					"-l", "app.kubernetes.io/name=argocd-repo-server",
+					"-o", "jsonpath={.items[0].status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Running"))
+			}).Should(Succeed())
+
+			By("verifying CA secret exists in custom namespace")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "secret", "argocd-agent-ca",
+					"-n", spokeArgoCDNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
## Summary
This PR adds support for customizable Argo CD namespaces

## Changes
- **Configurable Namespaces**: Added `ARGOCD_NAMESPACE` and `ARGOCD_OPERATOR_NAMESPACE` environment variables that are passed from the GitOpsCluster controller to the addon via AddOnDeploymentConfig
- **Dynamic Namespace Creation**: Updated addon code to read namespace configuration from environment variables and create namespaces programmatically
- **GitOpsCluster Integration**: The GitOpsCluster's namespace on the hub now correctly determines the ArgoCD namespace on the spoke cluster
- **New E2E Test**: Added `test-e2e-custom-namespace` to verify custom namespace functionality (hub: `notargocd`, spoke: `notargocd`)
- **CI Integration**: Updated GitHub Actions workflow to run custom namespace e2e test