### PR TITLE
feat: Add configurable namespace support for ArgoCD deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,20 +230,26 @@ test-e2e-custom-namespace: manifests generate fmt vet ## Run e2e test with custo
 		--namespace notargocd \
 		--create-namespace \
 		--set global.argoCDNamespace=notargocd \
-		--set global.argoCDOperatorNamespace=argocd-operator-system \
+		--set global.argoCDOperatorNamespace=notargocd-operator-system \
 		--set controller.namespace=notargocd \
 		--set gitOpsCluster.namespace=notargocd \
+		--set gitOpsCluster.argoCDAgentAddon.agentNamespace=argocdnot \
+		--set gitOpsCluster.argoCDAgentAddon.operatorNamespace=argocdnot-operator-system \
 		--set image=quay.io/open-cluster-management/argocd-pull-integration \
 		--set tag=latest \
 		--wait \
 		--timeout 10m
 	@echo ""
 	@echo "===== Running e2e tests with custom namespaces ====="
-	HUB_ARGOCD_NAMESPACE=notargocd go test -tags=e2e ./test/e2e/ -v -ginkgo.v --ginkgo.label-filter="custom-namespace"
+	HUB_ARGOCD_NAMESPACE=notargocd \
+	HUB_ARGOCD_OPERATOR_NAMESPACE=notargocd-operator-system \
+	SPOKE_ARGOCD_NAMESPACE=argocdnot \
+	SPOKE_ARGOCD_OPERATOR_NAMESPACE=argocdnot-operator-system \
+	go test -tags=e2e ./test/e2e/ -v -ginkgo.v --ginkgo.label-filter="custom-namespace"
 	@echo ""
 	@echo "===== E2E Custom Namespace Tests Complete ====="
-	@echo "Hub context: kind-$(HUB_CLUSTER) (ArgoCD in notargocd namespace)"
-	@echo "Spoke context: kind-$(SPOKE_CLUSTER) (ArgoCD in notargocd namespace)"
+	@echo "Hub context: kind-$(HUB_CLUSTER) (ArgoCD: notargocd, Operator: notargocd-operator-system)"
+	@echo "Spoke context: kind-$(SPOKE_CLUSTER) (ArgoCD: argocdnot, Operator: argocdnot-operator-system)"
 
 .PHONY: test-e2e-custom-namespace-full
 test-e2e-custom-namespace-full: ## Complete e2e test with custom namespaces (cluster setup + custom namespace deployment + tests)

--- a/api/v1alpha1/gitopscluster_types.go
+++ b/api/v1alpha1/gitopscluster_types.go
@@ -54,6 +54,14 @@ type ArgoCDAgentAddonSpec struct {
 	// AgentImage is the ArgoCD agent image to use
 	// +optional
 	AgentImage string `json:"agentImage,omitempty"`
+
+	// OperatorNamespace is the namespace where the ArgoCD operator will be deployed on the managed cluster
+	// +optional
+	OperatorNamespace string `json:"operatorNamespace,omitempty"`
+
+	// AgentNamespace is the namespace where the ArgoCD agent (ArgoCD CR) will be deployed on the managed cluster
+	// +optional
+	AgentNamespace string `json:"agentNamespace,omitempty"`
 }
 
 // GitOpsClusterStatus defines the observed state of GitOpsCluster

--- a/charts/argocd-agent-addon/crds/apps.open-cluster-management.io_gitopsclusters.yaml
+++ b/charts/argocd-agent-addon/crds/apps.open-cluster-management.io_gitopsclusters.yaml
@@ -53,12 +53,20 @@ spec:
                   agentImage:
                     description: AgentImage is the ArgoCD agent image to use
                     type: string
+                  agentNamespace:
+                    description: AgentNamespace is the namespace where the ArgoCD
+                      agent (ArgoCD CR) will be deployed on the managed cluster
+                    type: string
                   mode:
                     default: managed
                     description: Mode defines the agent mode (managed or autonomous)
                     type: string
                   operatorImage:
                     description: OperatorImage is the ArgoCD operator image to use
+                    type: string
+                  operatorNamespace:
+                    description: OperatorNamespace is the namespace where the ArgoCD
+                      operator will be deployed on the managed cluster
                     type: string
                   principalServerAddress:
                     description: PrincipalServerAddress is the address of the ArgoCD
@@ -68,9 +76,6 @@ spec:
                     description: PrincipalServerPort is the port of the ArgoCD principal
                       server
                     type: string
-                  uninstall:
-                    description: Uninstall indicates whether to uninstall the addon
-                    type: boolean
                 type: object
               placementRef:
                 description: PlacementRef references a Placement resource to select

--- a/charts/argocd-agent-addon/templates/argocd-operator/operator.yaml
+++ b/charts/argocd-agent-addon/templates/argocd-operator/operator.yaml
@@ -11,13 +11,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argocd-operator-controller-manager
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: argocd-operator-leader-election-role
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 rules:
 - apiGroups:
   - ""
@@ -295,7 +295,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argocd-operator-leader-election-rolebinding
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -303,7 +303,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-operator-controller-manager
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -316,7 +316,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-operator-controller-manager
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -329,7 +329,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-operator-controller-manager
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 ---
 apiVersion: v1
 data:
@@ -348,7 +348,7 @@ data:
 kind: ConfigMap
 metadata:
   name: argocd-operator-manager-config
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 ---
 apiVersion: v1
 kind: Service
@@ -356,7 +356,7 @@ metadata:
   labels:
     control-plane: argocd-operator
   name: argocd-operator-controller-manager-metrics-service
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 spec:
   ports:
   - name: https
@@ -369,7 +369,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: argocd-operator-webhook-service
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 spec:
   ports:
   - port: 443
@@ -384,7 +384,7 @@ metadata:
   labels:
     control-plane: argocd-operator
   name: argocd-operator-controller-manager
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 spec:
   replicas: 1
   selector:

--- a/charts/argocd-agent-addon/templates/gitopscluster/gitopscluster.yaml
+++ b/charts/argocd-agent-addon/templates/gitopscluster/gitopscluster.yaml
@@ -16,3 +16,9 @@ spec:
     principalServerPort: {{ .Values.gitOpsCluster.principalServerPort | quote }}
     {{- end }}
     mode: {{ .Values.gitOpsCluster.mode }}
+    {{- if .Values.gitOpsCluster.argoCDAgentAddon.agentNamespace }}
+    agentNamespace: {{ .Values.gitOpsCluster.argoCDAgentAddon.agentNamespace }}
+    {{- end }}
+    {{- if .Values.gitOpsCluster.argoCDAgentAddon.operatorNamespace }}
+    operatorNamespace: {{ .Values.gitOpsCluster.argoCDAgentAddon.operatorNamespace }}
+    {{- end }}

--- a/charts/argocd-agent-addon/values.yaml
+++ b/charts/argocd-agent-addon/values.yaml
@@ -27,6 +27,9 @@ gitOpsCluster:
   principalServerAddress: ""
   principalServerPort: ""
   mode: managed
+  argoCDAgentAddon:
+    agentNamespace: ""
+    operatorNamespace: ""
 
 # Controller settings  
 controller:

--- a/config/crd/bases/apps.open-cluster-management.io_gitopsclusters.yaml
+++ b/config/crd/bases/apps.open-cluster-management.io_gitopsclusters.yaml
@@ -53,12 +53,20 @@ spec:
                   agentImage:
                     description: AgentImage is the ArgoCD agent image to use
                     type: string
+                  agentNamespace:
+                    description: AgentNamespace is the namespace where the ArgoCD
+                      agent (ArgoCD CR) will be deployed on the managed cluster
+                    type: string
                   mode:
                     default: managed
                     description: Mode defines the agent mode (managed or autonomous)
                     type: string
                   operatorImage:
                     description: OperatorImage is the ArgoCD operator image to use
+                    type: string
+                  operatorNamespace:
+                    description: OperatorNamespace is the namespace where the ArgoCD
+                      operator will be deployed on the managed cluster
                     type: string
                   principalServerAddress:
                     description: PrincipalServerAddress is the address of the ArgoCD

--- a/internal/addon/addon_cleanup.go
+++ b/internal/addon/addon_cleanup.go
@@ -37,21 +37,6 @@ const (
 	PauseMarkerName = "argocd-agent-addon-pause"
 )
 
-// getNamespaceConfig returns namespace configuration from environment variables or defaults
-func getNamespaceConfig() (operatorNamespace, argoCDNamespace string) {
-	operatorNamespace = os.Getenv("ARGOCD_OPERATOR_NAMESPACE")
-	if operatorNamespace == "" {
-		operatorNamespace = "argocd-operator-system"
-	}
-
-	argoCDNamespace = os.Getenv("ARGOCD_NAMESPACE")
-	if argoCDNamespace == "" {
-		argoCDNamespace = "argocd"
-	}
-
-	return operatorNamespace, argoCDNamespace
-}
-
 // uninstallArgoCDAgent uninstalls the ArgoCD agent addon in reverse order
 // Does NOT delete namespaces, only deletes operator after ArgoCD CR is gone
 func (r *ArgoCDAgentAddonReconciler) uninstallArgoCDAgent(ctx context.Context) error {

--- a/internal/addon/addon_install.go
+++ b/internal/addon/addon_install.go
@@ -19,6 +19,7 @@ package addon
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,27 @@ import (
 	"k8s.io/klog/v2"
 	"open-cluster-management.io/argocd-pull-integration/internal/pkg/images"
 )
+
+const (
+	// Default namespace constants
+	operatorNamespace = "argocd-operator-system"
+	argoCDNamespace   = "argocd"
+)
+
+// getNamespaceConfig returns namespace configuration from environment variables or defaults
+func getNamespaceConfig() (string, string) {
+	opNamespace := os.Getenv("ARGOCD_OPERATOR_NAMESPACE")
+	if opNamespace == "" {
+		opNamespace = operatorNamespace
+	}
+
+	agentNamespace := os.Getenv("ARGOCD_NAMESPACE")
+	if agentNamespace == "" {
+		agentNamespace = argoCDNamespace
+	}
+
+	return opNamespace, agentNamespace
+}
 
 // ensureNamespace creates a namespace if it doesn't exist
 func (r *ArgoCDAgentAddonReconciler) ensureNamespace(ctx context.Context, namespaceName string) error {

--- a/internal/addon/charts/argocd-agent-addon/templates/operator.yaml
+++ b/internal/addon/charts/argocd-agent-addon/templates/operator.yaml
@@ -11,13 +11,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argocd-operator-controller-manager
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: argocd-operator-leader-election-role
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 rules:
 - apiGroups:
   - ""
@@ -295,7 +295,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argocd-operator-leader-election-rolebinding
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -303,7 +303,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-operator-controller-manager
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -316,7 +316,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-operator-controller-manager
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -329,7 +329,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-operator-controller-manager
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 ---
 apiVersion: v1
 data:
@@ -348,7 +348,7 @@ data:
 kind: ConfigMap
 metadata:
   name: argocd-operator-manager-config
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 ---
 apiVersion: v1
 kind: Service
@@ -356,7 +356,7 @@ metadata:
   labels:
     control-plane: argocd-operator
   name: argocd-operator-controller-manager-metrics-service
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 spec:
   ports:
   - name: https
@@ -369,7 +369,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: argocd-operator-webhook-service
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 spec:
   ports:
   - port: 443
@@ -384,7 +384,7 @@ metadata:
   labels:
     control-plane: argocd-operator
   name: argocd-operator-controller-manager
-  namespace: argocd-operator-system
+  namespace: {{ .Values.global.argoCDOperatorNamespace }}
 spec:
   replicas: 1
   selector:

--- a/internal/controller/gitopscluster_controller_integration_test.go
+++ b/internal/controller/gitopscluster_controller_integration_test.go
@@ -391,7 +391,8 @@ func TestCreateArgoCDAgentManifestWork(t *testing.T) {
 				Scheme: s,
 			}
 
-			err := r.createArgoCDAgentManifestWork(context.Background(), namespace, tt.cluster)
+			// Pass same namespace for both hub and spoke in test
+			err := r.createArgoCDAgentManifestWork(context.Background(), namespace, namespace, tt.cluster)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createArgoCDAgentManifestWork() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/internal/controller/gitopscluster_controller_test.go
+++ b/internal/controller/gitopscluster_controller_test.go
@@ -104,8 +104,6 @@ func TestBuildAddonVariables(t *testing.T) {
 				"ARGOCD_AGENT_SERVER_ADDRESS": "argocd-server.argocd.svc",
 				"ARGOCD_AGENT_SERVER_PORT":    "8080",
 				"ARGOCD_AGENT_MODE":           "managed",
-				"ARGOCD_NAMESPACE":            "argocd",
-				"ARGOCD_OPERATOR_NAMESPACE":   "argocd-operator-system",
 			},
 		},
 		{
@@ -131,8 +129,6 @@ func TestBuildAddonVariables(t *testing.T) {
 				"ARGOCD_AGENT_MODE":           "autonomous",
 				"ARGOCD_OPERATOR_IMAGE":       "quay.io/operator:v1.0.0",
 				"ARGOCD_AGENT_IMAGE":          "quay.io/agent:v2.0.0",
-				"ARGOCD_NAMESPACE":            "argocd",
-				"ARGOCD_OPERATOR_NAMESPACE":   "argocd-operator-system",
 			},
 		},
 		{
@@ -151,8 +147,31 @@ func TestBuildAddonVariables(t *testing.T) {
 			wantVars: map[string]string{
 				"ARGOCD_AGENT_SERVER_ADDRESS": "argocd-server.argocd.svc",
 				"ARGOCD_AGENT_SERVER_PORT":    "8080",
-				"ARGOCD_NAMESPACE":            "argocd",
-				"ARGOCD_OPERATOR_NAMESPACE":   "argocd-operator-system",
+			},
+		},
+		{
+			name: "with custom namespaces",
+			gitOpsCluster: &appsv1alpha1.GitOpsCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "argocd",
+				},
+				Spec: appsv1alpha1.GitOpsClusterSpec{
+					ArgoCDAgentAddon: appsv1alpha1.ArgoCDAgentAddonSpec{
+						Mode:              "managed",
+						AgentNamespace:    "custom-argocd",
+						OperatorNamespace: "custom-operator",
+					},
+				},
+			},
+			serverAddress: "argocd-server.argocd.svc",
+			serverPort:    "8080",
+			wantVars: map[string]string{
+				"ARGOCD_AGENT_SERVER_ADDRESS": "argocd-server.argocd.svc",
+				"ARGOCD_AGENT_SERVER_PORT":    "8080",
+				"ARGOCD_AGENT_MODE":           "managed",
+				"ARGOCD_NAMESPACE":            "custom-argocd",
+				"ARGOCD_OPERATOR_NAMESPACE":   "custom-operator",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
This PR adds full namespace customization support for ArgoCD agent addon deployments on managed clusters, fixing issues where namespace configuration wasn't properly propagated from the hub to spoke clusters.

## Problem
Previously, when customizing ArgoCD namespaces via Helm values, the configuration was not consistently applied. The hub could deploy ArgoCD in custom namespaces, but managed clusters always used hardcoded argocd and argocd-operator-system. ManifestWork created CA secrets in the wrong namespace on spoke clusters, and there was no way to specify different namespaces for hub vs spoke deployments.

## Solution
Added two new optional fields to ArgoCDAgentAddonSpec:
- agentNamespace: Namespace for ArgoCD CR on managed cluster (defaults to argocd)
- operatorNamespace: Namespace for ArgoCD operator on managed cluster (defaults to argocd-operator-system)

The namespace configuration flows as follows:
1. GitOpsCluster spec defines spoke namespaces (optional)
2. Controller passes namespaces as environment variables via AddOnDeploymentConfig
3. Addon reads environment variables with fallback to default constants
4. ManifestWork creates CA secret in correct spoke namespace

## Changes

### API Changes
Added AgentNamespace and OperatorNamespace fields to ArgoCDAgentAddonSpec and updated CRD generation.

### Controller Changes
Updated buildAddonVariables to include namespace config only when specified. Fixed ManifestWork creation to use correct spoke namespace for CA secret by passing both hub and spoke namespaces.

### Addon Changes  
Added getNamespaceConfig with default constants. Removed hardcoded namespace references and updated all addon code to use configurable namespaces.

### Helm Chart Updates
Replaced all hardcoded namespace references with template variables in both the main chart and embedded addon chart. Added agentNamespace and operatorNamespace to values.yaml and GitOpsCluster template.
