### PR TITLE
feat: Add basic pull model support with dual deployment modes

### DIFF
--- a/.github/workflows/chart-upload.yml
+++ b/.github/workflows/chart-upload.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CHART_NAME: argocd-agent-addon
+  BASIC_CHART_NAME: argocd-pull-integration
 
 jobs:
   env:
@@ -37,7 +38,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: submit charts to OCM chart repo
+      - name: submit advanced chart to OCM chart repo
         if: github.event_name != 'pull_request'
         uses: actions/github-script@v7
         with:
@@ -53,6 +54,29 @@ jobs:
                   repo:         "${{ github.repository }}",
                   version:      "${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}",
                   "chart-name": "${{ env.CHART_NAME }}",
+                },
+              })
+              console.log(result);
+            } catch(error) {
+              console.error(error);
+              core.setFailed(error);
+            }
+      - name: submit basic chart to OCM chart repo
+        if: github.event_name != 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.OCM_BOT_PAT }}
+          script: |
+            try {
+              const result = await github.rest.actions.createWorkflowDispatch({
+                owner:          'open-cluster-management-io',
+                repo:           'helm-charts',
+                workflow_id:    'download-chart.yml',
+                ref: 'main',
+                inputs: {
+                  repo:         "${{ github.repository }}",
+                  version:      "${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}",
+                  "chart-name": "${{ env.BASIC_CHART_NAME }}",
                 },
               })
               console.log(result);

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -195,3 +195,62 @@ jobs:
         env:
           KUBECONFIG: /home/runner/.kube/config
         run: make test-e2e-custom-namespace
+
+  e2e-basic:
+    name: e2e-basic
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: go/src/open-cluster-management.io/argocd-pull-integration
+
+      - name: install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Add GOPATH/bin to PATH
+        run: echo "$GOPATH/bin" >> "$GITHUB_PATH"
+
+      - name: install imagebuilder
+        run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.15.2
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.29.0
+
+      - name: build-images
+        run: make build-images
+
+      - name: setup kind (cluster1)
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: v0.14.0
+          name: cluster1
+
+      - name: setup kind (hub)
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: v0.14.0
+          name: hub
+
+      - name: Load image on the nodes of the hub
+        run: |
+          kind load docker-image --name=hub quay.io/open-cluster-management/argocd-pull-integration:latest
+
+      - name: Load image on the nodes of the cluster1
+        run: |
+          kind load docker-image --name=cluster1 quay.io/open-cluster-management/argocd-pull-integration:latest
+
+      - name: Run e2e basic test
+        env:
+          KUBECONFIG: /home/runner/.kube/config
+        run: make test-e2e-basic

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -10,6 +10,7 @@ env:
   GO_REQUIRED_MIN_VERSION: ''
   GITHUB_REF: ${{ github.ref }}
   CHART_NAME: argocd-agent-addon
+  BASIC_CHART_NAME: argocd-pull-integration
 
 jobs:
   env:
@@ -92,7 +93,7 @@ jobs:
           fetch-depth: 1
       - name: setup helm
         uses: azure/setup-helm@v4
-      - name: prepare chart for release
+      - name: prepare advanced chart for release
         run: |
           # Update Chart.yaml appVersion to match release version (without 'v' prefix)
           RELEASE_VERSION="${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}"
@@ -106,20 +107,40 @@ jobs:
           sed -i "s/^appVersion:.*/appVersion: ${RELEASE_VERSION}/" internal/addon/charts/${{ env.CHART_NAME }}/Chart.yaml
           sed -i "s/^version:.*/version: ${RELEASE_VERSION}/" internal/addon/charts/${{ env.CHART_NAME }}/Chart.yaml
           
-          echo "Chart prepared for release ${RELEASE_VERSION}"
+          echo "Advanced chart prepared for release ${RELEASE_VERSION}"
           echo "=== Chart.yaml ==="
           cat charts/${{ env.CHART_NAME }}/Chart.yaml
           echo "=== values.yaml (tag section) ==="
           grep -A2 "^image:" charts/${{ env.CHART_NAME }}/values.yaml || true
+      - name: prepare basic chart for release
+        run: |
+          # Update basic chart
+          RELEASE_VERSION="${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}"
+          sed -i "s/^appVersion:.*/appVersion: ${RELEASE_VERSION}/" charts/${{ env.BASIC_CHART_NAME }}/Chart.yaml
+          sed -i "s/^version:.*/version: ${RELEASE_VERSION}/" charts/${{ env.BASIC_CHART_NAME }}/Chart.yaml
+          
+          # Update tag in values.yaml to match release version
+          sed -i "s/^tag:.*/tag: ${RELEASE_VERSION}/" charts/${{ env.BASIC_CHART_NAME }}/values.yaml
+          
+          echo "Basic chart prepared for release ${RELEASE_VERSION}"
+          echo "=== Chart.yaml ==="
+          cat charts/${{ env.BASIC_CHART_NAME }}/Chart.yaml
+          echo "=== values.yaml (tag section) ==="
+          grep -A2 "^tag:" charts/${{ env.BASIC_CHART_NAME }}/values.yaml || true
       - name: chart package
         run: |
           mkdir -p release
           pushd release
           helm package ../charts/${{ env.CHART_NAME }}/
+          helm package ../charts/${{ env.BASIC_CHART_NAME }}/
           popd
       - name: generate changelog
         run: |
           echo "# Argo CD Pull Integration ${{ needs.env.outputs.RELEASE_VERSION }}" > /home/runner/work/changelog.txt
+          echo "" >> /home/runner/work/changelog.txt
+          echo "This release includes:" >> /home/runner/work/changelog.txt
+          echo "- **Advanced Pull Model Chart**: \`${{ env.CHART_NAME }}-${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}.tgz\`" >> /home/runner/work/changelog.txt
+          echo "- **Basic Pull Model Chart**: \`${{ env.BASIC_CHART_NAME }}-${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}.tgz\`" >> /home/runner/work/changelog.txt
       - name: publish release
         uses: softprops/action-gh-release@v2
         env:

--- a/charts/argocd-agent-addon/Chart.yaml
+++ b/charts/argocd-agent-addon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.25.2
+appVersion: 0.26.0
 description: Argo CD Agent Addon for Open Cluster Management
 name: argocd-agent-addon
 type: application
-version: 0.25.2
+version: 0.26.0

--- a/charts/argocd-agent-addon/values.yaml
+++ b/charts/argocd-agent-addon/values.yaml
@@ -1,6 +1,6 @@
 # Controller manager image settings
 # For development (main branch): use "latest" tag
-# For release branches: update tag to match the release version (e.g., "0.25.2")
+# For release branches: update tag to match the release version (e.g., "0.26.0")
 image: quay.io/open-cluster-management/argocd-pull-integration
 tag: latest
 replicas: 1

--- a/charts/argocd-pull-integration/Chart.yaml
+++ b/charts/argocd-pull-integration/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 0.26.0
+description: A Helm chart for OCM Argo CD Pull Model Integration
+name: argocd-pull-integration
+type: application
+version: 0.26.0

--- a/charts/argocd-pull-integration/templates/app-placement.yaml
+++ b/charts/argocd-pull-integration/templates/app-placement.yaml
@@ -1,0 +1,6 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: app-placement
+  namespace: argocd
+spec: {}

--- a/charts/argocd-pull-integration/templates/argocd-addon-template.yaml
+++ b/charts/argocd-pull-integration/templates/argocd-addon-template.yaml
@@ -1,0 +1,6908 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnTemplate
+metadata:
+  name: argocd
+spec:
+  addonName: argocd
+  agentSpec:
+    workload:
+      manifests:
+        - apiVersion: apiextensions.k8s.io/v1
+          kind: CustomResourceDefinition
+          metadata:
+            labels:
+              app.kubernetes.io/name: applications.argoproj.io
+              app.kubernetes.io/part-of: argocd
+            name: applications.argoproj.io
+          spec:
+            group: argoproj.io
+            names:
+              kind: Application
+              listKind: ApplicationList
+              plural: applications
+              shortNames:
+              - app
+              - apps
+              singular: application
+            scope: Namespaced
+            versions:
+            - additionalPrinterColumns:
+              - jsonPath: .status.sync.status
+                name: Sync Status
+                type: string
+              - jsonPath: .status.health.status
+                name: Health Status
+                type: string
+              - jsonPath: .status.sync.revision
+                name: Revision
+                priority: 10
+                type: string
+              - jsonPath: .spec.project
+                name: Project
+                priority: 10
+                type: string
+              name: v1alpha1
+              schema:
+                openAPIV3Schema:
+                  description: Application is a definition of Application resource.
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion defines the versioned schema of this representation of an object.
+                        Servers should convert recognized schemas to the latest internal value, and
+                        may reject unrecognized values.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is a string value representing the REST resource this object represents.
+                        Servers may infer this from the endpoint the client submits requests to.
+                        Cannot be updated.
+                        In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    metadata:
+                      type: object
+                    operation:
+                      description: Operation contains information about a requested or running
+                        operation
+                      properties:
+                        info:
+                          description: Info is a list of informational items for this operation
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        initiatedBy:
+                          description: InitiatedBy contains information about who initiated
+                            the operations
+                          properties:
+                            automated:
+                              description: Automated is set to true if operation was initiated
+                                automatically by the application controller.
+                              type: boolean
+                            username:
+                              description: Username contains the name of a user who started
+                                operation
+                              type: string
+                          type: object
+                        retry:
+                          description: Retry controls the strategy to apply if a sync fails
+                          properties:
+                            backoff:
+                              description: Backoff controls how to backoff on subsequent retries
+                                of failed syncs
+                              properties:
+                                duration:
+                                  description: Duration is the amount to back off. Default unit
+                                    is seconds, but could also be a duration (e.g. "2m", "1h")
+                                  type: string
+                                factor:
+                                  description: Factor is a factor to multiply the base duration
+                                    after each failed retry
+                                  format: int64
+                                  type: integer
+                                maxDuration:
+                                  description: MaxDuration is the maximum amount of time allowed
+                                    for the backoff strategy
+                                  type: string
+                              type: object
+                            limit:
+                              description: Limit is the maximum number of attempts for retrying
+                                a failed sync. If set to 0, no retries will be performed.
+                              format: int64
+                              type: integer
+                          type: object
+                        sync:
+                          description: Sync contains parameters for the operation
+                          properties:
+                            autoHealAttemptsCount:
+                              description: SelfHealAttemptsCount contains the number of auto-heal
+                                attempts
+                              format: int64
+                              type: integer
+                            dryRun:
+                              description: DryRun specifies to perform a `kubectl apply --dry-run`
+                                without actually performing the sync
+                              type: boolean
+                            manifests:
+                              description: Manifests is an optional field that overrides sync
+                                source with a local directory for development
+                              items:
+                                type: string
+                              type: array
+                            prune:
+                              description: Prune specifies to delete resources from the cluster
+                                that are no longer tracked in git
+                              type: boolean
+                            resources:
+                              description: Resources describes which resources shall be part
+                                of the sync
+                              items:
+                                description: SyncOperationResource contains resources to sync.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              type: array
+                            revision:
+                              description: |-
+                                Revision is the revision (Git) or chart version (Helm) which to sync the application to
+                                If omitted, will use the revision specified in app spec.
+                              type: string
+                            revisions:
+                              description: |-
+                                Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+                                If omitted, will use the revision specified in app spec.
+                              items:
+                                type: string
+                              type: array
+                            source:
+                              description: |-
+                                Source overrides the source definition set in the application.
+                                This is typically set in a Rollback operation and is nil during a Sync operation
+                              properties:
+                                chart:
+                                  description: Chart is a Helm chart name, and must be specified
+                                    for applications sourced from a Helm repo.
+                                  type: string
+                                directory:
+                                  description: Directory holds path/directory specific options
+                                  properties:
+                                    exclude:
+                                      description: Exclude contains a glob pattern to match
+                                        paths against that should be explicitly excluded from
+                                        being used during manifest generation
+                                      type: string
+                                    include:
+                                      description: Include contains a glob pattern to match
+                                        paths against that should be explicitly included during
+                                        manifest generation
+                                      type: string
+                                    jsonnet:
+                                      description: Jsonnet holds options specific to Jsonnet
+                                      properties:
+                                        extVars:
+                                          description: ExtVars is a list of Jsonnet External
+                                            Variables
+                                          items:
+                                            description: JsonnetVar represents a variable to
+                                              be passed to jsonnet during manifest generation
+                                            properties:
+                                              code:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        libs:
+                                          description: Additional library search dirs
+                                          items:
+                                            type: string
+                                          type: array
+                                        tlas:
+                                          description: TLAS is a list of Jsonnet Top-level Arguments
+                                          items:
+                                            description: JsonnetVar represents a variable to
+                                              be passed to jsonnet during manifest generation
+                                            properties:
+                                              code:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    recurse:
+                                      description: Recurse specifies whether to scan a directory
+                                        recursively for manifests
+                                      type: boolean
+                                  type: object
+                                helm:
+                                  description: Helm holds helm specific options
+                                  properties:
+                                    apiVersions:
+                                      description: |-
+                                        APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                        Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                      items:
+                                        type: string
+                                      type: array
+                                    fileParameters:
+                                      description: FileParameters are file parameters to the
+                                        helm template
+                                      items:
+                                        description: HelmFileParameter is a file parameter that's
+                                          passed to helm template during manifest generation
+                                        properties:
+                                          name:
+                                            description: Name is the name of the Helm parameter
+                                            type: string
+                                          path:
+                                            description: Path is the path to the file containing
+                                              the values for the Helm parameter
+                                            type: string
+                                        type: object
+                                      type: array
+                                    ignoreMissingValueFiles:
+                                      description: IgnoreMissingValueFiles prevents helm template
+                                        from failing when valueFiles do not exist locally by
+                                        not appending them to helm template --values
+                                      type: boolean
+                                    kubeVersion:
+                                      description: |-
+                                        KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                        uses the Kubernetes version of the target cluster.
+                                      type: string
+                                    namespace:
+                                      description: Namespace is an optional namespace to template
+                                        with. If left empty, defaults to the app's destination
+                                        namespace.
+                                      type: string
+                                    parameters:
+                                      description: Parameters is a list of Helm parameters which
+                                        are passed to the helm template command upon manifest
+                                        generation
+                                      items:
+                                        description: HelmParameter is a parameter that's passed
+                                          to helm template during manifest generation
+                                        properties:
+                                          forceString:
+                                            description: ForceString determines whether to tell
+                                              Helm to interpret booleans and numbers as strings
+                                            type: boolean
+                                          name:
+                                            description: Name is the name of the Helm parameter
+                                            type: string
+                                          value:
+                                            description: Value is the value for the Helm parameter
+                                            type: string
+                                        type: object
+                                      type: array
+                                    passCredentials:
+                                      description: PassCredentials pass credentials to all domains
+                                        (Helm's --pass-credentials)
+                                      type: boolean
+                                    releaseName:
+                                      description: ReleaseName is the Helm release name to use.
+                                        If omitted it will use the application name
+                                      type: string
+                                    skipCrds:
+                                      description: SkipCrds skips custom resource definition
+                                        installation step (Helm's --skip-crds)
+                                      type: boolean
+                                    skipTests:
+                                      description: SkipTests skips test manifest installation
+                                        step (Helm's --skip-tests).
+                                      type: boolean
+                                    valueFiles:
+                                      description: ValuesFiles is a list of Helm value files
+                                        to use when generating a template
+                                      items:
+                                        type: string
+                                      type: array
+                                    values:
+                                      description: Values specifies Helm values to be passed
+                                        to helm template, typically defined as a block. ValuesObject
+                                        takes precedence over Values, so use one or the other.
+                                      type: string
+                                    valuesObject:
+                                      description: ValuesObject specifies Helm values to be
+                                        passed to helm template, defined as a map. This takes
+                                        precedence over Values.
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    version:
+                                      description: Version is the Helm version to use for templating
+                                        ("3")
+                                      type: string
+                                  type: object
+                                kustomize:
+                                  description: Kustomize holds kustomize specific options
+                                  properties:
+                                    apiVersions:
+                                      description: |-
+                                        APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                        Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                      items:
+                                        type: string
+                                      type: array
+                                    commonAnnotations:
+                                      additionalProperties:
+                                        type: string
+                                      description: CommonAnnotations is a list of additional
+                                        annotations to add to rendered manifests
+                                      type: object
+                                    commonAnnotationsEnvsubst:
+                                      description: CommonAnnotationsEnvsubst specifies whether
+                                        to apply env variables substitution for annotation values
+                                      type: boolean
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: CommonLabels is a list of additional labels
+                                        to add to rendered manifests
+                                      type: object
+                                    components:
+                                      description: Components specifies a list of kustomize
+                                        components to add to the kustomization before building
+                                      items:
+                                        type: string
+                                      type: array
+                                    forceCommonAnnotations:
+                                      description: ForceCommonAnnotations specifies whether
+                                        to force applying common annotations to resources for
+                                        Kustomize apps
+                                      type: boolean
+                                    forceCommonLabels:
+                                      description: ForceCommonLabels specifies whether to force
+                                        applying common labels to resources for Kustomize apps
+                                      type: boolean
+                                    images:
+                                      description: Images is a list of Kustomize image override
+                                        specifications
+                                      items:
+                                        description: KustomizeImage represents a Kustomize image
+                                          definition in the format [old_image_name=]<image_name>:<image_tag>
+                                        type: string
+                                      type: array
+                                    kubeVersion:
+                                      description: |-
+                                        KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                        uses the Kubernetes version of the target cluster.
+                                      type: string
+                                    labelWithoutSelector:
+                                      description: LabelWithoutSelector specifies whether to
+                                        apply common labels to resource selectors or not
+                                      type: boolean
+                                    namePrefix:
+                                      description: NamePrefix is a prefix appended to resources
+                                        for Kustomize apps
+                                      type: string
+                                    nameSuffix:
+                                      description: NameSuffix is a suffix appended to resources
+                                        for Kustomize apps
+                                      type: string
+                                    namespace:
+                                      description: Namespace sets the namespace that Kustomize
+                                        adds to all resources
+                                      type: string
+                                    patches:
+                                      description: Patches is a list of Kustomize patches
+                                      items:
+                                        properties:
+                                          options:
+                                            additionalProperties:
+                                              type: boolean
+                                            type: object
+                                          patch:
+                                            type: string
+                                          path:
+                                            type: string
+                                          target:
+                                            properties:
+                                              annotationSelector:
+                                                type: string
+                                              group:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              labelSelector:
+                                                type: string
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              version:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                    replicas:
+                                      description: Replicas is a list of Kustomize Replicas
+                                        override specifications
+                                      items:
+                                        properties:
+                                          count:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number of replicas
+                                            x-kubernetes-int-or-string: true
+                                          name:
+                                            description: Name of Deployment or StatefulSet
+                                            type: string
+                                        required:
+                                        - count
+                                        - name
+                                        type: object
+                                      type: array
+                                    version:
+                                      description: Version controls which version of Kustomize
+                                        to use for rendering manifests
+                                      type: string
+                                  type: object
+                                path:
+                                  description: Path is a directory path within the Git repository,
+                                    and is only valid for applications sourced from Git.
+                                  type: string
+                                plugin:
+                                  description: Plugin holds config management plugin specific
+                                    options
+                                  properties:
+                                    env:
+                                      description: Env is a list of environment variable entries
+                                      items:
+                                        description: EnvEntry represents an entry in the application's
+                                          environment
+                                        properties:
+                                          name:
+                                            description: Name is the name of the variable, usually
+                                              expressed in uppercase
+                                            type: string
+                                          value:
+                                            description: Value is the value of the variable
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    parameters:
+                                      items:
+                                        properties:
+                                          array:
+                                            description: Array is the value of an array type
+                                              parameter.
+                                            items:
+                                              type: string
+                                            type: array
+                                          map:
+                                            additionalProperties:
+                                              type: string
+                                            description: Map is the value of a map type parameter.
+                                            type: object
+                                          name:
+                                            description: Name is the name identifying a parameter.
+                                            type: string
+                                          string:
+                                            description: String_ is the value of a string type
+                                              parameter.
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                ref:
+                                  description: Ref is reference to another source within sources
+                                    field. This field will not be used if used with a `source`
+                                    tag.
+                                  type: string
+                                repoURL:
+                                  description: RepoURL is the URL to the repository (Git or
+                                    Helm) that contains the application manifests
+                                  type: string
+                                targetRevision:
+                                  description: |-
+                                    TargetRevision defines the revision of the source to sync the application to.
+                                    In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                    In case of Helm, this is a semver tag for the Chart's version.
+                                  type: string
+                              required:
+                              - repoURL
+                              type: object
+                            sources:
+                              description: |-
+                                Sources overrides the source definition set in the application.
+                                This is typically set in a Rollback operation and is nil during a Sync operation
+                              items:
+                                description: ApplicationSource contains all required information
+                                  about the source of an application
+                                properties:
+                                  chart:
+                                    description: Chart is a Helm chart name, and must be specified
+                                      for applications sourced from a Helm repo.
+                                    type: string
+                                  directory:
+                                    description: Directory holds path/directory specific options
+                                    properties:
+                                      exclude:
+                                        description: Exclude contains a glob pattern to match
+                                          paths against that should be explicitly excluded from
+                                          being used during manifest generation
+                                        type: string
+                                      include:
+                                        description: Include contains a glob pattern to match
+                                          paths against that should be explicitly included during
+                                          manifest generation
+                                        type: string
+                                      jsonnet:
+                                        description: Jsonnet holds options specific to Jsonnet
+                                        properties:
+                                          extVars:
+                                            description: ExtVars is a list of Jsonnet External
+                                              Variables
+                                            items:
+                                              description: JsonnetVar represents a variable
+                                                to be passed to jsonnet during manifest generation
+                                              properties:
+                                                code:
+                                                  type: boolean
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          libs:
+                                            description: Additional library search dirs
+                                            items:
+                                              type: string
+                                            type: array
+                                          tlas:
+                                            description: TLAS is a list of Jsonnet Top-level
+                                              Arguments
+                                            items:
+                                              description: JsonnetVar represents a variable
+                                                to be passed to jsonnet during manifest generation
+                                              properties:
+                                                code:
+                                                  type: boolean
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                        type: object
+                                      recurse:
+                                        description: Recurse specifies whether to scan a directory
+                                          recursively for manifests
+                                        type: boolean
+                                    type: object
+                                  helm:
+                                    description: Helm holds helm specific options
+                                    properties:
+                                      apiVersions:
+                                        description: |-
+                                          APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                          Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                        items:
+                                          type: string
+                                        type: array
+                                      fileParameters:
+                                        description: FileParameters are file parameters to the
+                                          helm template
+                                        items:
+                                          description: HelmFileParameter is a file parameter
+                                            that's passed to helm template during manifest generation
+                                          properties:
+                                            name:
+                                              description: Name is the name of the Helm parameter
+                                              type: string
+                                            path:
+                                              description: Path is the path to the file containing
+                                                the values for the Helm parameter
+                                              type: string
+                                          type: object
+                                        type: array
+                                      ignoreMissingValueFiles:
+                                        description: IgnoreMissingValueFiles prevents helm template
+                                          from failing when valueFiles do not exist locally
+                                          by not appending them to helm template --values
+                                        type: boolean
+                                      kubeVersion:
+                                        description: |-
+                                          KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                          uses the Kubernetes version of the target cluster.
+                                        type: string
+                                      namespace:
+                                        description: Namespace is an optional namespace to template
+                                          with. If left empty, defaults to the app's destination
+                                          namespace.
+                                        type: string
+                                      parameters:
+                                        description: Parameters is a list of Helm parameters
+                                          which are passed to the helm template command upon
+                                          manifest generation
+                                        items:
+                                          description: HelmParameter is a parameter that's passed
+                                            to helm template during manifest generation
+                                          properties:
+                                            forceString:
+                                              description: ForceString determines whether to
+                                                tell Helm to interpret booleans and numbers
+                                                as strings
+                                              type: boolean
+                                            name:
+                                              description: Name is the name of the Helm parameter
+                                              type: string
+                                            value:
+                                              description: Value is the value for the Helm parameter
+                                              type: string
+                                          type: object
+                                        type: array
+                                      passCredentials:
+                                        description: PassCredentials pass credentials to all
+                                          domains (Helm's --pass-credentials)
+                                        type: boolean
+                                      releaseName:
+                                        description: ReleaseName is the Helm release name to
+                                          use. If omitted it will use the application name
+                                        type: string
+                                      skipCrds:
+                                        description: SkipCrds skips custom resource definition
+                                          installation step (Helm's --skip-crds)
+                                        type: boolean
+                                      skipTests:
+                                        description: SkipTests skips test manifest installation
+                                          step (Helm's --skip-tests).
+                                        type: boolean
+                                      valueFiles:
+                                        description: ValuesFiles is a list of Helm value files
+                                          to use when generating a template
+                                        items:
+                                          type: string
+                                        type: array
+                                      values:
+                                        description: Values specifies Helm values to be passed
+                                          to helm template, typically defined as a block. ValuesObject
+                                          takes precedence over Values, so use one or the other.
+                                        type: string
+                                      valuesObject:
+                                        description: ValuesObject specifies Helm values to be
+                                          passed to helm template, defined as a map. This takes
+                                          precedence over Values.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      version:
+                                        description: Version is the Helm version to use for
+                                          templating ("3")
+                                        type: string
+                                    type: object
+                                  kustomize:
+                                    description: Kustomize holds kustomize specific options
+                                    properties:
+                                      apiVersions:
+                                        description: |-
+                                          APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                          Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                        items:
+                                          type: string
+                                        type: array
+                                      commonAnnotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: CommonAnnotations is a list of additional
+                                          annotations to add to rendered manifests
+                                        type: object
+                                      commonAnnotationsEnvsubst:
+                                        description: CommonAnnotationsEnvsubst specifies whether
+                                          to apply env variables substitution for annotation
+                                          values
+                                        type: boolean
+                                      commonLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: CommonLabels is a list of additional labels
+                                          to add to rendered manifests
+                                        type: object
+                                      components:
+                                        description: Components specifies a list of kustomize
+                                          components to add to the kustomization before building
+                                        items:
+                                          type: string
+                                        type: array
+                                      forceCommonAnnotations:
+                                        description: ForceCommonAnnotations specifies whether
+                                          to force applying common annotations to resources
+                                          for Kustomize apps
+                                        type: boolean
+                                      forceCommonLabels:
+                                        description: ForceCommonLabels specifies whether to
+                                          force applying common labels to resources for Kustomize
+                                          apps
+                                        type: boolean
+                                      images:
+                                        description: Images is a list of Kustomize image override
+                                          specifications
+                                        items:
+                                          description: KustomizeImage represents a Kustomize
+                                            image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                          type: string
+                                        type: array
+                                      kubeVersion:
+                                        description: |-
+                                          KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                          uses the Kubernetes version of the target cluster.
+                                        type: string
+                                      labelWithoutSelector:
+                                        description: LabelWithoutSelector specifies whether
+                                          to apply common labels to resource selectors or not
+                                        type: boolean
+                                      namePrefix:
+                                        description: NamePrefix is a prefix appended to resources
+                                          for Kustomize apps
+                                        type: string
+                                      nameSuffix:
+                                        description: NameSuffix is a suffix appended to resources
+                                          for Kustomize apps
+                                        type: string
+                                      namespace:
+                                        description: Namespace sets the namespace that Kustomize
+                                          adds to all resources
+                                        type: string
+                                      patches:
+                                        description: Patches is a list of Kustomize patches
+                                        items:
+                                          properties:
+                                            options:
+                                              additionalProperties:
+                                                type: boolean
+                                              type: object
+                                            patch:
+                                              type: string
+                                            path:
+                                              type: string
+                                            target:
+                                              properties:
+                                                annotationSelector:
+                                                  type: string
+                                                group:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                labelSelector:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                                version:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        type: array
+                                      replicas:
+                                        description: Replicas is a list of Kustomize Replicas
+                                          override specifications
+                                        items:
+                                          properties:
+                                            count:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number of replicas
+                                              x-kubernetes-int-or-string: true
+                                            name:
+                                              description: Name of Deployment or StatefulSet
+                                              type: string
+                                          required:
+                                          - count
+                                          - name
+                                          type: object
+                                        type: array
+                                      version:
+                                        description: Version controls which version of Kustomize
+                                          to use for rendering manifests
+                                        type: string
+                                    type: object
+                                  path:
+                                    description: Path is a directory path within the Git repository,
+                                      and is only valid for applications sourced from Git.
+                                    type: string
+                                  plugin:
+                                    description: Plugin holds config management plugin specific
+                                      options
+                                    properties:
+                                      env:
+                                        description: Env is a list of environment variable entries
+                                        items:
+                                          description: EnvEntry represents an entry in the application's
+                                            environment
+                                          properties:
+                                            name:
+                                              description: Name is the name of the variable,
+                                                usually expressed in uppercase
+                                              type: string
+                                            value:
+                                              description: Value is the value of the variable
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                      parameters:
+                                        items:
+                                          properties:
+                                            array:
+                                              description: Array is the value of an array type
+                                                parameter.
+                                              items:
+                                                type: string
+                                              type: array
+                                            map:
+                                              additionalProperties:
+                                                type: string
+                                              description: Map is the value of a map type parameter.
+                                              type: object
+                                            name:
+                                              description: Name is the name identifying a parameter.
+                                              type: string
+                                            string:
+                                              description: String_ is the value of a string
+                                                type parameter.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  ref:
+                                    description: Ref is reference to another source within sources
+                                      field. This field will not be used if used with a `source`
+                                      tag.
+                                    type: string
+                                  repoURL:
+                                    description: RepoURL is the URL to the repository (Git or
+                                      Helm) that contains the application manifests
+                                    type: string
+                                  targetRevision:
+                                    description: |-
+                                      TargetRevision defines the revision of the source to sync the application to.
+                                      In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                      In case of Helm, this is a semver tag for the Chart's version.
+                                    type: string
+                                required:
+                                - repoURL
+                                type: object
+                              type: array
+                            syncOptions:
+                              description: SyncOptions provide per-sync sync-options, e.g. Validate=false
+                              items:
+                                type: string
+                              type: array
+                            syncStrategy:
+                              description: SyncStrategy describes how to perform the sync
+                              properties:
+                                apply:
+                                  description: Apply will perform a `kubectl apply` to perform
+                                    the sync.
+                                  properties:
+                                    force:
+                                      description: |-
+                                        Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                        The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                        retried for 5 times.
+                                      type: boolean
+                                  type: object
+                                hook:
+                                  description: Hook will submit any referenced resources to
+                                    perform the sync. This is the default strategy
+                                  properties:
+                                    force:
+                                      description: |-
+                                        Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                        The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                        retried for 5 times.
+                                      type: boolean
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    spec:
+                      description: ApplicationSpec represents desired application state. Contains
+                        link to repository with application definition and additional parameters
+                        link definition revision.
+                      properties:
+                        destination:
+                          description: Destination is a reference to the target Kubernetes server
+                            and namespace
+                          properties:
+                            name:
+                              description: Name is an alternate way of specifying the target
+                                cluster by its symbolic name. This must be set if Server is
+                                not set.
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace specifies the target namespace for the application's resources.
+                                The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
+                              type: string
+                            server:
+                              description: Server specifies the URL of the target cluster's
+                                Kubernetes control plane API. This must be set if Name is not
+                                set.
+                              type: string
+                          type: object
+                        ignoreDifferences:
+                          description: IgnoreDifferences is a list of resources and their fields
+                            which should be ignored during comparison
+                          items:
+                            description: ResourceIgnoreDifferences contains resource filter
+                              and list of json paths which should be ignored during comparison
+                              with live state.
+                            properties:
+                              group:
+                                type: string
+                              jqPathExpressions:
+                                items:
+                                  type: string
+                                type: array
+                              jsonPointers:
+                                items:
+                                  type: string
+                                type: array
+                              kind:
+                                type: string
+                              managedFieldsManagers:
+                                description: |-
+                                  ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+                                  desired state defined in the SCM and won't be displayed in diffs
+                                items:
+                                  type: string
+                                type: array
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          type: array
+                        info:
+                          description: Info contains a list of information (URLs, email addresses,
+                            and plain text) that relates to the application
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        project:
+                          description: |-
+                            Project is a reference to the project this application belongs to.
+                            The empty string means that application belongs to the 'default' project.
+                          type: string
+                        revisionHistoryLimit:
+                          description: |-
+                            RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions.
+                            This should only be changed in exceptional circumstances.
+                            Setting to zero will store no history. This will reduce storage used.
+                            Increasing will increase the space used to store the history, so we do not recommend increasing it.
+                            Default is 10.
+                          format: int64
+                          type: integer
+                        source:
+                          description: Source is a reference to the location of the application's
+                            manifests or chart
+                          properties:
+                            chart:
+                              description: Chart is a Helm chart name, and must be specified
+                                for applications sourced from a Helm repo.
+                              type: string
+                            directory:
+                              description: Directory holds path/directory specific options
+                              properties:
+                                exclude:
+                                  description: Exclude contains a glob pattern to match paths
+                                    against that should be explicitly excluded from being used
+                                    during manifest generation
+                                  type: string
+                                include:
+                                  description: Include contains a glob pattern to match paths
+                                    against that should be explicitly included during manifest
+                                    generation
+                                  type: string
+                                jsonnet:
+                                  description: Jsonnet holds options specific to Jsonnet
+                                  properties:
+                                    extVars:
+                                      description: ExtVars is a list of Jsonnet External Variables
+                                      items:
+                                        description: JsonnetVar represents a variable to be
+                                          passed to jsonnet during manifest generation
+                                        properties:
+                                          code:
+                                            type: boolean
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    libs:
+                                      description: Additional library search dirs
+                                      items:
+                                        type: string
+                                      type: array
+                                    tlas:
+                                      description: TLAS is a list of Jsonnet Top-level Arguments
+                                      items:
+                                        description: JsonnetVar represents a variable to be
+                                          passed to jsonnet during manifest generation
+                                        properties:
+                                          code:
+                                            type: boolean
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                  type: object
+                                recurse:
+                                  description: Recurse specifies whether to scan a directory
+                                    recursively for manifests
+                                  type: boolean
+                              type: object
+                            helm:
+                              description: Helm holds helm specific options
+                              properties:
+                                apiVersions:
+                                  description: |-
+                                    APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                    Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                  items:
+                                    type: string
+                                  type: array
+                                fileParameters:
+                                  description: FileParameters are file parameters to the helm
+                                    template
+                                  items:
+                                    description: HelmFileParameter is a file parameter that's
+                                      passed to helm template during manifest generation
+                                    properties:
+                                      name:
+                                        description: Name is the name of the Helm parameter
+                                        type: string
+                                      path:
+                                        description: Path is the path to the file containing
+                                          the values for the Helm parameter
+                                        type: string
+                                    type: object
+                                  type: array
+                                ignoreMissingValueFiles:
+                                  description: IgnoreMissingValueFiles prevents helm template
+                                    from failing when valueFiles do not exist locally by not
+                                    appending them to helm template --values
+                                  type: boolean
+                                kubeVersion:
+                                  description: |-
+                                    KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                    uses the Kubernetes version of the target cluster.
+                                  type: string
+                                namespace:
+                                  description: Namespace is an optional namespace to template
+                                    with. If left empty, defaults to the app's destination namespace.
+                                  type: string
+                                parameters:
+                                  description: Parameters is a list of Helm parameters which
+                                    are passed to the helm template command upon manifest generation
+                                  items:
+                                    description: HelmParameter is a parameter that's passed
+                                      to helm template during manifest generation
+                                    properties:
+                                      forceString:
+                                        description: ForceString determines whether to tell
+                                          Helm to interpret booleans and numbers as strings
+                                        type: boolean
+                                      name:
+                                        description: Name is the name of the Helm parameter
+                                        type: string
+                                      value:
+                                        description: Value is the value for the Helm parameter
+                                        type: string
+                                    type: object
+                                  type: array
+                                passCredentials:
+                                  description: PassCredentials pass credentials to all domains
+                                    (Helm's --pass-credentials)
+                                  type: boolean
+                                releaseName:
+                                  description: ReleaseName is the Helm release name to use.
+                                    If omitted it will use the application name
+                                  type: string
+                                skipCrds:
+                                  description: SkipCrds skips custom resource definition installation
+                                    step (Helm's --skip-crds)
+                                  type: boolean
+                                skipTests:
+                                  description: SkipTests skips test manifest installation step
+                                    (Helm's --skip-tests).
+                                  type: boolean
+                                valueFiles:
+                                  description: ValuesFiles is a list of Helm value files to
+                                    use when generating a template
+                                  items:
+                                    type: string
+                                  type: array
+                                values:
+                                  description: Values specifies Helm values to be passed to
+                                    helm template, typically defined as a block. ValuesObject
+                                    takes precedence over Values, so use one or the other.
+                                  type: string
+                                valuesObject:
+                                  description: ValuesObject specifies Helm values to be passed
+                                    to helm template, defined as a map. This takes precedence
+                                    over Values.
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                version:
+                                  description: Version is the Helm version to use for templating
+                                    ("3")
+                                  type: string
+                              type: object
+                            kustomize:
+                              description: Kustomize holds kustomize specific options
+                              properties:
+                                apiVersions:
+                                  description: |-
+                                    APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                    Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                  items:
+                                    type: string
+                                  type: array
+                                commonAnnotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: CommonAnnotations is a list of additional annotations
+                                    to add to rendered manifests
+                                  type: object
+                                commonAnnotationsEnvsubst:
+                                  description: CommonAnnotationsEnvsubst specifies whether to
+                                    apply env variables substitution for annotation values
+                                  type: boolean
+                                commonLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: CommonLabels is a list of additional labels to
+                                    add to rendered manifests
+                                  type: object
+                                components:
+                                  description: Components specifies a list of kustomize components
+                                    to add to the kustomization before building
+                                  items:
+                                    type: string
+                                  type: array
+                                forceCommonAnnotations:
+                                  description: ForceCommonAnnotations specifies whether to force
+                                    applying common annotations to resources for Kustomize apps
+                                  type: boolean
+                                forceCommonLabels:
+                                  description: ForceCommonLabels specifies whether to force
+                                    applying common labels to resources for Kustomize apps
+                                  type: boolean
+                                images:
+                                  description: Images is a list of Kustomize image override
+                                    specifications
+                                  items:
+                                    description: KustomizeImage represents a Kustomize image
+                                      definition in the format [old_image_name=]<image_name>:<image_tag>
+                                    type: string
+                                  type: array
+                                kubeVersion:
+                                  description: |-
+                                    KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                    uses the Kubernetes version of the target cluster.
+                                  type: string
+                                labelWithoutSelector:
+                                  description: LabelWithoutSelector specifies whether to apply
+                                    common labels to resource selectors or not
+                                  type: boolean
+                                namePrefix:
+                                  description: NamePrefix is a prefix appended to resources
+                                    for Kustomize apps
+                                  type: string
+                                nameSuffix:
+                                  description: NameSuffix is a suffix appended to resources
+                                    for Kustomize apps
+                                  type: string
+                                namespace:
+                                  description: Namespace sets the namespace that Kustomize adds
+                                    to all resources
+                                  type: string
+                                patches:
+                                  description: Patches is a list of Kustomize patches
+                                  items:
+                                    properties:
+                                      options:
+                                        additionalProperties:
+                                          type: boolean
+                                        type: object
+                                      patch:
+                                        type: string
+                                      path:
+                                        type: string
+                                      target:
+                                        properties:
+                                          annotationSelector:
+                                            type: string
+                                          group:
+                                            type: string
+                                          kind:
+                                            type: string
+                                          labelSelector:
+                                            type: string
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                          version:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                                replicas:
+                                  description: Replicas is a list of Kustomize Replicas override
+                                    specifications
+                                  items:
+                                    properties:
+                                      count:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number of replicas
+                                        x-kubernetes-int-or-string: true
+                                      name:
+                                        description: Name of Deployment or StatefulSet
+                                        type: string
+                                    required:
+                                    - count
+                                    - name
+                                    type: object
+                                  type: array
+                                version:
+                                  description: Version controls which version of Kustomize to
+                                    use for rendering manifests
+                                  type: string
+                              type: object
+                            path:
+                              description: Path is a directory path within the Git repository,
+                                and is only valid for applications sourced from Git.
+                              type: string
+                            plugin:
+                              description: Plugin holds config management plugin specific options
+                              properties:
+                                env:
+                                  description: Env is a list of environment variable entries
+                                  items:
+                                    description: EnvEntry represents an entry in the application's
+                                      environment
+                                    properties:
+                                      name:
+                                        description: Name is the name of the variable, usually
+                                          expressed in uppercase
+                                        type: string
+                                      value:
+                                        description: Value is the value of the variable
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                parameters:
+                                  items:
+                                    properties:
+                                      array:
+                                        description: Array is the value of an array type parameter.
+                                        items:
+                                          type: string
+                                        type: array
+                                      map:
+                                        additionalProperties:
+                                          type: string
+                                        description: Map is the value of a map type parameter.
+                                        type: object
+                                      name:
+                                        description: Name is the name identifying a parameter.
+                                        type: string
+                                      string:
+                                        description: String_ is the value of a string type parameter.
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            ref:
+                              description: Ref is reference to another source within sources
+                                field. This field will not be used if used with a `source` tag.
+                              type: string
+                            repoURL:
+                              description: RepoURL is the URL to the repository (Git or Helm)
+                                that contains the application manifests
+                              type: string
+                            targetRevision:
+                              description: |-
+                                TargetRevision defines the revision of the source to sync the application to.
+                                In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                In case of Helm, this is a semver tag for the Chart's version.
+                              type: string
+                          required:
+                          - repoURL
+                          type: object
+                        sources:
+                          description: Sources is a reference to the location of the application's
+                            manifests or chart
+                          items:
+                            description: ApplicationSource contains all required information
+                              about the source of an application
+                            properties:
+                              chart:
+                                description: Chart is a Helm chart name, and must be specified
+                                  for applications sourced from a Helm repo.
+                                type: string
+                              directory:
+                                description: Directory holds path/directory specific options
+                                properties:
+                                  exclude:
+                                    description: Exclude contains a glob pattern to match paths
+                                      against that should be explicitly excluded from being
+                                      used during manifest generation
+                                    type: string
+                                  include:
+                                    description: Include contains a glob pattern to match paths
+                                      against that should be explicitly included during manifest
+                                      generation
+                                    type: string
+                                  jsonnet:
+                                    description: Jsonnet holds options specific to Jsonnet
+                                    properties:
+                                      extVars:
+                                        description: ExtVars is a list of Jsonnet External Variables
+                                        items:
+                                          description: JsonnetVar represents a variable to be
+                                            passed to jsonnet during manifest generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        description: Additional library search dirs
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        description: TLAS is a list of Jsonnet Top-level Arguments
+                                        items:
+                                          description: JsonnetVar represents a variable to be
+                                            passed to jsonnet during manifest generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    description: Recurse specifies whether to scan a directory
+                                      recursively for manifests
+                                    type: boolean
+                                type: object
+                              helm:
+                                description: Helm holds helm specific options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  fileParameters:
+                                    description: FileParameters are file parameters to the helm
+                                      template
+                                    items:
+                                      description: HelmFileParameter is a file parameter that's
+                                        passed to helm template during manifest generation
+                                      properties:
+                                        name:
+                                          description: Name is the name of the Helm parameter
+                                          type: string
+                                        path:
+                                          description: Path is the path to the file containing
+                                            the values for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  ignoreMissingValueFiles:
+                                    description: IgnoreMissingValueFiles prevents helm template
+                                      from failing when valueFiles do not exist locally by not
+                                      appending them to helm template --values
+                                    type: boolean
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is an optional namespace to template
+                                      with. If left empty, defaults to the app's destination
+                                      namespace.
+                                    type: string
+                                  parameters:
+                                    description: Parameters is a list of Helm parameters which
+                                      are passed to the helm template command upon manifest
+                                      generation
+                                    items:
+                                      description: HelmParameter is a parameter that's passed
+                                        to helm template during manifest generation
+                                      properties:
+                                        forceString:
+                                          description: ForceString determines whether to tell
+                                            Helm to interpret booleans and numbers as strings
+                                          type: boolean
+                                        name:
+                                          description: Name is the name of the Helm parameter
+                                          type: string
+                                        value:
+                                          description: Value is the value for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  passCredentials:
+                                    description: PassCredentials pass credentials to all domains
+                                      (Helm's --pass-credentials)
+                                    type: boolean
+                                  releaseName:
+                                    description: ReleaseName is the Helm release name to use.
+                                      If omitted it will use the application name
+                                    type: string
+                                  skipCrds:
+                                    description: SkipCrds skips custom resource definition installation
+                                      step (Helm's --skip-crds)
+                                    type: boolean
+                                  skipTests:
+                                    description: SkipTests skips test manifest installation
+                                      step (Helm's --skip-tests).
+                                    type: boolean
+                                  valueFiles:
+                                    description: ValuesFiles is a list of Helm value files to
+                                      use when generating a template
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    description: Values specifies Helm values to be passed to
+                                      helm template, typically defined as a block. ValuesObject
+                                      takes precedence over Values, so use one or the other.
+                                    type: string
+                                  valuesObject:
+                                    description: ValuesObject specifies Helm values to be passed
+                                      to helm template, defined as a map. This takes precedence
+                                      over Values.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  version:
+                                    description: Version is the Helm version to use for templating
+                                      ("3")
+                                    type: string
+                                type: object
+                              kustomize:
+                                description: Kustomize holds kustomize specific options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonAnnotations is a list of additional annotations
+                                      to add to rendered manifests
+                                    type: object
+                                  commonAnnotationsEnvsubst:
+                                    description: CommonAnnotationsEnvsubst specifies whether
+                                      to apply env variables substitution for annotation values
+                                    type: boolean
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels is a list of additional labels
+                                      to add to rendered manifests
+                                    type: object
+                                  components:
+                                    description: Components specifies a list of kustomize components
+                                      to add to the kustomization before building
+                                    items:
+                                      type: string
+                                    type: array
+                                  forceCommonAnnotations:
+                                    description: ForceCommonAnnotations specifies whether to
+                                      force applying common annotations to resources for Kustomize
+                                      apps
+                                    type: boolean
+                                  forceCommonLabels:
+                                    description: ForceCommonLabels specifies whether to force
+                                      applying common labels to resources for Kustomize apps
+                                    type: boolean
+                                  images:
+                                    description: Images is a list of Kustomize image override
+                                      specifications
+                                    items:
+                                      description: KustomizeImage represents a Kustomize image
+                                        definition in the format [old_image_name=]<image_name>:<image_tag>
+                                      type: string
+                                    type: array
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  labelWithoutSelector:
+                                    description: LabelWithoutSelector specifies whether to apply
+                                      common labels to resource selectors or not
+                                    type: boolean
+                                  namePrefix:
+                                    description: NamePrefix is a prefix appended to resources
+                                      for Kustomize apps
+                                    type: string
+                                  nameSuffix:
+                                    description: NameSuffix is a suffix appended to resources
+                                      for Kustomize apps
+                                    type: string
+                                  namespace:
+                                    description: Namespace sets the namespace that Kustomize
+                                      adds to all resources
+                                    type: string
+                                  patches:
+                                    description: Patches is a list of Kustomize patches
+                                    items:
+                                      properties:
+                                        options:
+                                          additionalProperties:
+                                            type: boolean
+                                          type: object
+                                        patch:
+                                          type: string
+                                        path:
+                                          type: string
+                                        target:
+                                          properties:
+                                            annotationSelector:
+                                              type: string
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            labelSelector:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    type: array
+                                  replicas:
+                                    description: Replicas is a list of Kustomize Replicas override
+                                      specifications
+                                    items:
+                                      properties:
+                                        count:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number of replicas
+                                          x-kubernetes-int-or-string: true
+                                        name:
+                                          description: Name of Deployment or StatefulSet
+                                          type: string
+                                      required:
+                                      - count
+                                      - name
+                                      type: object
+                                    type: array
+                                  version:
+                                    description: Version controls which version of Kustomize
+                                      to use for rendering manifests
+                                    type: string
+                                type: object
+                              path:
+                                description: Path is a directory path within the Git repository,
+                                  and is only valid for applications sourced from Git.
+                                type: string
+                              plugin:
+                                description: Plugin holds config management plugin specific
+                                  options
+                                properties:
+                                  env:
+                                    description: Env is a list of environment variable entries
+                                    items:
+                                      description: EnvEntry represents an entry in the application's
+                                        environment
+                                      properties:
+                                        name:
+                                          description: Name is the name of the variable, usually
+                                            expressed in uppercase
+                                          type: string
+                                        value:
+                                          description: Value is the value of the variable
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        array:
+                                          description: Array is the value of an array type parameter.
+                                          items:
+                                            type: string
+                                          type: array
+                                        map:
+                                          additionalProperties:
+                                            type: string
+                                          description: Map is the value of a map type parameter.
+                                          type: object
+                                        name:
+                                          description: Name is the name identifying a parameter.
+                                          type: string
+                                        string:
+                                          description: String_ is the value of a string type
+                                            parameter.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              ref:
+                                description: Ref is reference to another source within sources
+                                  field. This field will not be used if used with a `source`
+                                  tag.
+                                type: string
+                              repoURL:
+                                description: RepoURL is the URL to the repository (Git or Helm)
+                                  that contains the application manifests
+                                type: string
+                              targetRevision:
+                                description: |-
+                                  TargetRevision defines the revision of the source to sync the application to.
+                                  In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                  In case of Helm, this is a semver tag for the Chart's version.
+                                type: string
+                            required:
+                            - repoURL
+                            type: object
+                          type: array
+                        syncPolicy:
+                          description: SyncPolicy controls when and how a sync will be performed
+                          properties:
+                            automated:
+                              description: Automated will keep an application synced to the
+                                target revision
+                              properties:
+                                allowEmpty:
+                                  description: 'AllowEmpty allows apps have zero live resources
+                                    (default: false)'
+                                  type: boolean
+                                prune:
+                                  description: 'Prune specifies whether to delete resources
+                                    from the cluster that are not found in the sources anymore
+                                    as part of automated sync (default: false)'
+                                  type: boolean
+                                selfHeal:
+                                  description: 'SelfHeal specifies whether to revert resources
+                                    back to their desired state upon modification in the cluster
+                                    (default: false)'
+                                  type: boolean
+                              type: object
+                            managedNamespaceMetadata:
+                              description: ManagedNamespaceMetadata controls metadata in the
+                                given namespace (if CreateNamespace=true)
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            retry:
+                              description: Retry controls failed sync retry behavior
+                              properties:
+                                backoff:
+                                  description: Backoff controls how to backoff on subsequent
+                                    retries of failed syncs
+                                  properties:
+                                    duration:
+                                      description: Duration is the amount to back off. Default
+                                        unit is seconds, but could also be a duration (e.g.
+                                        "2m", "1h")
+                                      type: string
+                                    factor:
+                                      description: Factor is a factor to multiply the base duration
+                                        after each failed retry
+                                      format: int64
+                                      type: integer
+                                    maxDuration:
+                                      description: MaxDuration is the maximum amount of time
+                                        allowed for the backoff strategy
+                                      type: string
+                                  type: object
+                                limit:
+                                  description: Limit is the maximum number of attempts for retrying
+                                    a failed sync. If set to 0, no retries will be performed.
+                                  format: int64
+                                  type: integer
+                              type: object
+                            syncOptions:
+                              description: Options allow you to specify whole app sync-options
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      required:
+                      - destination
+                      - project
+                      type: object
+                    status:
+                      description: ApplicationStatus contains status information for the application
+                      properties:
+                        conditions:
+                          description: Conditions is a list of currently observed application
+                            conditions
+                          items:
+                            description: ApplicationCondition contains details about an application
+                              condition, which is usually an error or warning
+                            properties:
+                              lastTransitionTime:
+                                description: LastTransitionTime is the time the condition was
+                                  last observed
+                                format: date-time
+                                type: string
+                              message:
+                                description: Message contains human-readable message indicating
+                                  details about condition
+                                type: string
+                              type:
+                                description: Type is an application condition type
+                                type: string
+                            required:
+                            - message
+                            - type
+                            type: object
+                          type: array
+                        controllerNamespace:
+                          description: ControllerNamespace indicates the namespace in which
+                            the application controller is located
+                          type: string
+                        health:
+                          description: Health contains information about the application's current
+                            health status
+                          properties:
+                            message:
+                              description: Message is a human-readable informational message
+                                describing the health status
+                              type: string
+                            status:
+                              description: Status holds the status code of the application or
+                                resource
+                              type: string
+                          type: object
+                        history:
+                          description: History contains information about the application's
+                            sync history
+                          items:
+                            description: RevisionHistory contains history information about
+                              a previous sync
+                            properties:
+                              deployStartedAt:
+                                description: DeployStartedAt holds the time the sync operation
+                                  started
+                                format: date-time
+                                type: string
+                              deployedAt:
+                                description: DeployedAt holds the time the sync operation completed
+                                format: date-time
+                                type: string
+                              id:
+                                description: ID is an auto incrementing identifier of the RevisionHistory
+                                format: int64
+                                type: integer
+                              initiatedBy:
+                                description: InitiatedBy contains information about who initiated
+                                  the operations
+                                properties:
+                                  automated:
+                                    description: Automated is set to true if operation was initiated
+                                      automatically by the application controller.
+                                    type: boolean
+                                  username:
+                                    description: Username contains the name of a user who started
+                                      operation
+                                    type: string
+                                type: object
+                              revision:
+                                description: Revision holds the revision the sync was performed
+                                  against
+                                type: string
+                              revisions:
+                                description: Revisions holds the revision of each source in
+                                  sources field the sync was performed against
+                                items:
+                                  type: string
+                                type: array
+                              source:
+                                description: Source is a reference to the application source
+                                  used for the sync operation
+                                properties:
+                                  chart:
+                                    description: Chart is a Helm chart name, and must be specified
+                                      for applications sourced from a Helm repo.
+                                    type: string
+                                  directory:
+                                    description: Directory holds path/directory specific options
+                                    properties:
+                                      exclude:
+                                        description: Exclude contains a glob pattern to match
+                                          paths against that should be explicitly excluded from
+                                          being used during manifest generation
+                                        type: string
+                                      include:
+                                        description: Include contains a glob pattern to match
+                                          paths against that should be explicitly included during
+                                          manifest generation
+                                        type: string
+                                      jsonnet:
+                                        description: Jsonnet holds options specific to Jsonnet
+                                        properties:
+                                          extVars:
+                                            description: ExtVars is a list of Jsonnet External
+                                              Variables
+                                            items:
+                                              description: JsonnetVar represents a variable
+                                                to be passed to jsonnet during manifest generation
+                                              properties:
+                                                code:
+                                                  type: boolean
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          libs:
+                                            description: Additional library search dirs
+                                            items:
+                                              type: string
+                                            type: array
+                                          tlas:
+                                            description: TLAS is a list of Jsonnet Top-level
+                                              Arguments
+                                            items:
+                                              description: JsonnetVar represents a variable
+                                                to be passed to jsonnet during manifest generation
+                                              properties:
+                                                code:
+                                                  type: boolean
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                        type: object
+                                      recurse:
+                                        description: Recurse specifies whether to scan a directory
+                                          recursively for manifests
+                                        type: boolean
+                                    type: object
+                                  helm:
+                                    description: Helm holds helm specific options
+                                    properties:
+                                      apiVersions:
+                                        description: |-
+                                          APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                          Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                        items:
+                                          type: string
+                                        type: array
+                                      fileParameters:
+                                        description: FileParameters are file parameters to the
+                                          helm template
+                                        items:
+                                          description: HelmFileParameter is a file parameter
+                                            that's passed to helm template during manifest generation
+                                          properties:
+                                            name:
+                                              description: Name is the name of the Helm parameter
+                                              type: string
+                                            path:
+                                              description: Path is the path to the file containing
+                                                the values for the Helm parameter
+                                              type: string
+                                          type: object
+                                        type: array
+                                      ignoreMissingValueFiles:
+                                        description: IgnoreMissingValueFiles prevents helm template
+                                          from failing when valueFiles do not exist locally
+                                          by not appending them to helm template --values
+                                        type: boolean
+                                      kubeVersion:
+                                        description: |-
+                                          KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                          uses the Kubernetes version of the target cluster.
+                                        type: string
+                                      namespace:
+                                        description: Namespace is an optional namespace to template
+                                          with. If left empty, defaults to the app's destination
+                                          namespace.
+                                        type: string
+                                      parameters:
+                                        description: Parameters is a list of Helm parameters
+                                          which are passed to the helm template command upon
+                                          manifest generation
+                                        items:
+                                          description: HelmParameter is a parameter that's passed
+                                            to helm template during manifest generation
+                                          properties:
+                                            forceString:
+                                              description: ForceString determines whether to
+                                                tell Helm to interpret booleans and numbers
+                                                as strings
+                                              type: boolean
+                                            name:
+                                              description: Name is the name of the Helm parameter
+                                              type: string
+                                            value:
+                                              description: Value is the value for the Helm parameter
+                                              type: string
+                                          type: object
+                                        type: array
+                                      passCredentials:
+                                        description: PassCredentials pass credentials to all
+                                          domains (Helm's --pass-credentials)
+                                        type: boolean
+                                      releaseName:
+                                        description: ReleaseName is the Helm release name to
+                                          use. If omitted it will use the application name
+                                        type: string
+                                      skipCrds:
+                                        description: SkipCrds skips custom resource definition
+                                          installation step (Helm's --skip-crds)
+                                        type: boolean
+                                      skipTests:
+                                        description: SkipTests skips test manifest installation
+                                          step (Helm's --skip-tests).
+                                        type: boolean
+                                      valueFiles:
+                                        description: ValuesFiles is a list of Helm value files
+                                          to use when generating a template
+                                        items:
+                                          type: string
+                                        type: array
+                                      values:
+                                        description: Values specifies Helm values to be passed
+                                          to helm template, typically defined as a block. ValuesObject
+                                          takes precedence over Values, so use one or the other.
+                                        type: string
+                                      valuesObject:
+                                        description: ValuesObject specifies Helm values to be
+                                          passed to helm template, defined as a map. This takes
+                                          precedence over Values.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      version:
+                                        description: Version is the Helm version to use for
+                                          templating ("3")
+                                        type: string
+                                    type: object
+                                  kustomize:
+                                    description: Kustomize holds kustomize specific options
+                                    properties:
+                                      apiVersions:
+                                        description: |-
+                                          APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                          Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                        items:
+                                          type: string
+                                        type: array
+                                      commonAnnotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: CommonAnnotations is a list of additional
+                                          annotations to add to rendered manifests
+                                        type: object
+                                      commonAnnotationsEnvsubst:
+                                        description: CommonAnnotationsEnvsubst specifies whether
+                                          to apply env variables substitution for annotation
+                                          values
+                                        type: boolean
+                                      commonLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: CommonLabels is a list of additional labels
+                                          to add to rendered manifests
+                                        type: object
+                                      components:
+                                        description: Components specifies a list of kustomize
+                                          components to add to the kustomization before building
+                                        items:
+                                          type: string
+                                        type: array
+                                      forceCommonAnnotations:
+                                        description: ForceCommonAnnotations specifies whether
+                                          to force applying common annotations to resources
+                                          for Kustomize apps
+                                        type: boolean
+                                      forceCommonLabels:
+                                        description: ForceCommonLabels specifies whether to
+                                          force applying common labels to resources for Kustomize
+                                          apps
+                                        type: boolean
+                                      images:
+                                        description: Images is a list of Kustomize image override
+                                          specifications
+                                        items:
+                                          description: KustomizeImage represents a Kustomize
+                                            image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                          type: string
+                                        type: array
+                                      kubeVersion:
+                                        description: |-
+                                          KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                          uses the Kubernetes version of the target cluster.
+                                        type: string
+                                      labelWithoutSelector:
+                                        description: LabelWithoutSelector specifies whether
+                                          to apply common labels to resource selectors or not
+                                        type: boolean
+                                      namePrefix:
+                                        description: NamePrefix is a prefix appended to resources
+                                          for Kustomize apps
+                                        type: string
+                                      nameSuffix:
+                                        description: NameSuffix is a suffix appended to resources
+                                          for Kustomize apps
+                                        type: string
+                                      namespace:
+                                        description: Namespace sets the namespace that Kustomize
+                                          adds to all resources
+                                        type: string
+                                      patches:
+                                        description: Patches is a list of Kustomize patches
+                                        items:
+                                          properties:
+                                            options:
+                                              additionalProperties:
+                                                type: boolean
+                                              type: object
+                                            patch:
+                                              type: string
+                                            path:
+                                              type: string
+                                            target:
+                                              properties:
+                                                annotationSelector:
+                                                  type: string
+                                                group:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                labelSelector:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                                version:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        type: array
+                                      replicas:
+                                        description: Replicas is a list of Kustomize Replicas
+                                          override specifications
+                                        items:
+                                          properties:
+                                            count:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number of replicas
+                                              x-kubernetes-int-or-string: true
+                                            name:
+                                              description: Name of Deployment or StatefulSet
+                                              type: string
+                                          required:
+                                          - count
+                                          - name
+                                          type: object
+                                        type: array
+                                      version:
+                                        description: Version controls which version of Kustomize
+                                          to use for rendering manifests
+                                        type: string
+                                    type: object
+                                  path:
+                                    description: Path is a directory path within the Git repository,
+                                      and is only valid for applications sourced from Git.
+                                    type: string
+                                  plugin:
+                                    description: Plugin holds config management plugin specific
+                                      options
+                                    properties:
+                                      env:
+                                        description: Env is a list of environment variable entries
+                                        items:
+                                          description: EnvEntry represents an entry in the application's
+                                            environment
+                                          properties:
+                                            name:
+                                              description: Name is the name of the variable,
+                                                usually expressed in uppercase
+                                              type: string
+                                            value:
+                                              description: Value is the value of the variable
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                      parameters:
+                                        items:
+                                          properties:
+                                            array:
+                                              description: Array is the value of an array type
+                                                parameter.
+                                              items:
+                                                type: string
+                                              type: array
+                                            map:
+                                              additionalProperties:
+                                                type: string
+                                              description: Map is the value of a map type parameter.
+                                              type: object
+                                            name:
+                                              description: Name is the name identifying a parameter.
+                                              type: string
+                                            string:
+                                              description: String_ is the value of a string
+                                                type parameter.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  ref:
+                                    description: Ref is reference to another source within sources
+                                      field. This field will not be used if used with a `source`
+                                      tag.
+                                    type: string
+                                  repoURL:
+                                    description: RepoURL is the URL to the repository (Git or
+                                      Helm) that contains the application manifests
+                                    type: string
+                                  targetRevision:
+                                    description: |-
+                                      TargetRevision defines the revision of the source to sync the application to.
+                                      In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                      In case of Helm, this is a semver tag for the Chart's version.
+                                    type: string
+                                required:
+                                - repoURL
+                                type: object
+                              sources:
+                                description: Sources is a reference to the application sources
+                                  used for the sync operation
+                                items:
+                                  description: ApplicationSource contains all required information
+                                    about the source of an application
+                                  properties:
+                                    chart:
+                                      description: Chart is a Helm chart name, and must be specified
+                                        for applications sourced from a Helm repo.
+                                      type: string
+                                    directory:
+                                      description: Directory holds path/directory specific options
+                                      properties:
+                                        exclude:
+                                          description: Exclude contains a glob pattern to match
+                                            paths against that should be explicitly excluded
+                                            from being used during manifest generation
+                                          type: string
+                                        include:
+                                          description: Include contains a glob pattern to match
+                                            paths against that should be explicitly included
+                                            during manifest generation
+                                          type: string
+                                        jsonnet:
+                                          description: Jsonnet holds options specific to Jsonnet
+                                          properties:
+                                            extVars:
+                                              description: ExtVars is a list of Jsonnet External
+                                                Variables
+                                              items:
+                                                description: JsonnetVar represents a variable
+                                                  to be passed to jsonnet during manifest generation
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              description: Additional library search dirs
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              description: TLAS is a list of Jsonnet Top-level
+                                                Arguments
+                                              items:
+                                                description: JsonnetVar represents a variable
+                                                  to be passed to jsonnet during manifest generation
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          description: Recurse specifies whether to scan a directory
+                                            recursively for manifests
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      description: Helm holds helm specific options
+                                      properties:
+                                        apiVersions:
+                                          description: |-
+                                            APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                            Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                          items:
+                                            type: string
+                                          type: array
+                                        fileParameters:
+                                          description: FileParameters are file parameters to
+                                            the helm template
+                                          items:
+                                            description: HelmFileParameter is a file parameter
+                                              that's passed to helm template during manifest
+                                              generation
+                                            properties:
+                                              name:
+                                                description: Name is the name of the Helm parameter
+                                                type: string
+                                              path:
+                                                description: Path is the path to the file containing
+                                                  the values for the Helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        ignoreMissingValueFiles:
+                                          description: IgnoreMissingValueFiles prevents helm
+                                            template from failing when valueFiles do not exist
+                                            locally by not appending them to helm template --values
+                                          type: boolean
+                                        kubeVersion:
+                                          description: |-
+                                            KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                            uses the Kubernetes version of the target cluster.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is an optional namespace to
+                                            template with. If left empty, defaults to the app's
+                                            destination namespace.
+                                          type: string
+                                        parameters:
+                                          description: Parameters is a list of Helm parameters
+                                            which are passed to the helm template command upon
+                                            manifest generation
+                                          items:
+                                            description: HelmParameter is a parameter that's
+                                              passed to helm template during manifest generation
+                                            properties:
+                                              forceString:
+                                                description: ForceString determines whether
+                                                  to tell Helm to interpret booleans and numbers
+                                                  as strings
+                                                type: boolean
+                                              name:
+                                                description: Name is the name of the Helm parameter
+                                                type: string
+                                              value:
+                                                description: Value is the value for the Helm
+                                                  parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        passCredentials:
+                                          description: PassCredentials pass credentials to all
+                                            domains (Helm's --pass-credentials)
+                                          type: boolean
+                                        releaseName:
+                                          description: ReleaseName is the Helm release name
+                                            to use. If omitted it will use the application name
+                                          type: string
+                                        skipCrds:
+                                          description: SkipCrds skips custom resource definition
+                                            installation step (Helm's --skip-crds)
+                                          type: boolean
+                                        skipTests:
+                                          description: SkipTests skips test manifest installation
+                                            step (Helm's --skip-tests).
+                                          type: boolean
+                                        valueFiles:
+                                          description: ValuesFiles is a list of Helm value files
+                                            to use when generating a template
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          description: Values specifies Helm values to be passed
+                                            to helm template, typically defined as a block.
+                                            ValuesObject takes precedence over Values, so use
+                                            one or the other.
+                                          type: string
+                                        valuesObject:
+                                          description: ValuesObject specifies Helm values to
+                                            be passed to helm template, defined as a map. This
+                                            takes precedence over Values.
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        version:
+                                          description: Version is the Helm version to use for
+                                            templating ("3")
+                                          type: string
+                                      type: object
+                                    kustomize:
+                                      description: Kustomize holds kustomize specific options
+                                      properties:
+                                        apiVersions:
+                                          description: |-
+                                            APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                            Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                          items:
+                                            type: string
+                                          type: array
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonAnnotations is a list of additional
+                                            annotations to add to rendered manifests
+                                          type: object
+                                        commonAnnotationsEnvsubst:
+                                          description: CommonAnnotationsEnvsubst specifies whether
+                                            to apply env variables substitution for annotation
+                                            values
+                                          type: boolean
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels is a list of additional
+                                            labels to add to rendered manifests
+                                          type: object
+                                        components:
+                                          description: Components specifies a list of kustomize
+                                            components to add to the kustomization before building
+                                          items:
+                                            type: string
+                                          type: array
+                                        forceCommonAnnotations:
+                                          description: ForceCommonAnnotations specifies whether
+                                            to force applying common annotations to resources
+                                            for Kustomize apps
+                                          type: boolean
+                                        forceCommonLabels:
+                                          description: ForceCommonLabels specifies whether to
+                                            force applying common labels to resources for Kustomize
+                                            apps
+                                          type: boolean
+                                        images:
+                                          description: Images is a list of Kustomize image override
+                                            specifications
+                                          items:
+                                            description: KustomizeImage represents a Kustomize
+                                              image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                            type: string
+                                          type: array
+                                        kubeVersion:
+                                          description: |-
+                                            KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                            uses the Kubernetes version of the target cluster.
+                                          type: string
+                                        labelWithoutSelector:
+                                          description: LabelWithoutSelector specifies whether
+                                            to apply common labels to resource selectors or
+                                            not
+                                          type: boolean
+                                        namePrefix:
+                                          description: NamePrefix is a prefix appended to resources
+                                            for Kustomize apps
+                                          type: string
+                                        nameSuffix:
+                                          description: NameSuffix is a suffix appended to resources
+                                            for Kustomize apps
+                                          type: string
+                                        namespace:
+                                          description: Namespace sets the namespace that Kustomize
+                                            adds to all resources
+                                          type: string
+                                        patches:
+                                          description: Patches is a list of Kustomize patches
+                                          items:
+                                            properties:
+                                              options:
+                                                additionalProperties:
+                                                  type: boolean
+                                                type: object
+                                              patch:
+                                                type: string
+                                              path:
+                                                type: string
+                                              target:
+                                                properties:
+                                                  annotationSelector:
+                                                    type: string
+                                                  group:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  labelSelector:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  namespace:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          type: array
+                                        replicas:
+                                          description: Replicas is a list of Kustomize Replicas
+                                            override specifications
+                                          items:
+                                            properties:
+                                              count:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number of replicas
+                                                x-kubernetes-int-or-string: true
+                                              name:
+                                                description: Name of Deployment or StatefulSet
+                                                type: string
+                                            required:
+                                            - count
+                                            - name
+                                            type: object
+                                          type: array
+                                        version:
+                                          description: Version controls which version of Kustomize
+                                            to use for rendering manifests
+                                          type: string
+                                      type: object
+                                    path:
+                                      description: Path is a directory path within the Git repository,
+                                        and is only valid for applications sourced from Git.
+                                      type: string
+                                    plugin:
+                                      description: Plugin holds config management plugin specific
+                                        options
+                                      properties:
+                                        env:
+                                          description: Env is a list of environment variable
+                                            entries
+                                          items:
+                                            description: EnvEntry represents an entry in the
+                                              application's environment
+                                            properties:
+                                              name:
+                                                description: Name is the name of the variable,
+                                                  usually expressed in uppercase
+                                                type: string
+                                              value:
+                                                description: Value is the value of the variable
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        parameters:
+                                          items:
+                                            properties:
+                                              array:
+                                                description: Array is the value of an array
+                                                  type parameter.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              map:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Map is the value of a map type
+                                                  parameter.
+                                                type: object
+                                              name:
+                                                description: Name is the name identifying a
+                                                  parameter.
+                                                type: string
+                                              string:
+                                                description: String_ is the value of a string
+                                                  type parameter.
+                                                type: string
+                                            type: object
+                                          type: array
+                                      type: object
+                                    ref:
+                                      description: Ref is reference to another source within
+                                        sources field. This field will not be used if used with
+                                        a `source` tag.
+                                      type: string
+                                    repoURL:
+                                      description: RepoURL is the URL to the repository (Git
+                                        or Helm) that contains the application manifests
+                                      type: string
+                                    targetRevision:
+                                      description: |-
+                                        TargetRevision defines the revision of the source to sync the application to.
+                                        In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                        In case of Helm, this is a semver tag for the Chart's version.
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                type: array
+                            required:
+                            - deployedAt
+                            - id
+                            type: object
+                          type: array
+                        observedAt:
+                          description: |-
+                            ObservedAt indicates when the application state was updated without querying latest git state
+                            Deprecated: controller no longer updates ObservedAt field
+                          format: date-time
+                          type: string
+                        operationState:
+                          description: OperationState contains information about any ongoing
+                            operations, such as a sync
+                          properties:
+                            finishedAt:
+                              description: FinishedAt contains time of operation completion
+                              format: date-time
+                              type: string
+                            message:
+                              description: Message holds any pertinent messages when attempting
+                                to perform operation (typically errors).
+                              type: string
+                            operation:
+                              description: Operation is the original requested operation
+                              properties:
+                                info:
+                                  description: Info is a list of informational items for this
+                                    operation
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                initiatedBy:
+                                  description: InitiatedBy contains information about who initiated
+                                    the operations
+                                  properties:
+                                    automated:
+                                      description: Automated is set to true if operation was
+                                        initiated automatically by the application controller.
+                                      type: boolean
+                                    username:
+                                      description: Username contains the name of a user who
+                                        started operation
+                                      type: string
+                                  type: object
+                                retry:
+                                  description: Retry controls the strategy to apply if a sync
+                                    fails
+                                  properties:
+                                    backoff:
+                                      description: Backoff controls how to backoff on subsequent
+                                        retries of failed syncs
+                                      properties:
+                                        duration:
+                                          description: Duration is the amount to back off. Default
+                                            unit is seconds, but could also be a duration (e.g.
+                                            "2m", "1h")
+                                          type: string
+                                        factor:
+                                          description: Factor is a factor to multiply the base
+                                            duration after each failed retry
+                                          format: int64
+                                          type: integer
+                                        maxDuration:
+                                          description: MaxDuration is the maximum amount of
+                                            time allowed for the backoff strategy
+                                          type: string
+                                      type: object
+                                    limit:
+                                      description: Limit is the maximum number of attempts for
+                                        retrying a failed sync. If set to 0, no retries will
+                                        be performed.
+                                      format: int64
+                                      type: integer
+                                  type: object
+                                sync:
+                                  description: Sync contains parameters for the operation
+                                  properties:
+                                    autoHealAttemptsCount:
+                                      description: SelfHealAttemptsCount contains the number
+                                        of auto-heal attempts
+                                      format: int64
+                                      type: integer
+                                    dryRun:
+                                      description: DryRun specifies to perform a `kubectl apply
+                                        --dry-run` without actually performing the sync
+                                      type: boolean
+                                    manifests:
+                                      description: Manifests is an optional field that overrides
+                                        sync source with a local directory for development
+                                      items:
+                                        type: string
+                                      type: array
+                                    prune:
+                                      description: Prune specifies to delete resources from
+                                        the cluster that are no longer tracked in git
+                                      type: boolean
+                                    resources:
+                                      description: Resources describes which resources shall
+                                        be part of the sync
+                                      items:
+                                        description: SyncOperationResource contains resources
+                                          to sync.
+                                        properties:
+                                          group:
+                                            type: string
+                                          kind:
+                                            type: string
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      type: array
+                                    revision:
+                                      description: |-
+                                        Revision is the revision (Git) or chart version (Helm) which to sync the application to
+                                        If omitted, will use the revision specified in app spec.
+                                      type: string
+                                    revisions:
+                                      description: |-
+                                        Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+                                        If omitted, will use the revision specified in app spec.
+                                      items:
+                                        type: string
+                                      type: array
+                                    source:
+                                      description: |-
+                                        Source overrides the source definition set in the application.
+                                        This is typically set in a Rollback operation and is nil during a Sync operation
+                                      properties:
+                                        chart:
+                                          description: Chart is a Helm chart name, and must
+                                            be specified for applications sourced from a Helm
+                                            repo.
+                                          type: string
+                                        directory:
+                                          description: Directory holds path/directory specific
+                                            options
+                                          properties:
+                                            exclude:
+                                              description: Exclude contains a glob pattern to
+                                                match paths against that should be explicitly
+                                                excluded from being used during manifest generation
+                                              type: string
+                                            include:
+                                              description: Include contains a glob pattern to
+                                                match paths against that should be explicitly
+                                                included during manifest generation
+                                              type: string
+                                            jsonnet:
+                                              description: Jsonnet holds options specific to
+                                                Jsonnet
+                                              properties:
+                                                extVars:
+                                                  description: ExtVars is a list of Jsonnet
+                                                    External Variables
+                                                  items:
+                                                    description: JsonnetVar represents a variable
+                                                      to be passed to jsonnet during manifest
+                                                      generation
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  description: Additional library search dirs
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  description: TLAS is a list of Jsonnet Top-level
+                                                    Arguments
+                                                  items:
+                                                    description: JsonnetVar represents a variable
+                                                      to be passed to jsonnet during manifest
+                                                      generation
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              description: Recurse specifies whether to scan
+                                                a directory recursively for manifests
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          description: Helm holds helm specific options
+                                          properties:
+                                            apiVersions:
+                                              description: |-
+                                                APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                                Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              description: FileParameters are file parameters
+                                                to the helm template
+                                              items:
+                                                description: HelmFileParameter is a file parameter
+                                                  that's passed to helm template during manifest
+                                                  generation
+                                                properties:
+                                                  name:
+                                                    description: Name is the name of the Helm
+                                                      parameter
+                                                    type: string
+                                                  path:
+                                                    description: Path is the path to the file
+                                                      containing the values for the Helm parameter
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              description: IgnoreMissingValueFiles prevents
+                                                helm template from failing when valueFiles do
+                                                not exist locally by not appending them to helm
+                                                template --values
+                                              type: boolean
+                                            kubeVersion:
+                                              description: |-
+                                                KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                                uses the Kubernetes version of the target cluster.
+                                              type: string
+                                            namespace:
+                                              description: Namespace is an optional namespace
+                                                to template with. If left empty, defaults to
+                                                the app's destination namespace.
+                                              type: string
+                                            parameters:
+                                              description: Parameters is a list of Helm parameters
+                                                which are passed to the helm template command
+                                                upon manifest generation
+                                              items:
+                                                description: HelmParameter is a parameter that's
+                                                  passed to helm template during manifest generation
+                                                properties:
+                                                  forceString:
+                                                    description: ForceString determines whether
+                                                      to tell Helm to interpret booleans and
+                                                      numbers as strings
+                                                    type: boolean
+                                                  name:
+                                                    description: Name is the name of the Helm
+                                                      parameter
+                                                    type: string
+                                                  value:
+                                                    description: Value is the value for the
+                                                      Helm parameter
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              description: PassCredentials pass credentials
+                                                to all domains (Helm's --pass-credentials)
+                                              type: boolean
+                                            releaseName:
+                                              description: ReleaseName is the Helm release name
+                                                to use. If omitted it will use the application
+                                                name
+                                              type: string
+                                            skipCrds:
+                                              description: SkipCrds skips custom resource definition
+                                                installation step (Helm's --skip-crds)
+                                              type: boolean
+                                            skipTests:
+                                              description: SkipTests skips test manifest installation
+                                                step (Helm's --skip-tests).
+                                              type: boolean
+                                            valueFiles:
+                                              description: ValuesFiles is a list of Helm value
+                                                files to use when generating a template
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              description: Values specifies Helm values to be
+                                                passed to helm template, typically defined as
+                                                a block. ValuesObject takes precedence over
+                                                Values, so use one or the other.
+                                              type: string
+                                            valuesObject:
+                                              description: ValuesObject specifies Helm values
+                                                to be passed to helm template, defined as a
+                                                map. This takes precedence over Values.
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              description: Version is the Helm version to use
+                                                for templating ("3")
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          description: Kustomize holds kustomize specific options
+                                          properties:
+                                            apiVersions:
+                                              description: |-
+                                                APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                                Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              description: CommonAnnotations is a list of additional
+                                                annotations to add to rendered manifests
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              description: CommonAnnotationsEnvsubst specifies
+                                                whether to apply env variables substitution
+                                                for annotation values
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: CommonLabels is a list of additional
+                                                labels to add to rendered manifests
+                                              type: object
+                                            components:
+                                              description: Components specifies a list of kustomize
+                                                components to add to the kustomization before
+                                                building
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              description: ForceCommonAnnotations specifies
+                                                whether to force applying common annotations
+                                                to resources for Kustomize apps
+                                              type: boolean
+                                            forceCommonLabels:
+                                              description: ForceCommonLabels specifies whether
+                                                to force applying common labels to resources
+                                                for Kustomize apps
+                                              type: boolean
+                                            images:
+                                              description: Images is a list of Kustomize image
+                                                override specifications
+                                              items:
+                                                description: KustomizeImage represents a Kustomize
+                                                  image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              description: |-
+                                                KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                                uses the Kubernetes version of the target cluster.
+                                              type: string
+                                            labelWithoutSelector:
+                                              description: LabelWithoutSelector specifies whether
+                                                to apply common labels to resource selectors
+                                                or not
+                                              type: boolean
+                                            namePrefix:
+                                              description: NamePrefix is a prefix appended to
+                                                resources for Kustomize apps
+                                              type: string
+                                            nameSuffix:
+                                              description: NameSuffix is a suffix appended to
+                                                resources for Kustomize apps
+                                              type: string
+                                            namespace:
+                                              description: Namespace sets the namespace that
+                                                Kustomize adds to all resources
+                                              type: string
+                                            patches:
+                                              description: Patches is a list of Kustomize patches
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              description: Replicas is a list of Kustomize Replicas
+                                                override specifications
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Number of replicas
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    description: Name of Deployment or StatefulSet
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              description: Version controls which version of
+                                                Kustomize to use for rendering manifests
+                                              type: string
+                                          type: object
+                                        path:
+                                          description: Path is a directory path within the Git
+                                            repository, and is only valid for applications sourced
+                                            from Git.
+                                          type: string
+                                        plugin:
+                                          description: Plugin holds config management plugin
+                                            specific options
+                                          properties:
+                                            env:
+                                              description: Env is a list of environment variable
+                                                entries
+                                              items:
+                                                description: EnvEntry represents an entry in
+                                                  the application's environment
+                                                properties:
+                                                  name:
+                                                    description: Name is the name of the variable,
+                                                      usually expressed in uppercase
+                                                    type: string
+                                                  value:
+                                                    description: Value is the value of the variable
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    description: Array is the value of an array
+                                                      type parameter.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: Map is the value of a map type
+                                                      parameter.
+                                                    type: object
+                                                  name:
+                                                    description: Name is the name identifying
+                                                      a parameter.
+                                                    type: string
+                                                  string:
+                                                    description: String_ is the value of a string
+                                                      type parameter.
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
+                                        ref:
+                                          description: Ref is reference to another source within
+                                            sources field. This field will not be used if used
+                                            with a `source` tag.
+                                          type: string
+                                        repoURL:
+                                          description: RepoURL is the URL to the repository
+                                            (Git or Helm) that contains the application manifests
+                                          type: string
+                                        targetRevision:
+                                          description: |-
+                                            TargetRevision defines the revision of the source to sync the application to.
+                                            In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                            In case of Helm, this is a semver tag for the Chart's version.
+                                          type: string
+                                      required:
+                                      - repoURL
+                                      type: object
+                                    sources:
+                                      description: |-
+                                        Sources overrides the source definition set in the application.
+                                        This is typically set in a Rollback operation and is nil during a Sync operation
+                                      items:
+                                        description: ApplicationSource contains all required
+                                          information about the source of an application
+                                        properties:
+                                          chart:
+                                            description: Chart is a Helm chart name, and must
+                                              be specified for applications sourced from a Helm
+                                              repo.
+                                            type: string
+                                          directory:
+                                            description: Directory holds path/directory specific
+                                              options
+                                            properties:
+                                              exclude:
+                                                description: Exclude contains a glob pattern
+                                                  to match paths against that should be explicitly
+                                                  excluded from being used during manifest generation
+                                                type: string
+                                              include:
+                                                description: Include contains a glob pattern
+                                                  to match paths against that should be explicitly
+                                                  included during manifest generation
+                                                type: string
+                                              jsonnet:
+                                                description: Jsonnet holds options specific
+                                                  to Jsonnet
+                                                properties:
+                                                  extVars:
+                                                    description: ExtVars is a list of Jsonnet
+                                                      External Variables
+                                                    items:
+                                                      description: JsonnetVar represents a variable
+                                                        to be passed to jsonnet during manifest
+                                                        generation
+                                                      properties:
+                                                        code:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  libs:
+                                                    description: Additional library search dirs
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  tlas:
+                                                    description: TLAS is a list of Jsonnet Top-level
+                                                      Arguments
+                                                    items:
+                                                      description: JsonnetVar represents a variable
+                                                        to be passed to jsonnet during manifest
+                                                        generation
+                                                      properties:
+                                                        code:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              recurse:
+                                                description: Recurse specifies whether to scan
+                                                  a directory recursively for manifests
+                                                type: boolean
+                                            type: object
+                                          helm:
+                                            description: Helm holds helm specific options
+                                            properties:
+                                              apiVersions:
+                                                description: |-
+                                                  APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                                  Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              fileParameters:
+                                                description: FileParameters are file parameters
+                                                  to the helm template
+                                                items:
+                                                  description: HelmFileParameter is a file parameter
+                                                    that's passed to helm template during manifest
+                                                    generation
+                                                  properties:
+                                                    name:
+                                                      description: Name is the name of the Helm
+                                                        parameter
+                                                      type: string
+                                                    path:
+                                                      description: Path is the path to the file
+                                                        containing the values for the Helm parameter
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              ignoreMissingValueFiles:
+                                                description: IgnoreMissingValueFiles prevents
+                                                  helm template from failing when valueFiles
+                                                  do not exist locally by not appending them
+                                                  to helm template --values
+                                                type: boolean
+                                              kubeVersion:
+                                                description: |-
+                                                  KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                                  uses the Kubernetes version of the target cluster.
+                                                type: string
+                                              namespace:
+                                                description: Namespace is an optional namespace
+                                                  to template with. If left empty, defaults
+                                                  to the app's destination namespace.
+                                                type: string
+                                              parameters:
+                                                description: Parameters is a list of Helm parameters
+                                                  which are passed to the helm template command
+                                                  upon manifest generation
+                                                items:
+                                                  description: HelmParameter is a parameter
+                                                    that's passed to helm template during manifest
+                                                    generation
+                                                  properties:
+                                                    forceString:
+                                                      description: ForceString determines whether
+                                                        to tell Helm to interpret booleans and
+                                                        numbers as strings
+                                                      type: boolean
+                                                    name:
+                                                      description: Name is the name of the Helm
+                                                        parameter
+                                                      type: string
+                                                    value:
+                                                      description: Value is the value for the
+                                                        Helm parameter
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              passCredentials:
+                                                description: PassCredentials pass credentials
+                                                  to all domains (Helm's --pass-credentials)
+                                                type: boolean
+                                              releaseName:
+                                                description: ReleaseName is the Helm release
+                                                  name to use. If omitted it will use the application
+                                                  name
+                                                type: string
+                                              skipCrds:
+                                                description: SkipCrds skips custom resource
+                                                  definition installation step (Helm's --skip-crds)
+                                                type: boolean
+                                              skipTests:
+                                                description: SkipTests skips test manifest installation
+                                                  step (Helm's --skip-tests).
+                                                type: boolean
+                                              valueFiles:
+                                                description: ValuesFiles is a list of Helm value
+                                                  files to use when generating a template
+                                                items:
+                                                  type: string
+                                                type: array
+                                              values:
+                                                description: Values specifies Helm values to
+                                                  be passed to helm template, typically defined
+                                                  as a block. ValuesObject takes precedence
+                                                  over Values, so use one or the other.
+                                                type: string
+                                              valuesObject:
+                                                description: ValuesObject specifies Helm values
+                                                  to be passed to helm template, defined as
+                                                  a map. This takes precedence over Values.
+                                                type: object
+                                                x-kubernetes-preserve-unknown-fields: true
+                                              version:
+                                                description: Version is the Helm version to
+                                                  use for templating ("3")
+                                                type: string
+                                            type: object
+                                          kustomize:
+                                            description: Kustomize holds kustomize specific
+                                              options
+                                            properties:
+                                              apiVersions:
+                                                description: |-
+                                                  APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                                  Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              commonAnnotations:
+                                                additionalProperties:
+                                                  type: string
+                                                description: CommonAnnotations is a list of
+                                                  additional annotations to add to rendered
+                                                  manifests
+                                                type: object
+                                              commonAnnotationsEnvsubst:
+                                                description: CommonAnnotationsEnvsubst specifies
+                                                  whether to apply env variables substitution
+                                                  for annotation values
+                                                type: boolean
+                                              commonLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: CommonLabels is a list of additional
+                                                  labels to add to rendered manifests
+                                                type: object
+                                              components:
+                                                description: Components specifies a list of
+                                                  kustomize components to add to the kustomization
+                                                  before building
+                                                items:
+                                                  type: string
+                                                type: array
+                                              forceCommonAnnotations:
+                                                description: ForceCommonAnnotations specifies
+                                                  whether to force applying common annotations
+                                                  to resources for Kustomize apps
+                                                type: boolean
+                                              forceCommonLabels:
+                                                description: ForceCommonLabels specifies whether
+                                                  to force applying common labels to resources
+                                                  for Kustomize apps
+                                                type: boolean
+                                              images:
+                                                description: Images is a list of Kustomize image
+                                                  override specifications
+                                                items:
+                                                  description: KustomizeImage represents a Kustomize
+                                                    image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                                  type: string
+                                                type: array
+                                              kubeVersion:
+                                                description: |-
+                                                  KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                                  uses the Kubernetes version of the target cluster.
+                                                type: string
+                                              labelWithoutSelector:
+                                                description: LabelWithoutSelector specifies
+                                                  whether to apply common labels to resource
+                                                  selectors or not
+                                                type: boolean
+                                              namePrefix:
+                                                description: NamePrefix is a prefix appended
+                                                  to resources for Kustomize apps
+                                                type: string
+                                              nameSuffix:
+                                                description: NameSuffix is a suffix appended
+                                                  to resources for Kustomize apps
+                                                type: string
+                                              namespace:
+                                                description: Namespace sets the namespace that
+                                                  Kustomize adds to all resources
+                                                type: string
+                                              patches:
+                                                description: Patches is a list of Kustomize
+                                                  patches
+                                                items:
+                                                  properties:
+                                                    options:
+                                                      additionalProperties:
+                                                        type: boolean
+                                                      type: object
+                                                    patch:
+                                                      type: string
+                                                    path:
+                                                      type: string
+                                                    target:
+                                                      properties:
+                                                        annotationSelector:
+                                                          type: string
+                                                        group:
+                                                          type: string
+                                                        kind:
+                                                          type: string
+                                                        labelSelector:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        namespace:
+                                                          type: string
+                                                        version:
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              replicas:
+                                                description: Replicas is a list of Kustomize
+                                                  Replicas override specifications
+                                                items:
+                                                  properties:
+                                                    count:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Number of replicas
+                                                      x-kubernetes-int-or-string: true
+                                                    name:
+                                                      description: Name of Deployment or StatefulSet
+                                                      type: string
+                                                  required:
+                                                  - count
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              version:
+                                                description: Version controls which version
+                                                  of Kustomize to use for rendering manifests
+                                                type: string
+                                            type: object
+                                          path:
+                                            description: Path is a directory path within the
+                                              Git repository, and is only valid for applications
+                                              sourced from Git.
+                                            type: string
+                                          plugin:
+                                            description: Plugin holds config management plugin
+                                              specific options
+                                            properties:
+                                              env:
+                                                description: Env is a list of environment variable
+                                                  entries
+                                                items:
+                                                  description: EnvEntry represents an entry
+                                                    in the application's environment
+                                                  properties:
+                                                    name:
+                                                      description: Name is the name of the variable,
+                                                        usually expressed in uppercase
+                                                      type: string
+                                                    value:
+                                                      description: Value is the value of the
+                                                        variable
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              name:
+                                                type: string
+                                              parameters:
+                                                items:
+                                                  properties:
+                                                    array:
+                                                      description: Array is the value of an
+                                                        array type parameter.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    map:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: Map is the value of a map
+                                                        type parameter.
+                                                      type: object
+                                                    name:
+                                                      description: Name is the name identifying
+                                                        a parameter.
+                                                      type: string
+                                                    string:
+                                                      description: String_ is the value of a
+                                                        string type parameter.
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          ref:
+                                            description: Ref is reference to another source
+                                              within sources field. This field will not be used
+                                              if used with a `source` tag.
+                                            type: string
+                                          repoURL:
+                                            description: RepoURL is the URL to the repository
+                                              (Git or Helm) that contains the application manifests
+                                            type: string
+                                          targetRevision:
+                                            description: |-
+                                              TargetRevision defines the revision of the source to sync the application to.
+                                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                              In case of Helm, this is a semver tag for the Chart's version.
+                                            type: string
+                                        required:
+                                        - repoURL
+                                        type: object
+                                      type: array
+                                    syncOptions:
+                                      description: SyncOptions provide per-sync sync-options,
+                                        e.g. Validate=false
+                                      items:
+                                        type: string
+                                      type: array
+                                    syncStrategy:
+                                      description: SyncStrategy describes how to perform the
+                                        sync
+                                      properties:
+                                        apply:
+                                          description: Apply will perform a `kubectl apply`
+                                            to perform the sync.
+                                          properties:
+                                            force:
+                                              description: |-
+                                                Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                                The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                                retried for 5 times.
+                                              type: boolean
+                                          type: object
+                                        hook:
+                                          description: Hook will submit any referenced resources
+                                            to perform the sync. This is the default strategy
+                                          properties:
+                                            force:
+                                              description: |-
+                                                Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                                The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                                retried for 5 times.
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                            phase:
+                              description: Phase is the current phase of the operation
+                              type: string
+                            retryCount:
+                              description: RetryCount contains time of operation retries
+                              format: int64
+                              type: integer
+                            startedAt:
+                              description: StartedAt contains time of operation start
+                              format: date-time
+                              type: string
+                            syncResult:
+                              description: SyncResult is the result of a Sync operation
+                              properties:
+                                managedNamespaceMetadata:
+                                  description: ManagedNamespaceMetadata contains the current
+                                    sync state of managed namespace metadata
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                resources:
+                                  description: Resources contains a list of sync result items
+                                    for each individual resource in a sync operation
+                                  items:
+                                    description: ResourceResult holds the operation result details
+                                      of a specific resource
+                                    properties:
+                                      group:
+                                        description: Group specifies the API group of the resource
+                                        type: string
+                                      hookPhase:
+                                        description: |-
+                                          HookPhase contains the state of any operation associated with this resource OR hook
+                                          This can also contain values for non-hook resources.
+                                        type: string
+                                      hookType:
+                                        description: HookType specifies the type of the hook.
+                                          Empty for non-hook resources
+                                        type: string
+                                      kind:
+                                        description: Kind specifies the API kind of the resource
+                                        type: string
+                                      message:
+                                        description: Message contains an informational or error
+                                          message for the last sync OR operation
+                                        type: string
+                                      name:
+                                        description: Name specifies the name of the resource
+                                        type: string
+                                      namespace:
+                                        description: Namespace specifies the target namespace
+                                          of the resource
+                                        type: string
+                                      status:
+                                        description: Status holds the final result of the sync.
+                                          Will be empty if the resources is yet to be applied/pruned
+                                          and is always zero-value for hooks
+                                        type: string
+                                      syncPhase:
+                                        description: SyncPhase indicates the particular phase
+                                          of the sync that this result was acquired in
+                                        type: string
+                                      version:
+                                        description: Version specifies the API version of the
+                                          resource
+                                        type: string
+                                    required:
+                                    - group
+                                    - kind
+                                    - name
+                                    - namespace
+                                    - version
+                                    type: object
+                                  type: array
+                                revision:
+                                  description: Revision holds the revision this sync operation
+                                    was performed to
+                                  type: string
+                                revisions:
+                                  description: Revisions holds the revision this sync operation
+                                    was performed for respective indexed source in sources field
+                                  items:
+                                    type: string
+                                  type: array
+                                source:
+                                  description: Source records the application source information
+                                    of the sync, used for comparing auto-sync
+                                  properties:
+                                    chart:
+                                      description: Chart is a Helm chart name, and must be specified
+                                        for applications sourced from a Helm repo.
+                                      type: string
+                                    directory:
+                                      description: Directory holds path/directory specific options
+                                      properties:
+                                        exclude:
+                                          description: Exclude contains a glob pattern to match
+                                            paths against that should be explicitly excluded
+                                            from being used during manifest generation
+                                          type: string
+                                        include:
+                                          description: Include contains a glob pattern to match
+                                            paths against that should be explicitly included
+                                            during manifest generation
+                                          type: string
+                                        jsonnet:
+                                          description: Jsonnet holds options specific to Jsonnet
+                                          properties:
+                                            extVars:
+                                              description: ExtVars is a list of Jsonnet External
+                                                Variables
+                                              items:
+                                                description: JsonnetVar represents a variable
+                                                  to be passed to jsonnet during manifest generation
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              description: Additional library search dirs
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              description: TLAS is a list of Jsonnet Top-level
+                                                Arguments
+                                              items:
+                                                description: JsonnetVar represents a variable
+                                                  to be passed to jsonnet during manifest generation
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          description: Recurse specifies whether to scan a directory
+                                            recursively for manifests
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      description: Helm holds helm specific options
+                                      properties:
+                                        apiVersions:
+                                          description: |-
+                                            APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                            Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                          items:
+                                            type: string
+                                          type: array
+                                        fileParameters:
+                                          description: FileParameters are file parameters to
+                                            the helm template
+                                          items:
+                                            description: HelmFileParameter is a file parameter
+                                              that's passed to helm template during manifest
+                                              generation
+                                            properties:
+                                              name:
+                                                description: Name is the name of the Helm parameter
+                                                type: string
+                                              path:
+                                                description: Path is the path to the file containing
+                                                  the values for the Helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        ignoreMissingValueFiles:
+                                          description: IgnoreMissingValueFiles prevents helm
+                                            template from failing when valueFiles do not exist
+                                            locally by not appending them to helm template --values
+                                          type: boolean
+                                        kubeVersion:
+                                          description: |-
+                                            KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                            uses the Kubernetes version of the target cluster.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is an optional namespace to
+                                            template with. If left empty, defaults to the app's
+                                            destination namespace.
+                                          type: string
+                                        parameters:
+                                          description: Parameters is a list of Helm parameters
+                                            which are passed to the helm template command upon
+                                            manifest generation
+                                          items:
+                                            description: HelmParameter is a parameter that's
+                                              passed to helm template during manifest generation
+                                            properties:
+                                              forceString:
+                                                description: ForceString determines whether
+                                                  to tell Helm to interpret booleans and numbers
+                                                  as strings
+                                                type: boolean
+                                              name:
+                                                description: Name is the name of the Helm parameter
+                                                type: string
+                                              value:
+                                                description: Value is the value for the Helm
+                                                  parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        passCredentials:
+                                          description: PassCredentials pass credentials to all
+                                            domains (Helm's --pass-credentials)
+                                          type: boolean
+                                        releaseName:
+                                          description: ReleaseName is the Helm release name
+                                            to use. If omitted it will use the application name
+                                          type: string
+                                        skipCrds:
+                                          description: SkipCrds skips custom resource definition
+                                            installation step (Helm's --skip-crds)
+                                          type: boolean
+                                        skipTests:
+                                          description: SkipTests skips test manifest installation
+                                            step (Helm's --skip-tests).
+                                          type: boolean
+                                        valueFiles:
+                                          description: ValuesFiles is a list of Helm value files
+                                            to use when generating a template
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          description: Values specifies Helm values to be passed
+                                            to helm template, typically defined as a block.
+                                            ValuesObject takes precedence over Values, so use
+                                            one or the other.
+                                          type: string
+                                        valuesObject:
+                                          description: ValuesObject specifies Helm values to
+                                            be passed to helm template, defined as a map. This
+                                            takes precedence over Values.
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        version:
+                                          description: Version is the Helm version to use for
+                                            templating ("3")
+                                          type: string
+                                      type: object
+                                    kustomize:
+                                      description: Kustomize holds kustomize specific options
+                                      properties:
+                                        apiVersions:
+                                          description: |-
+                                            APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                            Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                          items:
+                                            type: string
+                                          type: array
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonAnnotations is a list of additional
+                                            annotations to add to rendered manifests
+                                          type: object
+                                        commonAnnotationsEnvsubst:
+                                          description: CommonAnnotationsEnvsubst specifies whether
+                                            to apply env variables substitution for annotation
+                                            values
+                                          type: boolean
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels is a list of additional
+                                            labels to add to rendered manifests
+                                          type: object
+                                        components:
+                                          description: Components specifies a list of kustomize
+                                            components to add to the kustomization before building
+                                          items:
+                                            type: string
+                                          type: array
+                                        forceCommonAnnotations:
+                                          description: ForceCommonAnnotations specifies whether
+                                            to force applying common annotations to resources
+                                            for Kustomize apps
+                                          type: boolean
+                                        forceCommonLabels:
+                                          description: ForceCommonLabels specifies whether to
+                                            force applying common labels to resources for Kustomize
+                                            apps
+                                          type: boolean
+                                        images:
+                                          description: Images is a list of Kustomize image override
+                                            specifications
+                                          items:
+                                            description: KustomizeImage represents a Kustomize
+                                              image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                            type: string
+                                          type: array
+                                        kubeVersion:
+                                          description: |-
+                                            KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                            uses the Kubernetes version of the target cluster.
+                                          type: string
+                                        labelWithoutSelector:
+                                          description: LabelWithoutSelector specifies whether
+                                            to apply common labels to resource selectors or
+                                            not
+                                          type: boolean
+                                        namePrefix:
+                                          description: NamePrefix is a prefix appended to resources
+                                            for Kustomize apps
+                                          type: string
+                                        nameSuffix:
+                                          description: NameSuffix is a suffix appended to resources
+                                            for Kustomize apps
+                                          type: string
+                                        namespace:
+                                          description: Namespace sets the namespace that Kustomize
+                                            adds to all resources
+                                          type: string
+                                        patches:
+                                          description: Patches is a list of Kustomize patches
+                                          items:
+                                            properties:
+                                              options:
+                                                additionalProperties:
+                                                  type: boolean
+                                                type: object
+                                              patch:
+                                                type: string
+                                              path:
+                                                type: string
+                                              target:
+                                                properties:
+                                                  annotationSelector:
+                                                    type: string
+                                                  group:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  labelSelector:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  namespace:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          type: array
+                                        replicas:
+                                          description: Replicas is a list of Kustomize Replicas
+                                            override specifications
+                                          items:
+                                            properties:
+                                              count:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number of replicas
+                                                x-kubernetes-int-or-string: true
+                                              name:
+                                                description: Name of Deployment or StatefulSet
+                                                type: string
+                                            required:
+                                            - count
+                                            - name
+                                            type: object
+                                          type: array
+                                        version:
+                                          description: Version controls which version of Kustomize
+                                            to use for rendering manifests
+                                          type: string
+                                      type: object
+                                    path:
+                                      description: Path is a directory path within the Git repository,
+                                        and is only valid for applications sourced from Git.
+                                      type: string
+                                    plugin:
+                                      description: Plugin holds config management plugin specific
+                                        options
+                                      properties:
+                                        env:
+                                          description: Env is a list of environment variable
+                                            entries
+                                          items:
+                                            description: EnvEntry represents an entry in the
+                                              application's environment
+                                            properties:
+                                              name:
+                                                description: Name is the name of the variable,
+                                                  usually expressed in uppercase
+                                                type: string
+                                              value:
+                                                description: Value is the value of the variable
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        parameters:
+                                          items:
+                                            properties:
+                                              array:
+                                                description: Array is the value of an array
+                                                  type parameter.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              map:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Map is the value of a map type
+                                                  parameter.
+                                                type: object
+                                              name:
+                                                description: Name is the name identifying a
+                                                  parameter.
+                                                type: string
+                                              string:
+                                                description: String_ is the value of a string
+                                                  type parameter.
+                                                type: string
+                                            type: object
+                                          type: array
+                                      type: object
+                                    ref:
+                                      description: Ref is reference to another source within
+                                        sources field. This field will not be used if used with
+                                        a `source` tag.
+                                      type: string
+                                    repoURL:
+                                      description: RepoURL is the URL to the repository (Git
+                                        or Helm) that contains the application manifests
+                                      type: string
+                                    targetRevision:
+                                      description: |-
+                                        TargetRevision defines the revision of the source to sync the application to.
+                                        In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                        In case of Helm, this is a semver tag for the Chart's version.
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                sources:
+                                  description: Source records the application source information
+                                    of the sync, used for comparing auto-sync
+                                  items:
+                                    description: ApplicationSource contains all required information
+                                      about the source of an application
+                                    properties:
+                                      chart:
+                                        description: Chart is a Helm chart name, and must be
+                                          specified for applications sourced from a Helm repo.
+                                        type: string
+                                      directory:
+                                        description: Directory holds path/directory specific
+                                          options
+                                        properties:
+                                          exclude:
+                                            description: Exclude contains a glob pattern to
+                                              match paths against that should be explicitly
+                                              excluded from being used during manifest generation
+                                            type: string
+                                          include:
+                                            description: Include contains a glob pattern to
+                                              match paths against that should be explicitly
+                                              included during manifest generation
+                                            type: string
+                                          jsonnet:
+                                            description: Jsonnet holds options specific to Jsonnet
+                                            properties:
+                                              extVars:
+                                                description: ExtVars is a list of Jsonnet External
+                                                  Variables
+                                                items:
+                                                  description: JsonnetVar represents a variable
+                                                    to be passed to jsonnet during manifest
+                                                    generation
+                                                  properties:
+                                                    code:
+                                                      type: boolean
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              libs:
+                                                description: Additional library search dirs
+                                                items:
+                                                  type: string
+                                                type: array
+                                              tlas:
+                                                description: TLAS is a list of Jsonnet Top-level
+                                                  Arguments
+                                                items:
+                                                  description: JsonnetVar represents a variable
+                                                    to be passed to jsonnet during manifest
+                                                    generation
+                                                  properties:
+                                                    code:
+                                                      type: boolean
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          recurse:
+                                            description: Recurse specifies whether to scan a
+                                              directory recursively for manifests
+                                            type: boolean
+                                        type: object
+                                      helm:
+                                        description: Helm holds helm specific options
+                                        properties:
+                                          apiVersions:
+                                            description: |-
+                                              APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                              Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                            items:
+                                              type: string
+                                            type: array
+                                          fileParameters:
+                                            description: FileParameters are file parameters
+                                              to the helm template
+                                            items:
+                                              description: HelmFileParameter is a file parameter
+                                                that's passed to helm template during manifest
+                                                generation
+                                              properties:
+                                                name:
+                                                  description: Name is the name of the Helm
+                                                    parameter
+                                                  type: string
+                                                path:
+                                                  description: Path is the path to the file
+                                                    containing the values for the Helm parameter
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          ignoreMissingValueFiles:
+                                            description: IgnoreMissingValueFiles prevents helm
+                                              template from failing when valueFiles do not exist
+                                              locally by not appending them to helm template
+                                              --values
+                                            type: boolean
+                                          kubeVersion:
+                                            description: |-
+                                              KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                              uses the Kubernetes version of the target cluster.
+                                            type: string
+                                          namespace:
+                                            description: Namespace is an optional namespace
+                                              to template with. If left empty, defaults to the
+                                              app's destination namespace.
+                                            type: string
+                                          parameters:
+                                            description: Parameters is a list of Helm parameters
+                                              which are passed to the helm template command
+                                              upon manifest generation
+                                            items:
+                                              description: HelmParameter is a parameter that's
+                                                passed to helm template during manifest generation
+                                              properties:
+                                                forceString:
+                                                  description: ForceString determines whether
+                                                    to tell Helm to interpret booleans and numbers
+                                                    as strings
+                                                  type: boolean
+                                                name:
+                                                  description: Name is the name of the Helm
+                                                    parameter
+                                                  type: string
+                                                value:
+                                                  description: Value is the value for the Helm
+                                                    parameter
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          passCredentials:
+                                            description: PassCredentials pass credentials to
+                                              all domains (Helm's --pass-credentials)
+                                            type: boolean
+                                          releaseName:
+                                            description: ReleaseName is the Helm release name
+                                              to use. If omitted it will use the application
+                                              name
+                                            type: string
+                                          skipCrds:
+                                            description: SkipCrds skips custom resource definition
+                                              installation step (Helm's --skip-crds)
+                                            type: boolean
+                                          skipTests:
+                                            description: SkipTests skips test manifest installation
+                                              step (Helm's --skip-tests).
+                                            type: boolean
+                                          valueFiles:
+                                            description: ValuesFiles is a list of Helm value
+                                              files to use when generating a template
+                                            items:
+                                              type: string
+                                            type: array
+                                          values:
+                                            description: Values specifies Helm values to be
+                                              passed to helm template, typically defined as
+                                              a block. ValuesObject takes precedence over Values,
+                                              so use one or the other.
+                                            type: string
+                                          valuesObject:
+                                            description: ValuesObject specifies Helm values
+                                              to be passed to helm template, defined as a map.
+                                              This takes precedence over Values.
+                                            type: object
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          version:
+                                            description: Version is the Helm version to use
+                                              for templating ("3")
+                                            type: string
+                                        type: object
+                                      kustomize:
+                                        description: Kustomize holds kustomize specific options
+                                        properties:
+                                          apiVersions:
+                                            description: |-
+                                              APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                              Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                            items:
+                                              type: string
+                                            type: array
+                                          commonAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: CommonAnnotations is a list of additional
+                                              annotations to add to rendered manifests
+                                            type: object
+                                          commonAnnotationsEnvsubst:
+                                            description: CommonAnnotationsEnvsubst specifies
+                                              whether to apply env variables substitution for
+                                              annotation values
+                                            type: boolean
+                                          commonLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: CommonLabels is a list of additional
+                                              labels to add to rendered manifests
+                                            type: object
+                                          components:
+                                            description: Components specifies a list of kustomize
+                                              components to add to the kustomization before
+                                              building
+                                            items:
+                                              type: string
+                                            type: array
+                                          forceCommonAnnotations:
+                                            description: ForceCommonAnnotations specifies whether
+                                              to force applying common annotations to resources
+                                              for Kustomize apps
+                                            type: boolean
+                                          forceCommonLabels:
+                                            description: ForceCommonLabels specifies whether
+                                              to force applying common labels to resources for
+                                              Kustomize apps
+                                            type: boolean
+                                          images:
+                                            description: Images is a list of Kustomize image
+                                              override specifications
+                                            items:
+                                              description: KustomizeImage represents a Kustomize
+                                                image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                              type: string
+                                            type: array
+                                          kubeVersion:
+                                            description: |-
+                                              KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                              uses the Kubernetes version of the target cluster.
+                                            type: string
+                                          labelWithoutSelector:
+                                            description: LabelWithoutSelector specifies whether
+                                              to apply common labels to resource selectors or
+                                              not
+                                            type: boolean
+                                          namePrefix:
+                                            description: NamePrefix is a prefix appended to
+                                              resources for Kustomize apps
+                                            type: string
+                                          nameSuffix:
+                                            description: NameSuffix is a suffix appended to
+                                              resources for Kustomize apps
+                                            type: string
+                                          namespace:
+                                            description: Namespace sets the namespace that Kustomize
+                                              adds to all resources
+                                            type: string
+                                          patches:
+                                            description: Patches is a list of Kustomize patches
+                                            items:
+                                              properties:
+                                                options:
+                                                  additionalProperties:
+                                                    type: boolean
+                                                  type: object
+                                                patch:
+                                                  type: string
+                                                path:
+                                                  type: string
+                                                target:
+                                                  properties:
+                                                    annotationSelector:
+                                                      type: string
+                                                    group:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    labelSelector:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    namespace:
+                                                      type: string
+                                                    version:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            type: array
+                                          replicas:
+                                            description: Replicas is a list of Kustomize Replicas
+                                              override specifications
+                                            items:
+                                              properties:
+                                                count:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number of replicas
+                                                  x-kubernetes-int-or-string: true
+                                                name:
+                                                  description: Name of Deployment or StatefulSet
+                                                  type: string
+                                              required:
+                                              - count
+                                              - name
+                                              type: object
+                                            type: array
+                                          version:
+                                            description: Version controls which version of Kustomize
+                                              to use for rendering manifests
+                                            type: string
+                                        type: object
+                                      path:
+                                        description: Path is a directory path within the Git
+                                          repository, and is only valid for applications sourced
+                                          from Git.
+                                        type: string
+                                      plugin:
+                                        description: Plugin holds config management plugin specific
+                                          options
+                                        properties:
+                                          env:
+                                            description: Env is a list of environment variable
+                                              entries
+                                            items:
+                                              description: EnvEntry represents an entry in the
+                                                application's environment
+                                              properties:
+                                                name:
+                                                  description: Name is the name of the variable,
+                                                    usually expressed in uppercase
+                                                  type: string
+                                                value:
+                                                  description: Value is the value of the variable
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          parameters:
+                                            items:
+                                              properties:
+                                                array:
+                                                  description: Array is the value of an array
+                                                    type parameter.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                map:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Map is the value of a map type
+                                                    parameter.
+                                                  type: object
+                                                name:
+                                                  description: Name is the name identifying
+                                                    a parameter.
+                                                  type: string
+                                                string:
+                                                  description: String_ is the value of a string
+                                                    type parameter.
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                      ref:
+                                        description: Ref is reference to another source within
+                                          sources field. This field will not be used if used
+                                          with a `source` tag.
+                                        type: string
+                                      repoURL:
+                                        description: RepoURL is the URL to the repository (Git
+                                          or Helm) that contains the application manifests
+                                        type: string
+                                      targetRevision:
+                                        description: |-
+                                          TargetRevision defines the revision of the source to sync the application to.
+                                          In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                          In case of Helm, this is a semver tag for the Chart's version.
+                                        type: string
+                                    required:
+                                    - repoURL
+                                    type: object
+                                  type: array
+                              required:
+                              - revision
+                              type: object
+                          required:
+                          - operation
+                          - phase
+                          - startedAt
+                          type: object
+                        reconciledAt:
+                          description: ReconciledAt indicates when the application state was
+                            reconciled using the latest git version
+                          format: date-time
+                          type: string
+                        resourceHealthSource:
+                          description: 'ResourceHealthSource indicates where the resource health
+                            status is stored: inline if not set or appTree'
+                          type: string
+                        resources:
+                          description: Resources is a list of Kubernetes resources managed by
+                            this application
+                          items:
+                            description: |-
+                              ResourceStatus holds the current sync and health status of a resource
+                              TODO: describe members of this type
+                            properties:
+                              group:
+                                type: string
+                              health:
+                                description: HealthStatus contains information about the currently
+                                  observed health state of an application or resource
+                                properties:
+                                  message:
+                                    description: Message is a human-readable informational message
+                                      describing the health status
+                                    type: string
+                                  status:
+                                    description: Status holds the status code of the application
+                                      or resource
+                                    type: string
+                                type: object
+                              hook:
+                                type: boolean
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              requiresDeletionConfirmation:
+                                type: boolean
+                              requiresPruning:
+                                type: boolean
+                              status:
+                                description: SyncStatusCode is a type which represents possible
+                                  comparison results
+                                type: string
+                              syncWave:
+                                format: int64
+                                type: integer
+                              version:
+                                type: string
+                            type: object
+                          type: array
+                        sourceType:
+                          description: SourceType specifies the type of this application
+                          type: string
+                        sourceTypes:
+                          description: SourceTypes specifies the type of the sources included
+                            in the application
+                          items:
+                            description: ApplicationSourceType specifies the type of the application's
+                              source
+                            type: string
+                          type: array
+                        summary:
+                          description: Summary contains a list of URLs and container images
+                            used by this application
+                          properties:
+                            externalURLs:
+                              description: ExternalURLs holds all external URLs of application
+                                child resources.
+                              items:
+                                type: string
+                              type: array
+                            images:
+                              description: Images holds all images of application child resources.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        sync:
+                          description: Sync contains information about the application's current
+                            sync status
+                          properties:
+                            comparedTo:
+                              description: ComparedTo contains information about what has been
+                                compared
+                              properties:
+                                destination:
+                                  description: Destination is a reference to the application's
+                                    destination used for comparison
+                                  properties:
+                                    name:
+                                      description: Name is an alternate way of specifying the
+                                        target cluster by its symbolic name. This must be set
+                                        if Server is not set.
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace specifies the target namespace for the application's resources.
+                                        The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
+                                      type: string
+                                    server:
+                                      description: Server specifies the URL of the target cluster's
+                                        Kubernetes control plane API. This must be set if Name
+                                        is not set.
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  description: IgnoreDifferences is a reference to the application's
+                                    ignored differences used for comparison
+                                  items:
+                                    description: ResourceIgnoreDifferences contains resource
+                                      filter and list of json paths which should be ignored
+                                      during comparison with live state.
+                                    properties:
+                                      group:
+                                        type: string
+                                      jqPathExpressions:
+                                        items:
+                                          type: string
+                                        type: array
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      managedFieldsManagers:
+                                        description: |-
+                                          ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+                                          desired state defined in the SCM and won't be displayed in diffs
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - kind
+                                    type: object
+                                  type: array
+                                source:
+                                  description: Source is a reference to the application's source
+                                    used for comparison
+                                  properties:
+                                    chart:
+                                      description: Chart is a Helm chart name, and must be specified
+                                        for applications sourced from a Helm repo.
+                                      type: string
+                                    directory:
+                                      description: Directory holds path/directory specific options
+                                      properties:
+                                        exclude:
+                                          description: Exclude contains a glob pattern to match
+                                            paths against that should be explicitly excluded
+                                            from being used during manifest generation
+                                          type: string
+                                        include:
+                                          description: Include contains a glob pattern to match
+                                            paths against that should be explicitly included
+                                            during manifest generation
+                                          type: string
+                                        jsonnet:
+                                          description: Jsonnet holds options specific to Jsonnet
+                                          properties:
+                                            extVars:
+                                              description: ExtVars is a list of Jsonnet External
+                                                Variables
+                                              items:
+                                                description: JsonnetVar represents a variable
+                                                  to be passed to jsonnet during manifest generation
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              description: Additional library search dirs
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              description: TLAS is a list of Jsonnet Top-level
+                                                Arguments
+                                              items:
+                                                description: JsonnetVar represents a variable
+                                                  to be passed to jsonnet during manifest generation
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          description: Recurse specifies whether to scan a directory
+                                            recursively for manifests
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      description: Helm holds helm specific options
+                                      properties:
+                                        apiVersions:
+                                          description: |-
+                                            APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                            Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                          items:
+                                            type: string
+                                          type: array
+                                        fileParameters:
+                                          description: FileParameters are file parameters to
+                                            the helm template
+                                          items:
+                                            description: HelmFileParameter is a file parameter
+                                              that's passed to helm template during manifest
+                                              generation
+                                            properties:
+                                              name:
+                                                description: Name is the name of the Helm parameter
+                                                type: string
+                                              path:
+                                                description: Path is the path to the file containing
+                                                  the values for the Helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        ignoreMissingValueFiles:
+                                          description: IgnoreMissingValueFiles prevents helm
+                                            template from failing when valueFiles do not exist
+                                            locally by not appending them to helm template --values
+                                          type: boolean
+                                        kubeVersion:
+                                          description: |-
+                                            KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                            uses the Kubernetes version of the target cluster.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is an optional namespace to
+                                            template with. If left empty, defaults to the app's
+                                            destination namespace.
+                                          type: string
+                                        parameters:
+                                          description: Parameters is a list of Helm parameters
+                                            which are passed to the helm template command upon
+                                            manifest generation
+                                          items:
+                                            description: HelmParameter is a parameter that's
+                                              passed to helm template during manifest generation
+                                            properties:
+                                              forceString:
+                                                description: ForceString determines whether
+                                                  to tell Helm to interpret booleans and numbers
+                                                  as strings
+                                                type: boolean
+                                              name:
+                                                description: Name is the name of the Helm parameter
+                                                type: string
+                                              value:
+                                                description: Value is the value for the Helm
+                                                  parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        passCredentials:
+                                          description: PassCredentials pass credentials to all
+                                            domains (Helm's --pass-credentials)
+                                          type: boolean
+                                        releaseName:
+                                          description: ReleaseName is the Helm release name
+                                            to use. If omitted it will use the application name
+                                          type: string
+                                        skipCrds:
+                                          description: SkipCrds skips custom resource definition
+                                            installation step (Helm's --skip-crds)
+                                          type: boolean
+                                        skipTests:
+                                          description: SkipTests skips test manifest installation
+                                            step (Helm's --skip-tests).
+                                          type: boolean
+                                        valueFiles:
+                                          description: ValuesFiles is a list of Helm value files
+                                            to use when generating a template
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          description: Values specifies Helm values to be passed
+                                            to helm template, typically defined as a block.
+                                            ValuesObject takes precedence over Values, so use
+                                            one or the other.
+                                          type: string
+                                        valuesObject:
+                                          description: ValuesObject specifies Helm values to
+                                            be passed to helm template, defined as a map. This
+                                            takes precedence over Values.
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        version:
+                                          description: Version is the Helm version to use for
+                                            templating ("3")
+                                          type: string
+                                      type: object
+                                    kustomize:
+                                      description: Kustomize holds kustomize specific options
+                                      properties:
+                                        apiVersions:
+                                          description: |-
+                                            APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                            Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                          items:
+                                            type: string
+                                          type: array
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonAnnotations is a list of additional
+                                            annotations to add to rendered manifests
+                                          type: object
+                                        commonAnnotationsEnvsubst:
+                                          description: CommonAnnotationsEnvsubst specifies whether
+                                            to apply env variables substitution for annotation
+                                            values
+                                          type: boolean
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels is a list of additional
+                                            labels to add to rendered manifests
+                                          type: object
+                                        components:
+                                          description: Components specifies a list of kustomize
+                                            components to add to the kustomization before building
+                                          items:
+                                            type: string
+                                          type: array
+                                        forceCommonAnnotations:
+                                          description: ForceCommonAnnotations specifies whether
+                                            to force applying common annotations to resources
+                                            for Kustomize apps
+                                          type: boolean
+                                        forceCommonLabels:
+                                          description: ForceCommonLabels specifies whether to
+                                            force applying common labels to resources for Kustomize
+                                            apps
+                                          type: boolean
+                                        images:
+                                          description: Images is a list of Kustomize image override
+                                            specifications
+                                          items:
+                                            description: KustomizeImage represents a Kustomize
+                                              image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                            type: string
+                                          type: array
+                                        kubeVersion:
+                                          description: |-
+                                            KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                            uses the Kubernetes version of the target cluster.
+                                          type: string
+                                        labelWithoutSelector:
+                                          description: LabelWithoutSelector specifies whether
+                                            to apply common labels to resource selectors or
+                                            not
+                                          type: boolean
+                                        namePrefix:
+                                          description: NamePrefix is a prefix appended to resources
+                                            for Kustomize apps
+                                          type: string
+                                        nameSuffix:
+                                          description: NameSuffix is a suffix appended to resources
+                                            for Kustomize apps
+                                          type: string
+                                        namespace:
+                                          description: Namespace sets the namespace that Kustomize
+                                            adds to all resources
+                                          type: string
+                                        patches:
+                                          description: Patches is a list of Kustomize patches
+                                          items:
+                                            properties:
+                                              options:
+                                                additionalProperties:
+                                                  type: boolean
+                                                type: object
+                                              patch:
+                                                type: string
+                                              path:
+                                                type: string
+                                              target:
+                                                properties:
+                                                  annotationSelector:
+                                                    type: string
+                                                  group:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  labelSelector:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  namespace:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          type: array
+                                        replicas:
+                                          description: Replicas is a list of Kustomize Replicas
+                                            override specifications
+                                          items:
+                                            properties:
+                                              count:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number of replicas
+                                                x-kubernetes-int-or-string: true
+                                              name:
+                                                description: Name of Deployment or StatefulSet
+                                                type: string
+                                            required:
+                                            - count
+                                            - name
+                                            type: object
+                                          type: array
+                                        version:
+                                          description: Version controls which version of Kustomize
+                                            to use for rendering manifests
+                                          type: string
+                                      type: object
+                                    path:
+                                      description: Path is a directory path within the Git repository,
+                                        and is only valid for applications sourced from Git.
+                                      type: string
+                                    plugin:
+                                      description: Plugin holds config management plugin specific
+                                        options
+                                      properties:
+                                        env:
+                                          description: Env is a list of environment variable
+                                            entries
+                                          items:
+                                            description: EnvEntry represents an entry in the
+                                              application's environment
+                                            properties:
+                                              name:
+                                                description: Name is the name of the variable,
+                                                  usually expressed in uppercase
+                                                type: string
+                                              value:
+                                                description: Value is the value of the variable
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        parameters:
+                                          items:
+                                            properties:
+                                              array:
+                                                description: Array is the value of an array
+                                                  type parameter.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              map:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Map is the value of a map type
+                                                  parameter.
+                                                type: object
+                                              name:
+                                                description: Name is the name identifying a
+                                                  parameter.
+                                                type: string
+                                              string:
+                                                description: String_ is the value of a string
+                                                  type parameter.
+                                                type: string
+                                            type: object
+                                          type: array
+                                      type: object
+                                    ref:
+                                      description: Ref is reference to another source within
+                                        sources field. This field will not be used if used with
+                                        a `source` tag.
+                                      type: string
+                                    repoURL:
+                                      description: RepoURL is the URL to the repository (Git
+                                        or Helm) that contains the application manifests
+                                      type: string
+                                    targetRevision:
+                                      description: |-
+                                        TargetRevision defines the revision of the source to sync the application to.
+                                        In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                        In case of Helm, this is a semver tag for the Chart's version.
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                sources:
+                                  description: Sources is a reference to the application's multiple
+                                    sources used for comparison
+                                  items:
+                                    description: ApplicationSource contains all required information
+                                      about the source of an application
+                                    properties:
+                                      chart:
+                                        description: Chart is a Helm chart name, and must be
+                                          specified for applications sourced from a Helm repo.
+                                        type: string
+                                      directory:
+                                        description: Directory holds path/directory specific
+                                          options
+                                        properties:
+                                          exclude:
+                                            description: Exclude contains a glob pattern to
+                                              match paths against that should be explicitly
+                                              excluded from being used during manifest generation
+                                            type: string
+                                          include:
+                                            description: Include contains a glob pattern to
+                                              match paths against that should be explicitly
+                                              included during manifest generation
+                                            type: string
+                                          jsonnet:
+                                            description: Jsonnet holds options specific to Jsonnet
+                                            properties:
+                                              extVars:
+                                                description: ExtVars is a list of Jsonnet External
+                                                  Variables
+                                                items:
+                                                  description: JsonnetVar represents a variable
+                                                    to be passed to jsonnet during manifest
+                                                    generation
+                                                  properties:
+                                                    code:
+                                                      type: boolean
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              libs:
+                                                description: Additional library search dirs
+                                                items:
+                                                  type: string
+                                                type: array
+                                              tlas:
+                                                description: TLAS is a list of Jsonnet Top-level
+                                                  Arguments
+                                                items:
+                                                  description: JsonnetVar represents a variable
+                                                    to be passed to jsonnet during manifest
+                                                    generation
+                                                  properties:
+                                                    code:
+                                                      type: boolean
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          recurse:
+                                            description: Recurse specifies whether to scan a
+                                              directory recursively for manifests
+                                            type: boolean
+                                        type: object
+                                      helm:
+                                        description: Helm holds helm specific options
+                                        properties:
+                                          apiVersions:
+                                            description: |-
+                                              APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                              Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                            items:
+                                              type: string
+                                            type: array
+                                          fileParameters:
+                                            description: FileParameters are file parameters
+                                              to the helm template
+                                            items:
+                                              description: HelmFileParameter is a file parameter
+                                                that's passed to helm template during manifest
+                                                generation
+                                              properties:
+                                                name:
+                                                  description: Name is the name of the Helm
+                                                    parameter
+                                                  type: string
+                                                path:
+                                                  description: Path is the path to the file
+                                                    containing the values for the Helm parameter
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          ignoreMissingValueFiles:
+                                            description: IgnoreMissingValueFiles prevents helm
+                                              template from failing when valueFiles do not exist
+                                              locally by not appending them to helm template
+                                              --values
+                                            type: boolean
+                                          kubeVersion:
+                                            description: |-
+                                              KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                              uses the Kubernetes version of the target cluster.
+                                            type: string
+                                          namespace:
+                                            description: Namespace is an optional namespace
+                                              to template with. If left empty, defaults to the
+                                              app's destination namespace.
+                                            type: string
+                                          parameters:
+                                            description: Parameters is a list of Helm parameters
+                                              which are passed to the helm template command
+                                              upon manifest generation
+                                            items:
+                                              description: HelmParameter is a parameter that's
+                                                passed to helm template during manifest generation
+                                              properties:
+                                                forceString:
+                                                  description: ForceString determines whether
+                                                    to tell Helm to interpret booleans and numbers
+                                                    as strings
+                                                  type: boolean
+                                                name:
+                                                  description: Name is the name of the Helm
+                                                    parameter
+                                                  type: string
+                                                value:
+                                                  description: Value is the value for the Helm
+                                                    parameter
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          passCredentials:
+                                            description: PassCredentials pass credentials to
+                                              all domains (Helm's --pass-credentials)
+                                            type: boolean
+                                          releaseName:
+                                            description: ReleaseName is the Helm release name
+                                              to use. If omitted it will use the application
+                                              name
+                                            type: string
+                                          skipCrds:
+                                            description: SkipCrds skips custom resource definition
+                                              installation step (Helm's --skip-crds)
+                                            type: boolean
+                                          skipTests:
+                                            description: SkipTests skips test manifest installation
+                                              step (Helm's --skip-tests).
+                                            type: boolean
+                                          valueFiles:
+                                            description: ValuesFiles is a list of Helm value
+                                              files to use when generating a template
+                                            items:
+                                              type: string
+                                            type: array
+                                          values:
+                                            description: Values specifies Helm values to be
+                                              passed to helm template, typically defined as
+                                              a block. ValuesObject takes precedence over Values,
+                                              so use one or the other.
+                                            type: string
+                                          valuesObject:
+                                            description: ValuesObject specifies Helm values
+                                              to be passed to helm template, defined as a map.
+                                              This takes precedence over Values.
+                                            type: object
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          version:
+                                            description: Version is the Helm version to use
+                                              for templating ("3")
+                                            type: string
+                                        type: object
+                                      kustomize:
+                                        description: Kustomize holds kustomize specific options
+                                        properties:
+                                          apiVersions:
+                                            description: |-
+                                              APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                              Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                            items:
+                                              type: string
+                                            type: array
+                                          commonAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: CommonAnnotations is a list of additional
+                                              annotations to add to rendered manifests
+                                            type: object
+                                          commonAnnotationsEnvsubst:
+                                            description: CommonAnnotationsEnvsubst specifies
+                                              whether to apply env variables substitution for
+                                              annotation values
+                                            type: boolean
+                                          commonLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: CommonLabels is a list of additional
+                                              labels to add to rendered manifests
+                                            type: object
+                                          components:
+                                            description: Components specifies a list of kustomize
+                                              components to add to the kustomization before
+                                              building
+                                            items:
+                                              type: string
+                                            type: array
+                                          forceCommonAnnotations:
+                                            description: ForceCommonAnnotations specifies whether
+                                              to force applying common annotations to resources
+                                              for Kustomize apps
+                                            type: boolean
+                                          forceCommonLabels:
+                                            description: ForceCommonLabels specifies whether
+                                              to force applying common labels to resources for
+                                              Kustomize apps
+                                            type: boolean
+                                          images:
+                                            description: Images is a list of Kustomize image
+                                              override specifications
+                                            items:
+                                              description: KustomizeImage represents a Kustomize
+                                                image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                              type: string
+                                            type: array
+                                          kubeVersion:
+                                            description: |-
+                                              KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                              uses the Kubernetes version of the target cluster.
+                                            type: string
+                                          labelWithoutSelector:
+                                            description: LabelWithoutSelector specifies whether
+                                              to apply common labels to resource selectors or
+                                              not
+                                            type: boolean
+                                          namePrefix:
+                                            description: NamePrefix is a prefix appended to
+                                              resources for Kustomize apps
+                                            type: string
+                                          nameSuffix:
+                                            description: NameSuffix is a suffix appended to
+                                              resources for Kustomize apps
+                                            type: string
+                                          namespace:
+                                            description: Namespace sets the namespace that Kustomize
+                                              adds to all resources
+                                            type: string
+                                          patches:
+                                            description: Patches is a list of Kustomize patches
+                                            items:
+                                              properties:
+                                                options:
+                                                  additionalProperties:
+                                                    type: boolean
+                                                  type: object
+                                                patch:
+                                                  type: string
+                                                path:
+                                                  type: string
+                                                target:
+                                                  properties:
+                                                    annotationSelector:
+                                                      type: string
+                                                    group:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    labelSelector:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    namespace:
+                                                      type: string
+                                                    version:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            type: array
+                                          replicas:
+                                            description: Replicas is a list of Kustomize Replicas
+                                              override specifications
+                                            items:
+                                              properties:
+                                                count:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number of replicas
+                                                  x-kubernetes-int-or-string: true
+                                                name:
+                                                  description: Name of Deployment or StatefulSet
+                                                  type: string
+                                              required:
+                                              - count
+                                              - name
+                                              type: object
+                                            type: array
+                                          version:
+                                            description: Version controls which version of Kustomize
+                                              to use for rendering manifests
+                                            type: string
+                                        type: object
+                                      path:
+                                        description: Path is a directory path within the Git
+                                          repository, and is only valid for applications sourced
+                                          from Git.
+                                        type: string
+                                      plugin:
+                                        description: Plugin holds config management plugin specific
+                                          options
+                                        properties:
+                                          env:
+                                            description: Env is a list of environment variable
+                                              entries
+                                            items:
+                                              description: EnvEntry represents an entry in the
+                                                application's environment
+                                              properties:
+                                                name:
+                                                  description: Name is the name of the variable,
+                                                    usually expressed in uppercase
+                                                  type: string
+                                                value:
+                                                  description: Value is the value of the variable
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          parameters:
+                                            items:
+                                              properties:
+                                                array:
+                                                  description: Array is the value of an array
+                                                    type parameter.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                map:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Map is the value of a map type
+                                                    parameter.
+                                                  type: object
+                                                name:
+                                                  description: Name is the name identifying
+                                                    a parameter.
+                                                  type: string
+                                                string:
+                                                  description: String_ is the value of a string
+                                                    type parameter.
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                      ref:
+                                        description: Ref is reference to another source within
+                                          sources field. This field will not be used if used
+                                          with a `source` tag.
+                                        type: string
+                                      repoURL:
+                                        description: RepoURL is the URL to the repository (Git
+                                          or Helm) that contains the application manifests
+                                        type: string
+                                      targetRevision:
+                                        description: |-
+                                          TargetRevision defines the revision of the source to sync the application to.
+                                          In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                          In case of Helm, this is a semver tag for the Chart's version.
+                                        type: string
+                                    required:
+                                    - repoURL
+                                    type: object
+                                  type: array
+                              required:
+                              - destination
+                              type: object
+                            revision:
+                              description: Revision contains information about the revision
+                                the comparison has been performed to
+                              type: string
+                            revisions:
+                              description: Revisions contains information about the revisions
+                                of multiple sources the comparison has been performed to
+                              items:
+                                type: string
+                              type: array
+                            status:
+                              description: Status is the sync state of the comparison
+                              type: string
+                          required:
+                          - status
+                          type: object
+                      type: object
+                  required:
+                  - metadata
+                  - spec
+                  type: object
+              served: true
+              storage: true
+              subresources: {}
+        - apiVersion: apiextensions.k8s.io/v1
+          kind: CustomResourceDefinition
+          metadata:
+            labels:
+              app.kubernetes.io/name: appprojects.argoproj.io
+              app.kubernetes.io/part-of: argocd
+            name: appprojects.argoproj.io
+          spec:
+            group: argoproj.io
+            names:
+              kind: AppProject
+              listKind: AppProjectList
+              plural: appprojects
+              shortNames:
+              - appproj
+              - appprojs
+              singular: appproject
+            scope: Namespaced
+            versions:
+            - name: v1alpha1
+              schema:
+                openAPIV3Schema:
+                  description: |-
+                    AppProject provides a logical grouping of applications, providing controls for:
+                    * where the apps may deploy to (cluster whitelist)
+                    * what may be deployed (repository whitelist, resource whitelist/blacklist)
+                    * who can access these applications (roles, OIDC group claims bindings)
+                    * and what they can do (RBAC policies)
+                    * automation access to these roles (JWT tokens)
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion defines the versioned schema of this representation of an object.
+                        Servers should convert recognized schemas to the latest internal value, and
+                        may reject unrecognized values.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is a string value representing the REST resource this object represents.
+                        Servers may infer this from the endpoint the client submits requests to.
+                        Cannot be updated.
+                        In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    metadata:
+                      type: object
+                    spec:
+                      description: AppProjectSpec is the specification of an AppProject
+                      properties:
+                        clusterResourceBlacklist:
+                          description: ClusterResourceBlacklist contains list of blacklisted
+                            cluster level resources
+                          items:
+                            description: |-
+                              GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                              concepts during lookup stages without having partially valid types
+                            properties:
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            type: object
+                          type: array
+                        clusterResourceWhitelist:
+                          description: ClusterResourceWhitelist contains list of whitelisted
+                            cluster level resources
+                          items:
+                            description: |-
+                              GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                              concepts during lookup stages without having partially valid types
+                            properties:
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            type: object
+                          type: array
+                        description:
+                          description: Description contains optional project description
+                          type: string
+                        destinationServiceAccounts:
+                          description: DestinationServiceAccounts holds information about the
+                            service accounts to be impersonated for the application sync operation
+                            for each destination.
+                          items:
+                            description: ApplicationDestinationServiceAccount holds information
+                              about the service account to be impersonated for the application
+                              sync operation.
+                            properties:
+                              defaultServiceAccount:
+                                description: DefaultServiceAccount to be used for impersonation
+                                  during the sync operation
+                                type: string
+                              namespace:
+                                description: Namespace specifies the target namespace for the
+                                  application's resources.
+                                type: string
+                              server:
+                                description: Server specifies the URL of the target cluster's
+                                  Kubernetes control plane API.
+                                type: string
+                            required:
+                            - defaultServiceAccount
+                            - server
+                            type: object
+                          type: array
+                        destinations:
+                          description: Destinations contains list of destinations available
+                            for deployment
+                          items:
+                            description: ApplicationDestination holds information about the
+                              application's destination
+                            properties:
+                              name:
+                                description: Name is an alternate way of specifying the target
+                                  cluster by its symbolic name. This must be set if Server is
+                                  not set.
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace specifies the target namespace for the application's resources.
+                                  The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
+                                type: string
+                              server:
+                                description: Server specifies the URL of the target cluster's
+                                  Kubernetes control plane API. This must be set if Name is
+                                  not set.
+                                type: string
+                            type: object
+                          type: array
+                        namespaceResourceBlacklist:
+                          description: NamespaceResourceBlacklist contains list of blacklisted
+                            namespace level resources
+                          items:
+                            description: |-
+                              GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                              concepts during lookup stages without having partially valid types
+                            properties:
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            type: object
+                          type: array
+                        namespaceResourceWhitelist:
+                          description: NamespaceResourceWhitelist contains list of whitelisted
+                            namespace level resources
+                          items:
+                            description: |-
+                              GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                              concepts during lookup stages without having partially valid types
+                            properties:
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            type: object
+                          type: array
+                        orphanedResources:
+                          description: OrphanedResources specifies if controller should monitor
+                            orphaned resources of apps in this project
+                          properties:
+                            ignore:
+                              description: Ignore contains a list of resources that are to be
+                                excluded from orphaned resources monitoring
+                              items:
+                                description: OrphanedResourceKey is a reference to a resource
+                                  to be ignored from
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            warn:
+                              description: Warn indicates if warning condition should be created
+                                for apps which have orphaned resources
+                              type: boolean
+                          type: object
+                        permitOnlyProjectScopedClusters:
+                          description: PermitOnlyProjectScopedClusters determines whether destinations
+                            can only reference clusters which are project-scoped
+                          type: boolean
+                        roles:
+                          description: Roles are user defined RBAC roles associated with this
+                            project
+                          items:
+                            description: ProjectRole represents a role that has access to a
+                              project
+                            properties:
+                              description:
+                                description: Description is a description of the role
+                                type: string
+                              groups:
+                                description: Groups are a list of OIDC group claims bound to
+                                  this role
+                                items:
+                                  type: string
+                                type: array
+                              jwtTokens:
+                                description: JWTTokens are a list of generated JWT tokens bound
+                                  to this role
+                                items:
+                                  description: JWTToken holds the issuedAt and expiresAt values
+                                    of a token
+                                  properties:
+                                    exp:
+                                      format: int64
+                                      type: integer
+                                    iat:
+                                      format: int64
+                                      type: integer
+                                    id:
+                                      type: string
+                                  required:
+                                  - iat
+                                  type: object
+                                type: array
+                              name:
+                                description: Name is a name for this role
+                                type: string
+                              policies:
+                                description: Policies Stores a list of casbin formatted strings
+                                  that define access policies for the role in the project
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        signatureKeys:
+                          description: SignatureKeys contains a list of PGP key IDs that commits
+                            in Git must be signed with in order to be allowed for sync
+                          items:
+                            description: SignatureKey is the specification of a key required
+                              to verify commit signatures with
+                            properties:
+                              keyID:
+                                description: The ID of the key in hexadecimal notation
+                                type: string
+                            required:
+                            - keyID
+                            type: object
+                          type: array
+                        sourceNamespaces:
+                          description: SourceNamespaces defines the namespaces application resources
+                            are allowed to be created in
+                          items:
+                            type: string
+                          type: array
+                        sourceRepos:
+                          description: SourceRepos contains list of repository URLs which can
+                            be used for deployment
+                          items:
+                            type: string
+                          type: array
+                        syncWindows:
+                          description: SyncWindows controls when syncs can be run for apps in
+                            this project
+                          items:
+                            description: SyncWindow contains the kind, time, duration and attributes
+                              that are used to assign the syncWindows to apps
+                            properties:
+                              applications:
+                                description: Applications contains a list of applications that
+                                  the window will apply to
+                                items:
+                                  type: string
+                                type: array
+                              clusters:
+                                description: Clusters contains a list of clusters that the window
+                                  will apply to
+                                items:
+                                  type: string
+                                type: array
+                              duration:
+                                description: Duration is the amount of time the sync window
+                                  will be open
+                                type: string
+                              kind:
+                                description: Kind defines if the window allows or blocks syncs
+                                type: string
+                              manualSync:
+                                description: ManualSync enables manual syncs when they would
+                                  otherwise be blocked
+                                type: boolean
+                              namespaces:
+                                description: Namespaces contains a list of namespaces that the
+                                  window will apply to
+                                items:
+                                  type: string
+                                type: array
+                              schedule:
+                                description: Schedule is the time the window will begin, specified
+                                  in cron format
+                                type: string
+                              timeZone:
+                                description: TimeZone of the sync that will be applied to the
+                                  schedule
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    status:
+                      description: AppProjectStatus contains status information for AppProject
+                        CRs
+                      properties:
+                        jwtTokensByRole:
+                          additionalProperties:
+                            description: JWTTokens represents a list of JWT tokens
+                            properties:
+                              items:
+                                items:
+                                  description: JWTToken holds the issuedAt and expiresAt values
+                                    of a token
+                                  properties:
+                                    exp:
+                                      format: int64
+                                      type: integer
+                                    iat:
+                                      format: int64
+                                      type: integer
+                                    id:
+                                      type: string
+                                  required:
+                                  - iat
+                                  type: object
+                                type: array
+                            type: object
+                          description: JWTTokensByRole contains a list of JWT tokens issued
+                            for a given role
+                          type: object
+                      type: object
+                  required:
+                  - metadata
+                  - spec
+                  type: object
+              served: true
+              storage: true
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-application-controller
+              app.kubernetes.io/part-of: argocd
+              app.kubernetes.io/component: application-controller
+            name: argocd-application-controller
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: argocd-application-controller
+          subjects:
+          - kind: ServiceAccount
+            name: argocd-application-controller
+            namespace: argocd
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-application-controller
+              app.kubernetes.io/part-of: argocd
+              app.kubernetes.io/component: application-controller
+            name: argocd-application-controller
+          rules:
+          - apiGroups:
+            - '*'
+            resources:
+            - '*'
+            verbs:
+            - '*'
+          - nonResourceURLs:
+            - '*'
+            verbs:
+            - '*'
+        - apiVersion: networking.k8s.io/v1
+          kind: NetworkPolicy
+          metadata:
+            namespace: argocd
+            name: argocd-application-controller-network-policy
+          spec:
+            podSelector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-application-controller
+            ingress:
+              - from:
+                  - namespaceSelector: { }
+                ports:
+                  - port: 8082
+            policyTypes:
+            - Ingress
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-application-controller
+              app.kubernetes.io/part-of: argocd
+              app.kubernetes.io/component: application-controller
+            name: argocd-application-controller
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: argocd-application-controller
+          subjects:
+          - kind: ServiceAccount
+            name: argocd-application-controller
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-application-controller
+              app.kubernetes.io/part-of: argocd
+              app.kubernetes.io/component: application-controller
+            name: argocd-application-controller
+          rules:
+          - apiGroups:
+            - ""
+            resources:
+            - secrets
+            - configmaps
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - argoproj.io
+            resources:
+            - applications
+            - appprojects
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+            - update
+            - patch
+            - delete
+          - apiGroups:
+            - ""
+            resources:
+            - events
+            verbs:
+            - create
+            - list
+          - apiGroups:
+            - apps
+            resources:
+            - deployments
+            verbs:
+            - get
+            - list
+            - watch
+        - apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-application-controller
+              app.kubernetes.io/part-of: argocd
+              app.kubernetes.io/component: application-controller
+            name: argocd-application-controller
+        - apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-application-controller
+              app.kubernetes.io/part-of: argocd
+              app.kubernetes.io/component: application-controller
+            name: argocd-application-controller
+          spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-application-controller
+            serviceName: argocd-application-controller
+            replicas: 1
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: argocd-application-controller
+              spec:
+                containers:
+                - args:
+                  - /usr/local/bin/argocd-application-controller
+                  env:
+                  - name: REDIS_PASSWORD
+                    valueFrom:
+                      secretKeyRef:
+                        key: auth
+                        name: argocd-redis
+                  - name: ARGOCD_CONTROLLER_REPLICAS
+                    value: "1"
+                  - name: ARGOCD_RECONCILIATION_TIMEOUT
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cm
+                        key: timeout.reconciliation
+                        optional: true
+                  - name: ARGOCD_HARD_RECONCILIATION_TIMEOUT
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cm
+                        key: timeout.hard.reconciliation
+                        optional: true
+                  - name: ARGOCD_RECONCILIATION_JITTER
+                    valueFrom:
+                      configMapKeyRef:
+                        key: timeout.reconciliation.jitter
+                        name: argocd-cm
+                        optional: true
+                  - name: ARGOCD_REPO_ERROR_GRACE_PERIOD_SECONDS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.repo.error.grace.period.seconds
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: repo.server
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER_TIMEOUT_SECONDS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.repo.server.timeout.seconds
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_STATUS_PROCESSORS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.status.processors
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_OPERATION_PROCESSORS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.operation.processors
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_LOGFORMAT
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.log.format
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_LOGLEVEL
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.log.level
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_METRICS_CACHE_EXPIRATION
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.metrics.cache.expiration
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_TIMEOUT_SECONDS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.self.heal.timeout.seconds
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_BACKOFF_TIMEOUT_SECONDS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.self.heal.backoff.timeout.seconds
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_BACKOFF_FACTOR
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.self.heal.backoff.factor
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_BACKOFF_CAP_SECONDS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.self.heal.backoff.cap.seconds
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER_PLAINTEXT
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.repo.server.plaintext
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER_STRICT_TLS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.repo.server.strict.tls
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_PERSIST_RESOURCE_HEALTH
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.resource.health.persist
+                        optional: true
+                  - name: ARGOCD_APP_STATE_CACHE_EXPIRATION
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.app.state.cache.expiration
+                        optional: true
+                  - name: REDIS_SERVER
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: redis.server
+                        optional: true
+                  - name: REDIS_COMPRESSION
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: redis.compression
+                        optional: true
+                  - name: REDISDB
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: redis.db
+                        optional: true
+                  - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.default.cache.expiration
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_ADDRESS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: otlp.address
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_INSECURE
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: otlp.insecure
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_OTLP_HEADERS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: otlp.headers
+                        optional: true
+                  - name: ARGOCD_APPLICATION_NAMESPACES
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: application.namespaces
+                        optional: true
+                  - name: ARGOCD_CONTROLLER_SHARDING_ALGORITHM
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.sharding.algorithm
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_KUBECTL_PARALLELISM_LIMIT
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.kubectl.parallelism.limit
+                        optional: true
+                  - name: ARGOCD_K8SCLIENT_RETRY_MAX
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.k8sclient.retry.max
+                        optional: true
+                  - name: ARGOCD_K8SCLIENT_RETRY_BASE_BACKOFF
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.k8sclient.retry.base.backoff
+                        optional: true
+                  - name: ARGOCD_APPLICATION_CONTROLLER_SERVER_SIDE_DIFF
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.diff.server.side
+                        optional: true
+                  - name: ARGOCD_IGNORE_NORMALIZER_JQ_TIMEOUT
+                    valueFrom:
+                      configMapKeyRef:
+                        name: argocd-cmd-params-cm
+                        key: controller.ignore.normalizer.jq.timeout
+                        optional: true
+                  - name: KUBECACHEDIR
+                    value: /tmp/kubecache
+                  image: "{{ .Values.argocd.image.repository }}:{{ .Values.argocd.image.tag }}"
+                  imagePullPolicy: Always
+                  name: argocd-application-controller
+                  ports:
+                  - containerPort: 8082
+                  readinessProbe:
+                    httpGet:
+                      path: /healthz
+                      port: 8082
+                    initialDelaySeconds: 5
+                    periodSeconds: 10
+                  securityContext:
+                    runAsNonRoot: true
+                    readOnlyRootFilesystem: true
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    seccompProfile:
+                      type: RuntimeDefault
+                  workingDir: /home/argocd
+                  volumeMounts:
+                  - name: argocd-repo-server-tls
+                    mountPath: /app/config/controller/tls
+                  - name: argocd-home
+                    mountPath: /home/argocd
+                  - name: argocd-cmd-params-cm
+                    mountPath: /home/argocd/params
+                  - name: argocd-application-controller-tmp
+                    mountPath: /tmp
+                serviceAccountName: argocd-application-controller
+                affinity:
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 100
+                      podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/name: argocd-application-controller
+                        topologyKey: kubernetes.io/hostname
+                    - weight: 5
+                      podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/part-of: argocd
+                        topologyKey: kubernetes.io/hostname
+                volumes:
+                - emptyDir: {}
+                  name: argocd-home
+                - emptyDir: {}
+                  name: argocd-application-controller-tmp
+                - name: argocd-repo-server-tls
+                  secret:
+                    secretName: argocd-repo-server-tls
+                    optional: true
+                    items:
+                    - key: tls.crt
+                      path: tls.crt
+                    - key: tls.key
+                      path: tls.key
+                    - key: ca.crt
+                      path: ca.crt
+                - name: argocd-cmd-params-cm
+                  configMap:
+                    optional: true
+                    name: argocd-cmd-params-cm
+                    items:
+                      - key: controller.profile.enabled
+                        path: profiler.enabled
+                nodeSelector:
+                  kubernetes.io/os: linux
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            namespace: argocd
+            name: argocd-cmd-params-cm
+            labels:
+              app.kubernetes.io/name: argocd-cmd-params-cm
+              app.kubernetes.io/part-of: argocd
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            namespace: argocd
+            name: argocd-cm
+            labels:
+              app.kubernetes.io/name: argocd-cm
+              app.kubernetes.io/part-of: argocd
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-gpg-keys-cm
+              app.kubernetes.io/part-of: argocd
+            name: argocd-gpg-keys-cm
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-metrics
+              app.kubernetes.io/part-of: argocd
+              app.kubernetes.io/component: metrics
+            name: argocd-metrics
+          spec:
+            ports:
+            - name: metrics
+              protocol: TCP
+              port: 8082
+              targetPort: 8082
+            selector:
+              app.kubernetes.io/name: argocd-application-controller
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            namespace: argocd
+            name: argocd-rbac-cm
+            labels:
+              app.kubernetes.io/name: argocd-rbac-cm
+              app.kubernetes.io/part-of: argocd
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-redis
+              app.kubernetes.io/part-of: argocd
+              app.kubernetes.io/component: redis
+            name: argocd-redis
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-redis
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: argocd-redis
+              spec:
+                initContainers:
+                  - command:
+                      - argocd
+                      - admin
+                      - redis-initial-password
+                    image: "{{ .Values.argocd.image.repository }}:{{ .Values.argocd.image.tag }}"
+                    imagePullPolicy: IfNotPresent
+                    name: secret-init
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                      runAsNonRoot: true
+                      seccompProfile:
+                        type: RuntimeDefault
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 999
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: argocd-redis        
+                containers:
+                - name: redis
+                  image: redis:7.0.15-alpine
+                  imagePullPolicy: Always
+                  args:
+                  - "--save"
+                  - ""
+                  - "--appendonly"
+                  - "no"
+                  - --requirepass $(REDIS_PASSWORD)
+                  env:
+                    - name: REDIS_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          key: auth
+                          name: argocd-redis
+                  ports:
+                  - containerPort: 6379
+                  securityContext:
+                    readOnlyRootFilesystem: true
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                affinity:
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 100
+                      podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/name: argocd-redis
+                        topologyKey: kubernetes.io/hostname
+                    - weight: 5
+                      podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/part-of: argocd
+                        topologyKey: kubernetes.io/hostname
+                nodeSelector:
+                  kubernetes.io/os: linux
+        - kind: NetworkPolicy
+          apiVersion: networking.k8s.io/v1
+          metadata:
+            namespace: argocd
+            name: argocd-redis-network-policy
+          spec:
+            podSelector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-redis
+            policyTypes:
+            - Ingress
+            ingress:
+            - from:
+              - podSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: argocd-server
+              - podSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: argocd-repo-server
+              - podSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: argocd-application-controller
+              ports:
+              - protocol: TCP
+                port: 6379
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/component: redis
+              app.kubernetes.io/name: argocd-redis
+              app.kubernetes.io/part-of: argocd
+            name: argocd-redis
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: argocd-redis
+          subjects:
+            - kind: ServiceAccount
+              name: argocd-redis
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/component: redis
+              app.kubernetes.io/name: argocd-redis
+              app.kubernetes.io/part-of: argocd
+            name: argocd-redis
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              resourceNames:
+                - argocd-redis
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+        - apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/component: redis
+              app.kubernetes.io/name: argocd-redis
+              app.kubernetes.io/part-of: argocd
+            name: argocd-redis
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-redis
+              app.kubernetes.io/part-of: argocd
+              app.kubernetes.io/component: redis
+            name: argocd-redis
+          spec:
+            ports:
+              - name: tcp-redis
+                port: 6379
+                targetPort: 6379
+            selector:
+              app.kubernetes.io/name: argocd-redis
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-repo-server
+              app.kubernetes.io/part-of: argocd
+              app.kubernetes.io/component: repo-server
+            name: argocd-repo-server
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-repo-server
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: argocd-repo-server
+              spec:
+                serviceAccountName: argocd-repo-server
+                automountServiceAccountToken: false
+                containers:
+                - name: argocd-repo-server
+                  image: "{{ .Values.argocd.image.repository }}:{{ .Values.argocd.image.tag }}"
+                  imagePullPolicy: Always
+                  args:
+                    - /usr/local/bin/argocd-repo-server
+                  env:
+                    - name: REDIS_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          key: auth
+                          name: argocd-redis
+                    - name: ARGOCD_RECONCILIATION_TIMEOUT
+                      valueFrom:
+                        configMapKeyRef:
+                          name: argocd-cm
+                          key: timeout.reconciliation
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_LOGFORMAT
+                      valueFrom:
+                        configMapKeyRef:
+                          name: argocd-cmd-params-cm
+                          key: reposerver.log.format
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_LOGLEVEL
+                      valueFrom:
+                        configMapKeyRef:
+                          name: argocd-cmd-params-cm
+                          key: reposerver.log.level
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_PARALLELISM_LIMIT
+                      valueFrom:
+                        configMapKeyRef:
+                          name: argocd-cmd-params-cm
+                          key: reposerver.parallelism.limit
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_LISTEN_ADDRESS
+                      valueFrom:
+                        configMapKeyRef:
+                          name: argocd-cmd-params-cm
+                          key: reposerver.listen.address
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_LISTEN_METRICS_ADDRESS
+                      valueFrom:
+                        configMapKeyRef:
+                          name: argocd-cmd-params-cm
+                          key: reposerver.metrics.listen.address
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_DISABLE_TLS
+                      valueFrom:
+                        configMapKeyRef:
+                          name: argocd-cmd-params-cm
+                          key: reposerver.disable.tls
+                          optional: true
+                    - name: ARGOCD_TLS_MIN_VERSION
+                      valueFrom:
+                          configMapKeyRef:
+                            name: argocd-cmd-params-cm
+                            key: reposerver.tls.minversion
+                            optional: true
+                    - name: ARGOCD_TLS_MAX_VERSION
+                      valueFrom:
+                          configMapKeyRef:
+                            name: argocd-cmd-params-cm
+                            key: reposerver.tls.maxversion
+                            optional: true
+                    - name: ARGOCD_TLS_CIPHERS
+                      valueFrom:
+                          configMapKeyRef:
+                            name: argocd-cmd-params-cm
+                            key: reposerver.tls.ciphers
+                            optional: true
+                    - name: ARGOCD_REPO_CACHE_EXPIRATION
+                      valueFrom:
+                          configMapKeyRef:
+                            name: argocd-cmd-params-cm
+                            key: reposerver.repo.cache.expiration
+                            optional: true
+                    - name: REDIS_SERVER
+                      valueFrom:
+                          configMapKeyRef:
+                            name: argocd-cmd-params-cm
+                            key: redis.server
+                            optional: true
+                    - name: REDIS_COMPRESSION
+                      valueFrom:
+                        configMapKeyRef:
+                          name: argocd-cmd-params-cm
+                          key: redis.compression
+                          optional: true
+                    - name: REDISDB
+                      valueFrom:
+                          configMapKeyRef:
+                            name: argocd-cmd-params-cm
+                            key: redis.db
+                            optional: true
+                    - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
+                      valueFrom:
+                          configMapKeyRef:
+                            name: argocd-cmd-params-cm
+                            key: reposerver.default.cache.expiration
+                            optional: true
+                    - name: ARGOCD_REPO_SERVER_OTLP_ADDRESS
+                      valueFrom:
+                          configMapKeyRef:
+                            name: argocd-cmd-params-cm
+                            key: otlp.address
+                            optional: true
+                    - name: ARGOCD_REPO_SERVER_OTLP_INSECURE
+                      valueFrom:
+                          configMapKeyRef:
+                            name: argocd-cmd-params-cm
+                            key: otlp.insecure
+                            optional: true
+                    - name: ARGOCD_REPO_SERVER_OTLP_HEADERS
+                      valueFrom:
+                          configMapKeyRef:
+                            name: argocd-cmd-params-cm
+                            key: otlp.headers
+                            optional: true
+                    - name: ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE
+                      valueFrom:
+                        configMapKeyRef:
+                          name: argocd-cmd-params-cm
+                          key: reposerver.max.combined.directory.manifests.size
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS
+                      valueFrom:
+                        configMapKeyRef:
+                          name: argocd-cmd-params-cm
+                          key: reposerver.plugin.tar.exclusions
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_PLUGIN_USE_MANIFEST_GENERATE_PATHS
+                      valueFrom:
+                        configMapKeyRef:
+                          key: reposerver.plugin.use.manifest.generate.paths
+                          name: argocd-cmd-params-cm
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_ALLOW_OUT_OF_BOUNDS_SYMLINKS
+                      valueFrom:
+                        configMapKeyRef:
+                          key: reposerver.allow.oob.symlinks
+                          name: argocd-cmd-params-cm
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_STREAMED_MANIFEST_MAX_TAR_SIZE
+                      valueFrom:
+                        configMapKeyRef:
+                          key: reposerver.streamed.manifest.max.tar.size
+                          name: argocd-cmd-params-cm
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_STREAMED_MANIFEST_MAX_EXTRACTED_SIZE
+                      valueFrom:
+                        configMapKeyRef:
+                          key: reposerver.streamed.manifest.max.extracted.size
+                          name: argocd-cmd-params-cm
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_HELM_MANIFEST_MAX_EXTRACTED_SIZE
+                      valueFrom:
+                        configMapKeyRef:
+                          key: reposerver.helm.manifest.max.extracted.size
+                          name: argocd-cmd-params-cm
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_DISABLE_HELM_MANIFEST_MAX_EXTRACTED_SIZE
+                      valueFrom:
+                        configMapKeyRef:
+                          name: argocd-cmd-params-cm
+                          key: reposerver.disable.helm.manifest.max.extracted.size
+                          optional: true
+                    - name: ARGOCD_REVISION_CACHE_LOCK_TIMEOUT
+                      valueFrom:
+                        configMapKeyRef:
+                          key: reposerver.revision.cache.lock.timeout
+                          name: argocd-cmd-params-cm
+                          optional: true
+                    - name: ARGOCD_GIT_MODULES_ENABLED
+                      valueFrom:
+                        configMapKeyRef:
+                          key: reposerver.enable.git.submodule
+                          name: argocd-cmd-params-cm
+                          optional: true
+                    - name: ARGOCD_GIT_LS_REMOTE_PARALLELISM_LIMIT
+                      valueFrom:
+                        configMapKeyRef:
+                          key: reposerver.git.lsremote.parallelism.limit
+                          name: argocd-cmd-params-cm
+                          optional: true
+                    - name: ARGOCD_GIT_REQUEST_TIMEOUT
+                      valueFrom:
+                        configMapKeyRef:
+                          key: reposerver.git.request.timeout
+                          name: argocd-cmd-params-cm
+                          optional: true
+                    - name: ARGOCD_GRPC_MAX_SIZE_MB
+                      valueFrom:
+                        configMapKeyRef:
+                          key: reposerver.grpc.max.size
+                          name: argocd-cmd-params-cm
+                          optional: true
+                    - name: ARGOCD_REPO_SERVER_INCLUDE_HIDDEN_DIRECTORIES
+                      valueFrom:
+                        configMapKeyRef:
+                          key: reposerver.include.hidden.directories
+                          name: argocd-cmd-params-cm
+                          optional: true
+                    - name: HELM_CACHE_HOME
+                      value: /helm-working-dir
+                    - name: HELM_CONFIG_HOME
+                      value: /helm-working-dir
+                    - name: HELM_DATA_HOME
+                      value: /helm-working-dir
+                  ports:
+                  - containerPort: 8081
+                  - containerPort: 8084
+                  livenessProbe:
+                    httpGet:
+                      path: /healthz?full=true
+                      port: 8084
+                    initialDelaySeconds: 30
+                    periodSeconds: 30
+                    failureThreshold: 3
+                    timeoutSeconds: 5
+                  readinessProbe:
+                    httpGet:
+                      path: /healthz
+                      port: 8084
+                    initialDelaySeconds: 5
+                    periodSeconds: 10
+                  securityContext:
+                    runAsNonRoot: true
+                    readOnlyRootFilesystem: true
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    seccompProfile:
+                      type: RuntimeDefault
+                  volumeMounts:
+                  - name: ssh-known-hosts
+                    mountPath: /app/config/ssh
+                  - name: tls-certs
+                    mountPath: /app/config/tls
+                  - name: gpg-keys
+                    mountPath: /app/config/gpg/source
+                  - name: gpg-keyring
+                    mountPath: /app/config/gpg/keys
+                  - name: argocd-repo-server-tls
+                    mountPath: /app/config/reposerver/tls
+                  - name: tmp
+                    mountPath: /tmp
+                  - mountPath: /helm-working-dir
+                    name: helm-working-dir
+                  - mountPath: /home/argocd/cmp-server/plugins
+                    name: plugins
+                initContainers:
+                - command:
+                  - /bin/cp
+                  - -n
+                  - /usr/local/bin/argocd
+                  - /var/run/argocd/argocd-cmp-server
+                  image: "{{ .Values.argocd.image.repository }}:{{ .Values.argocd.image.tag }}"
+                  name: copyutil
+                  securityContext:
+                    runAsNonRoot: true
+                    readOnlyRootFilesystem: true
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    seccompProfile:
+                      type: RuntimeDefault
+                  volumeMounts:
+                  - mountPath: /var/run/argocd
+                    name: var-files
+                volumes:
+                  - name: ssh-known-hosts
+                    configMap:
+                      name: argocd-ssh-known-hosts-cm
+                  - name: tls-certs
+                    configMap:
+                      name: argocd-tls-certs-cm
+                  - name: gpg-keys
+                    configMap:
+                      name: argocd-gpg-keys-cm
+                  - name: gpg-keyring
+                    emptyDir: {}
+                  - name: tmp
+                    emptyDir: {}
+                  - name: helm-working-dir
+                    emptyDir: {}
+                  - name: argocd-repo-server-tls
+                    secret:
+                      secretName: argocd-repo-server-tls
+                      optional: true
+                      items:
+                      - key: tls.crt
+                        path: tls.crt
+                      - key: tls.key
+                        path: tls.key
+                      - key: ca.crt
+                        path: ca.crt
+                  - emptyDir: {}
+                    name: var-files
+                  - emptyDir: {}
+                    name: plugins
+                affinity:
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 100
+                      podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/name: argocd-repo-server
+                        topologyKey: kubernetes.io/hostname
+                    - weight: 5
+                      podAffinityTerm:
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/part-of: argocd
+                        topologyKey: kubernetes.io/hostname
+                nodeSelector:
+                  kubernetes.io/os: linux
+        - kind: NetworkPolicy
+          apiVersion: networking.k8s.io/v1
+          metadata:
+            namespace: argocd
+            name: argocd-repo-server-network-policy
+          spec:
+            podSelector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-repo-server
+            policyTypes:
+              - Ingress
+            ingress:
+              - from:
+                  - podSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: argocd-server
+                  - podSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: argocd-application-controller
+                  - podSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: argocd-notifications-controller
+                  - podSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: argocd-applicationset-controller
+                ports:
+                  - protocol: TCP
+                    port: 8081
+              - from:
+                  - namespaceSelector: { }
+                ports:
+                  - port: 8084
+        - apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-repo-server
+              app.kubernetes.io/part-of: argocd
+              app.kubernetes.io/component: repo-server
+            name: argocd-repo-server
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-repo-server
+              app.kubernetes.io/part-of: argocd
+              app.kubernetes.io/component: repo-server
+            name: argocd-repo-server
+          spec:
+            ports:
+            - name: server
+              protocol: TCP
+              port: 8081
+              targetPort: 8081
+            - name: metrics
+              protocol: TCP
+              port: 8084
+              targetPort: 8084
+            selector:
+              app.kubernetes.io/name: argocd-repo-server
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            namespace: argocd
+            name: argocd-secret
+            labels:
+              app.kubernetes.io/name: argocd-secret
+              app.kubernetes.io/part-of: argocd
+          data:
+            server.secretkey: Zm9v # dummy key workaround for https://github.com/argoproj/argo-cd/issues/22931
+          type: Opaque
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-ssh-known-hosts-cm
+              app.kubernetes.io/part-of: argocd
+            name: argocd-ssh-known-hosts-cm
+          data:
+            ssh_known_hosts: |
+              # This file was automatically generated by hack/update-ssh-known-hosts.sh. DO NOT EDIT
+              [ssh.github.com]:443 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+              [ssh.github.com]:443 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+              [ssh.github.com]:443 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+              bitbucket.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPIQmuzMBuKdWeF4+a2sjSSpBK0iqitSQ+5BM9KhpexuGt20JpTVM7u5BDZngncgrqDMbWdxMWWOGtZ9UgbqgZE=
+              bitbucket.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIazEu89wgQZ4bqs3d63QSMzYVa0MuJ2e2gKTKqu+UUO
+              bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDQeJzhupRu0u0cdegZIa8e86EG2qOCsIsD1Xw0xSeiPDlCr7kq97NLmMbpKTX6Esc30NuoqEEHCuc7yWtwp8dI76EEEB1VqY9QJq6vk+aySyboD5QF61I/1WeTwu+deCbgKMGbUijeXhtfbxSxm6JwGrXrhBdofTsbKRUsrN1WoNgUa8uqN1Vx6WAJw1JHPhglEGGHea6QICwJOAr/6mrui/oB7pkaWKHj3z7d1IC4KWLtY47elvjbaTlkN04Kc/5LFEirorGYVbt15kAUlqGM65pk6ZBxtaO3+30LVlORZkxOh+LKL/BvbZ/iRNhItLqNyieoQj/uh/7Iv4uyH/cV/0b4WDSd3DptigWq84lJubb9t/DnZlrJazxyDCulTmKdOR7vs9gMTo+uoIrPSb8ScTtvw65+odKAlBj59dhnVp9zd7QUojOpXlL62Aw56U4oO+FALuevvMjiWeavKhJqlR7i5n9srYcrNV7ttmDw7kf/97P5zauIhxcjX+xHv4M=
+              github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+              github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+              github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+              gitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=
+              gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf
+              gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9
+              ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
+              vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            namespace: argocd
+            labels:
+              app.kubernetes.io/name: argocd-tls-certs-cm
+              app.kubernetes.io/part-of: argocd
+            name: argocd-tls-certs-cm
+        - apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: argocd
+        - apiVersion: argoproj.io/v1alpha1
+          kind: AppProject
+          metadata:
+            name: default
+            namespace: argocd
+          spec:
+            clusterResourceWhitelist:
+            - group: '*'
+              kind: '*'
+            destinations:
+            - namespace: '*'
+              server: '*'
+            sourceNamespaces:
+            - '*'
+            sourceRepos:
+            - '*'
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            namespace: argocd
+            name: argocd-work-role
+          rules:
+          - apiGroups: ["argoproj.io"]
+            resources: ["appprojects", "applications"]
+            verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            namespace: argocd
+            name: argocd-work-role-binding
+          subjects:
+          - kind: ServiceAccount
+            name: klusterlet-work-sa
+            namespace: open-cluster-management-agent
+          roleRef:
+            kind: Role
+            name: argocd-work-role
+            apiGroup: rbac.authorization.k8s.io

--- a/charts/argocd-pull-integration/templates/argocd-clustermanagement-addon.yaml
+++ b/charts/argocd-pull-integration/templates/argocd-clustermanagement-addon.yaml
@@ -1,0 +1,15 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: argocd
+  annotations:
+    addon.open-cluster-management.io/lifecycle: "addon-manager"
+spec:
+  addOnMeta:
+    description: Argo CD
+    displayName: Argo CD
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addontemplates
+      defaultConfig:
+        name: argocd

--- a/charts/argocd-pull-integration/templates/clusterrole.yaml
+++ b/charts/argocd-pull-integration/templates/clusterrole.yaml
@@ -1,0 +1,67 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-pull-integration
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - work.open-cluster-management.io
+  resources:
+  - manifestworks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/charts/argocd-pull-integration/templates/clusterrolebinding.yaml
+++ b/charts/argocd-pull-integration/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-pull-integration-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-pull-integration
+subjects:
+- kind: ServiceAccount
+  name: argocd-pull-integration
+  namespace: argocd

--- a/charts/argocd-pull-integration/templates/clusterset-binding.yaml
+++ b/charts/argocd-pull-integration/templates/clusterset-binding.yaml
@@ -1,0 +1,8 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: argocd
+spec:
+  clusterSet: global
+

--- a/charts/argocd-pull-integration/templates/deployment.yaml
+++ b/charts/argocd-pull-integration/templates/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: argocd-pull-integration
+  name: argocd-pull-integration
+  namespace: argocd
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: argocd-pull-integration
+  template:
+    metadata:
+      labels:
+        app: argocd-pull-integration
+    spec:
+      containers:
+      - name:  argocd-pull-integration
+        args:
+        - --mode=basic
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /manager
+        image: "{{ .Values.image }}:{{ .Values.tag }}"
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      serviceAccountName: argocd-pull-integration

--- a/charts/argocd-pull-integration/templates/ocm-placement-consumer-role.yaml
+++ b/charts/argocd-pull-integration/templates/ocm-placement-consumer-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ocm-placement-consumer
+  namespace: argocd
+rules:
+# Allow controller to manage placements/placementdecisions
+- apiGroups: ["cluster.open-cluster-management.io"]
+  resources: ["placements"]
+  verbs: ["get", "list"]
+- apiGroups: ["cluster.open-cluster-management.io"]
+  resources: ["placementdecisions"]
+  verbs: ["get", "list"]

--- a/charts/argocd-pull-integration/templates/ocm-placement-consumer-rolebinding.yaml
+++ b/charts/argocd-pull-integration/templates/ocm-placement-consumer-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ocm-placement-consumer:argocd
+  namespace: argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ocm-placement-consumer
+subjects:
+- kind: ServiceAccount
+  namespace: argocd
+  name: argocd-applicationset-controller

--- a/charts/argocd-pull-integration/templates/ocm-placement-generator-cm.yaml
+++ b/charts/argocd-pull-integration/templates/ocm-placement-generator-cm.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ocm-placement-generator
+  namespace: argocd
+data:
+  apiVersion: cluster.open-cluster-management.io/v1beta1
+  kind: placementdecisions
+  statusListKey: decisions
+  matchKey: clusterName

--- a/charts/argocd-pull-integration/templates/serviceaccount.yaml
+++ b/charts/argocd-pull-integration/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-pull-integration
+  namespace: argocd

--- a/charts/argocd-pull-integration/values.yaml
+++ b/charts/argocd-pull-integration/values.yaml
@@ -1,0 +1,11 @@
+# Controller manager image settings
+# For development (main branch): use "latest" tag
+# For release branches: update tag to match the release version (e.g., "0.26.0")
+image: quay.io/open-cluster-management/argocd-pull-integration
+tag: latest
+replicas: 1
+
+argocd:
+  image:
+    repository: quay.io/argoproj/argocd
+    tag: v3.0.6

--- a/hack/crds/application-crd.yaml
+++ b/hack/crds/application-crd.yaml
@@ -1,0 +1,2156 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/name: applications.argoproj.io
+    app.kubernetes.io/part-of: argocd
+  name: applications.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    shortNames:
+    - app
+    - apps
+    singular: application
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.sync.status
+      name: Sync Status
+      type: string
+    - jsonPath: .status.health.status
+      name: Health Status
+      type: string
+    - jsonPath: .status.sync.revision
+      name: Revision
+      priority: 10
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Application is a definition of Application resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          operation:
+            description: Operation contains information about a requested or running
+              operation
+            properties:
+              info:
+                description: Info is a list of informational items for this operation
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              initiatedBy:
+                description: InitiatedBy contains information about who initiated
+                  the operations
+                properties:
+                  automated:
+                    description: Automated is set to true if operation was initiated
+                      automatically by the application controller.
+                    type: boolean
+                  username:
+                    description: Username contains the name of a user who started
+                      operation
+                    type: string
+                type: object
+              retry:
+                description: Retry controls the strategy to apply if a sync fails
+                properties:
+                  backoff:
+                    description: Backoff controls how to backoff on subsequent retries
+                      of failed syncs
+                    properties:
+                      duration:
+                        description: Duration is the amount to back off. Default unit
+                          is seconds, but could also be a duration (e.g. "2m", "1h")
+                        type: string
+                      factor:
+                        description: Factor is a factor to multiply the base duration
+                          after each failed retry
+                        format: int64
+                        type: integer
+                      maxDuration:
+                        description: MaxDuration is the maximum amount of time allowed
+                          for the backoff strategy
+                        type: string
+                    type: object
+                  limit:
+                    description: Limit is the maximum number of attempts for retrying
+                      a failed sync. If set to 0, no retries will be performed.
+                    format: int64
+                    type: integer
+                type: object
+              sync:
+                description: Sync contains parameters for the operation
+                properties:
+                  dryRun:
+                    description: DryRun specifies to perform a `kubectl apply --dry-run`
+                      without actually performing the sync
+                    type: boolean
+                  manifests:
+                    description: Manifests is an optional field that overrides sync
+                      source with a local directory for development
+                    items:
+                      type: string
+                    type: array
+                  prune:
+                    description: Prune specifies to delete resources from the cluster
+                      that are no longer tracked in git
+                    type: boolean
+                  resources:
+                    description: Resources describes which resources shall be part
+                      of the sync
+                    items:
+                      description: SyncOperationResource contains resources to sync.
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                  revision:
+                    description: Revision is the revision (Git) or chart version (Helm)
+                      which to sync the application to If omitted, will use the revision
+                      specified in app spec.
+                    type: string
+                  source:
+                    description: Source overrides the source definition set in the
+                      application. This is typically set in a Rollback operation and
+                      is nil during a Sync operation
+                    properties:
+                      chart:
+                        description: Chart is a Helm chart name, and must be specified
+                          for applications sourced from a Helm repo.
+                        type: string
+                      directory:
+                        description: Directory holds path/directory specific options
+                        properties:
+                          exclude:
+                            description: Exclude contains a glob pattern to match
+                              paths against that should be explicitly excluded from
+                              being used during manifest generation
+                            type: string
+                          include:
+                            description: Include contains a glob pattern to match
+                              paths against that should be explicitly included during
+                              manifest generation
+                            type: string
+                          jsonnet:
+                            description: Jsonnet holds options specific to Jsonnet
+                            properties:
+                              extVars:
+                                description: ExtVars is a list of Jsonnet External
+                                  Variables
+                                items:
+                                  description: JsonnetVar represents a variable to
+                                    be passed to jsonnet during manifest generation
+                                  properties:
+                                    code:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              libs:
+                                description: Additional library search dirs
+                                items:
+                                  type: string
+                                type: array
+                              tlas:
+                                description: TLAS is a list of Jsonnet Top-level Arguments
+                                items:
+                                  description: JsonnetVar represents a variable to
+                                    be passed to jsonnet during manifest generation
+                                  properties:
+                                    code:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          recurse:
+                            description: Recurse specifies whether to scan a directory
+                              recursively for manifests
+                            type: boolean
+                        type: object
+                      helm:
+                        description: Helm holds helm specific options
+                        properties:
+                          fileParameters:
+                            description: FileParameters are file parameters to the
+                              helm template
+                            items:
+                              description: HelmFileParameter is a file parameter that's
+                                passed to helm template during manifest generation
+                              properties:
+                                name:
+                                  description: Name is the name of the Helm parameter
+                                  type: string
+                                path:
+                                  description: Path is the path to the file containing
+                                    the values for the Helm parameter
+                                  type: string
+                              type: object
+                            type: array
+                          ignoreMissingValueFiles:
+                            description: IgnoreMissingValueFiles prevents helm template
+                              from failing when valueFiles do not exist locally by
+                              not appending them to helm template --values
+                            type: boolean
+                          parameters:
+                            description: Parameters is a list of Helm parameters which
+                              are passed to the helm template command upon manifest
+                              generation
+                            items:
+                              description: HelmParameter is a parameter that's passed
+                                to helm template during manifest generation
+                              properties:
+                                forceString:
+                                  description: ForceString determines whether to tell
+                                    Helm to interpret booleans and numbers as strings
+                                  type: boolean
+                                name:
+                                  description: Name is the name of the Helm parameter
+                                  type: string
+                                value:
+                                  description: Value is the value for the Helm parameter
+                                  type: string
+                              type: object
+                            type: array
+                          passCredentials:
+                            description: PassCredentials pass credentials to all domains
+                              (Helm's --pass-credentials)
+                            type: boolean
+                          releaseName:
+                            description: ReleaseName is the Helm release name to use.
+                              If omitted it will use the application name
+                            type: string
+                          skipCrds:
+                            description: SkipCrds skips custom resource definition
+                              installation step (Helm's --skip-crds)
+                            type: boolean
+                          valueFiles:
+                            description: ValuesFiles is a list of Helm value files
+                              to use when generating a template
+                            items:
+                              type: string
+                            type: array
+                          values:
+                            description: Values specifies Helm values to be passed
+                              to helm template, typically defined as a block
+                            type: string
+                          version:
+                            description: Version is the Helm version to use for templating
+                              ("3")
+                            type: string
+                        type: object
+                      kustomize:
+                        description: Kustomize holds kustomize specific options
+                        properties:
+                          commonAnnotations:
+                            additionalProperties:
+                              type: string
+                            description: CommonAnnotations is a list of additional
+                              annotations to add to rendered manifests
+                            type: object
+                          commonLabels:
+                            additionalProperties:
+                              type: string
+                            description: CommonLabels is a list of additional labels
+                              to add to rendered manifests
+                            type: object
+                          forceCommonAnnotations:
+                            description: ForceCommonAnnotations specifies whether
+                              to force applying common annotations to resources for
+                              Kustomize apps
+                            type: boolean
+                          forceCommonLabels:
+                            description: ForceCommonLabels specifies whether to force
+                              applying common labels to resources for Kustomize apps
+                            type: boolean
+                          images:
+                            description: Images is a list of Kustomize image override
+                              specifications
+                            items:
+                              description: KustomizeImage represents a Kustomize image
+                                definition in the format [old_image_name=]<image_name>:<image_tag>
+                              type: string
+                            type: array
+                          namePrefix:
+                            description: NamePrefix is a prefix appended to resources
+                              for Kustomize apps
+                            type: string
+                          nameSuffix:
+                            description: NameSuffix is a suffix appended to resources
+                              for Kustomize apps
+                            type: string
+                          version:
+                            description: Version controls which version of Kustomize
+                              to use for rendering manifests
+                            type: string
+                        type: object
+                      path:
+                        description: Path is a directory path within the Git repository,
+                          and is only valid for applications sourced from Git.
+                        type: string
+                      plugin:
+                        description: Plugin holds config management plugin specific
+                          options
+                        properties:
+                          env:
+                            description: Env is a list of environment variable entries
+                            items:
+                              description: EnvEntry represents an entry in the application's
+                                environment
+                              properties:
+                                name:
+                                  description: Name is the name of the variable, usually
+                                    expressed in uppercase
+                                  type: string
+                                value:
+                                  description: Value is the value of the variable
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                        type: object
+                      repoURL:
+                        description: RepoURL is the URL to the repository (Git or
+                          Helm) that contains the application manifests
+                        type: string
+                      targetRevision:
+                        description: TargetRevision defines the revision of the source
+                          to sync the application to. In case of Git, this can be
+                          commit, tag, or branch. If omitted, will equal to HEAD.
+                          In case of Helm, this is a semver tag for the Chart's version.
+                        type: string
+                    required:
+                    - repoURL
+                    type: object
+                  syncOptions:
+                    description: SyncOptions provide per-sync sync-options, e.g. Validate=false
+                    items:
+                      type: string
+                    type: array
+                  syncStrategy:
+                    description: SyncStrategy describes how to perform the sync
+                    properties:
+                      apply:
+                        description: Apply will perform a `kubectl apply` to perform
+                          the sync.
+                        properties:
+                          force:
+                            description: Force indicates whether or not to supply
+                              the --force flag to `kubectl apply`. The --force flag
+                              deletes and re-create the resource, when PATCH encounters
+                              conflict and has retried for 5 times.
+                            type: boolean
+                        type: object
+                      hook:
+                        description: Hook will submit any referenced resources to
+                          perform the sync. This is the default strategy
+                        properties:
+                          force:
+                            description: Force indicates whether or not to supply
+                              the --force flag to `kubectl apply`. The --force flag
+                              deletes and re-create the resource, when PATCH encounters
+                              conflict and has retried for 5 times.
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
+            type: object
+          spec:
+            description: ApplicationSpec represents desired application state. Contains
+              link to repository with application definition and additional parameters
+              link definition revision.
+            properties:
+              destination:
+                description: Destination is a reference to the target Kubernetes server
+                  and namespace
+                properties:
+                  name:
+                    description: Name is an alternate way of specifying the target
+                      cluster by its symbolic name
+                    type: string
+                  namespace:
+                    description: Namespace specifies the target namespace for the
+                      application's resources. The namespace will only be set for
+                      namespace-scoped resources that have not set a value for .metadata.namespace
+                    type: string
+                  server:
+                    description: Server specifies the URL of the target cluster and
+                      must be set to the Kubernetes control plane API
+                    type: string
+                type: object
+              ignoreDifferences:
+                description: IgnoreDifferences is a list of resources and their fields
+                  which should be ignored during comparison
+                items:
+                  description: ResourceIgnoreDifferences contains resource filter
+                    and list of json paths which should be ignored during comparison
+                    with live state.
+                  properties:
+                    group:
+                      type: string
+                    jqPathExpressions:
+                      items:
+                        type: string
+                      type: array
+                    jsonPointers:
+                      items:
+                        type: string
+                      type: array
+                    kind:
+                      type: string
+                    managedFieldsManagers:
+                      description: ManagedFieldsManagers is a list of trusted managers.
+                        Fields mutated by those managers will take precedence over
+                        the desired state defined in the SCM and won't be displayed
+                        in diffs
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - kind
+                  type: object
+                type: array
+              info:
+                description: Info contains a list of information (URLs, email addresses,
+                  and plain text) that relates to the application
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              project:
+                description: Project is a reference to the project this application
+                  belongs to. The empty string means that application belongs to the
+                  'default' project.
+                type: string
+              revisionHistoryLimit:
+                description: RevisionHistoryLimit limits the number of items kept
+                  in the application's revision history, which is used for informational
+                  purposes as well as for rollbacks to previous versions. This should
+                  only be changed in exceptional circumstances. Setting to zero will
+                  store no history. This will reduce storage used. Increasing will
+                  increase the space used to store the history, so we do not recommend
+                  increasing it. Default is 10.
+                format: int64
+                type: integer
+              source:
+                description: Source is a reference to the location of the application's
+                  manifests or chart
+                properties:
+                  chart:
+                    description: Chart is a Helm chart name, and must be specified
+                      for applications sourced from a Helm repo.
+                    type: string
+                  directory:
+                    description: Directory holds path/directory specific options
+                    properties:
+                      exclude:
+                        description: Exclude contains a glob pattern to match paths
+                          against that should be explicitly excluded from being used
+                          during manifest generation
+                        type: string
+                      include:
+                        description: Include contains a glob pattern to match paths
+                          against that should be explicitly included during manifest
+                          generation
+                        type: string
+                      jsonnet:
+                        description: Jsonnet holds options specific to Jsonnet
+                        properties:
+                          extVars:
+                            description: ExtVars is a list of Jsonnet External Variables
+                            items:
+                              description: JsonnetVar represents a variable to be
+                                passed to jsonnet during manifest generation
+                              properties:
+                                code:
+                                  type: boolean
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          libs:
+                            description: Additional library search dirs
+                            items:
+                              type: string
+                            type: array
+                          tlas:
+                            description: TLAS is a list of Jsonnet Top-level Arguments
+                            items:
+                              description: JsonnetVar represents a variable to be
+                                passed to jsonnet during manifest generation
+                              properties:
+                                code:
+                                  type: boolean
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
+                      recurse:
+                        description: Recurse specifies whether to scan a directory
+                          recursively for manifests
+                        type: boolean
+                    type: object
+                  helm:
+                    description: Helm holds helm specific options
+                    properties:
+                      fileParameters:
+                        description: FileParameters are file parameters to the helm
+                          template
+                        items:
+                          description: HelmFileParameter is a file parameter that's
+                            passed to helm template during manifest generation
+                          properties:
+                            name:
+                              description: Name is the name of the Helm parameter
+                              type: string
+                            path:
+                              description: Path is the path to the file containing
+                                the values for the Helm parameter
+                              type: string
+                          type: object
+                        type: array
+                      ignoreMissingValueFiles:
+                        description: IgnoreMissingValueFiles prevents helm template
+                          from failing when valueFiles do not exist locally by not
+                          appending them to helm template --values
+                        type: boolean
+                      parameters:
+                        description: Parameters is a list of Helm parameters which
+                          are passed to the helm template command upon manifest generation
+                        items:
+                          description: HelmParameter is a parameter that's passed
+                            to helm template during manifest generation
+                          properties:
+                            forceString:
+                              description: ForceString determines whether to tell
+                                Helm to interpret booleans and numbers as strings
+                              type: boolean
+                            name:
+                              description: Name is the name of the Helm parameter
+                              type: string
+                            value:
+                              description: Value is the value for the Helm parameter
+                              type: string
+                          type: object
+                        type: array
+                      passCredentials:
+                        description: PassCredentials pass credentials to all domains
+                          (Helm's --pass-credentials)
+                        type: boolean
+                      releaseName:
+                        description: ReleaseName is the Helm release name to use.
+                          If omitted it will use the application name
+                        type: string
+                      skipCrds:
+                        description: SkipCrds skips custom resource definition installation
+                          step (Helm's --skip-crds)
+                        type: boolean
+                      valueFiles:
+                        description: ValuesFiles is a list of Helm value files to
+                          use when generating a template
+                        items:
+                          type: string
+                        type: array
+                      values:
+                        description: Values specifies Helm values to be passed to
+                          helm template, typically defined as a block
+                        type: string
+                      version:
+                        description: Version is the Helm version to use for templating
+                          ("3")
+                        type: string
+                    type: object
+                  kustomize:
+                    description: Kustomize holds kustomize specific options
+                    properties:
+                      commonAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: CommonAnnotations is a list of additional annotations
+                          to add to rendered manifests
+                        type: object
+                      commonLabels:
+                        additionalProperties:
+                          type: string
+                        description: CommonLabels is a list of additional labels to
+                          add to rendered manifests
+                        type: object
+                      forceCommonAnnotations:
+                        description: ForceCommonAnnotations specifies whether to force
+                          applying common annotations to resources for Kustomize apps
+                        type: boolean
+                      forceCommonLabels:
+                        description: ForceCommonLabels specifies whether to force
+                          applying common labels to resources for Kustomize apps
+                        type: boolean
+                      images:
+                        description: Images is a list of Kustomize image override
+                          specifications
+                        items:
+                          description: KustomizeImage represents a Kustomize image
+                            definition in the format [old_image_name=]<image_name>:<image_tag>
+                          type: string
+                        type: array
+                      namePrefix:
+                        description: NamePrefix is a prefix appended to resources
+                          for Kustomize apps
+                        type: string
+                      nameSuffix:
+                        description: NameSuffix is a suffix appended to resources
+                          for Kustomize apps
+                        type: string
+                      version:
+                        description: Version controls which version of Kustomize to
+                          use for rendering manifests
+                        type: string
+                    type: object
+                  path:
+                    description: Path is a directory path within the Git repository,
+                      and is only valid for applications sourced from Git.
+                    type: string
+                  plugin:
+                    description: Plugin holds config management plugin specific options
+                    properties:
+                      env:
+                        description: Env is a list of environment variable entries
+                        items:
+                          description: EnvEntry represents an entry in the application's
+                            environment
+                          properties:
+                            name:
+                              description: Name is the name of the variable, usually
+                                expressed in uppercase
+                              type: string
+                            value:
+                              description: Value is the value of the variable
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      name:
+                        type: string
+                    type: object
+                  repoURL:
+                    description: RepoURL is the URL to the repository (Git or Helm)
+                      that contains the application manifests
+                    type: string
+                  targetRevision:
+                    description: TargetRevision defines the revision of the source
+                      to sync the application to. In case of Git, this can be commit,
+                      tag, or branch. If omitted, will equal to HEAD. In case of Helm,
+                      this is a semver tag for the Chart's version.
+                    type: string
+                required:
+                - repoURL
+                type: object
+              syncPolicy:
+                description: SyncPolicy controls when and how a sync will be performed
+                properties:
+                  automated:
+                    description: Automated will keep an application synced to the
+                      target revision
+                    properties:
+                      allowEmpty:
+                        description: 'AllowEmpty allows apps have zero live resources
+                          (default: false)'
+                        type: boolean
+                      prune:
+                        description: 'Prune specifies whether to delete resources
+                          from the cluster that are not found in the sources anymore
+                          as part of automated sync (default: false)'
+                        type: boolean
+                      selfHeal:
+                        description: 'SelfHeal specifes whether to revert resources
+                          back to their desired state upon modification in the cluster
+                          (default: false)'
+                        type: boolean
+                    type: object
+                  retry:
+                    description: Retry controls failed sync retry behavior
+                    properties:
+                      backoff:
+                        description: Backoff controls how to backoff on subsequent
+                          retries of failed syncs
+                        properties:
+                          duration:
+                            description: Duration is the amount to back off. Default
+                              unit is seconds, but could also be a duration (e.g.
+                              "2m", "1h")
+                            type: string
+                          factor:
+                            description: Factor is a factor to multiply the base duration
+                              after each failed retry
+                            format: int64
+                            type: integer
+                          maxDuration:
+                            description: MaxDuration is the maximum amount of time
+                              allowed for the backoff strategy
+                            type: string
+                        type: object
+                      limit:
+                        description: Limit is the maximum number of attempts for retrying
+                          a failed sync. If set to 0, no retries will be performed.
+                        format: int64
+                        type: integer
+                    type: object
+                  syncOptions:
+                    description: Options allow you to specify whole app sync-options
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - destination
+            - project
+            - source
+            type: object
+          status:
+            description: ApplicationStatus contains status information for the application
+            properties:
+              conditions:
+                description: Conditions is a list of currently observed application
+                  conditions
+                items:
+                  description: ApplicationCondition contains details about an application
+                    condition, which is usally an error or warning
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the time the condition was
+                        last observed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message contains human-readable message indicating
+                        details about condition
+                      type: string
+                    type:
+                      description: Type is an application condition type
+                      type: string
+                  required:
+                  - message
+                  - type
+                  type: object
+                type: array
+              health:
+                description: Health contains information about the application's current
+                  health status
+                properties:
+                  message:
+                    description: Message is a human-readable informational message
+                      describing the health status
+                    type: string
+                  status:
+                    description: Status holds the status code of the application or
+                      resource
+                    type: string
+                type: object
+              history:
+                description: History contains information about the application's
+                  sync history
+                items:
+                  description: RevisionHistory contains history information about
+                    a previous sync
+                  properties:
+                    deployStartedAt:
+                      description: DeployStartedAt holds the time the sync operation
+                        started
+                      format: date-time
+                      type: string
+                    deployedAt:
+                      description: DeployedAt holds the time the sync operation completed
+                      format: date-time
+                      type: string
+                    id:
+                      description: ID is an auto incrementing identifier of the RevisionHistory
+                      format: int64
+                      type: integer
+                    revision:
+                      description: Revision holds the revision the sync was performed
+                        against
+                      type: string
+                    source:
+                      description: Source is a reference to the application source
+                        used for the sync operation
+                      properties:
+                        chart:
+                          description: Chart is a Helm chart name, and must be specified
+                            for applications sourced from a Helm repo.
+                          type: string
+                        directory:
+                          description: Directory holds path/directory specific options
+                          properties:
+                            exclude:
+                              description: Exclude contains a glob pattern to match
+                                paths against that should be explicitly excluded from
+                                being used during manifest generation
+                              type: string
+                            include:
+                              description: Include contains a glob pattern to match
+                                paths against that should be explicitly included during
+                                manifest generation
+                              type: string
+                            jsonnet:
+                              description: Jsonnet holds options specific to Jsonnet
+                              properties:
+                                extVars:
+                                  description: ExtVars is a list of Jsonnet External
+                                    Variables
+                                  items:
+                                    description: JsonnetVar represents a variable
+                                      to be passed to jsonnet during manifest generation
+                                    properties:
+                                      code:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                libs:
+                                  description: Additional library search dirs
+                                  items:
+                                    type: string
+                                  type: array
+                                tlas:
+                                  description: TLAS is a list of Jsonnet Top-level
+                                    Arguments
+                                  items:
+                                    description: JsonnetVar represents a variable
+                                      to be passed to jsonnet during manifest generation
+                                    properties:
+                                      code:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                              type: object
+                            recurse:
+                              description: Recurse specifies whether to scan a directory
+                                recursively for manifests
+                              type: boolean
+                          type: object
+                        helm:
+                          description: Helm holds helm specific options
+                          properties:
+                            fileParameters:
+                              description: FileParameters are file parameters to the
+                                helm template
+                              items:
+                                description: HelmFileParameter is a file parameter
+                                  that's passed to helm template during manifest generation
+                                properties:
+                                  name:
+                                    description: Name is the name of the Helm parameter
+                                    type: string
+                                  path:
+                                    description: Path is the path to the file containing
+                                      the values for the Helm parameter
+                                    type: string
+                                type: object
+                              type: array
+                            ignoreMissingValueFiles:
+                              description: IgnoreMissingValueFiles prevents helm template
+                                from failing when valueFiles do not exist locally
+                                by not appending them to helm template --values
+                              type: boolean
+                            parameters:
+                              description: Parameters is a list of Helm parameters
+                                which are passed to the helm template command upon
+                                manifest generation
+                              items:
+                                description: HelmParameter is a parameter that's passed
+                                  to helm template during manifest generation
+                                properties:
+                                  forceString:
+                                    description: ForceString determines whether to
+                                      tell Helm to interpret booleans and numbers
+                                      as strings
+                                    type: boolean
+                                  name:
+                                    description: Name is the name of the Helm parameter
+                                    type: string
+                                  value:
+                                    description: Value is the value for the Helm parameter
+                                    type: string
+                                type: object
+                              type: array
+                            passCredentials:
+                              description: PassCredentials pass credentials to all
+                                domains (Helm's --pass-credentials)
+                              type: boolean
+                            releaseName:
+                              description: ReleaseName is the Helm release name to
+                                use. If omitted it will use the application name
+                              type: string
+                            skipCrds:
+                              description: SkipCrds skips custom resource definition
+                                installation step (Helm's --skip-crds)
+                              type: boolean
+                            valueFiles:
+                              description: ValuesFiles is a list of Helm value files
+                                to use when generating a template
+                              items:
+                                type: string
+                              type: array
+                            values:
+                              description: Values specifies Helm values to be passed
+                                to helm template, typically defined as a block
+                              type: string
+                            version:
+                              description: Version is the Helm version to use for
+                                templating ("3")
+                              type: string
+                          type: object
+                        kustomize:
+                          description: Kustomize holds kustomize specific options
+                          properties:
+                            commonAnnotations:
+                              additionalProperties:
+                                type: string
+                              description: CommonAnnotations is a list of additional
+                                annotations to add to rendered manifests
+                              type: object
+                            commonLabels:
+                              additionalProperties:
+                                type: string
+                              description: CommonLabels is a list of additional labels
+                                to add to rendered manifests
+                              type: object
+                            forceCommonAnnotations:
+                              description: ForceCommonAnnotations specifies whether
+                                to force applying common annotations to resources
+                                for Kustomize apps
+                              type: boolean
+                            forceCommonLabels:
+                              description: ForceCommonLabels specifies whether to
+                                force applying common labels to resources for Kustomize
+                                apps
+                              type: boolean
+                            images:
+                              description: Images is a list of Kustomize image override
+                                specifications
+                              items:
+                                description: KustomizeImage represents a Kustomize
+                                  image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                type: string
+                              type: array
+                            namePrefix:
+                              description: NamePrefix is a prefix appended to resources
+                                for Kustomize apps
+                              type: string
+                            nameSuffix:
+                              description: NameSuffix is a suffix appended to resources
+                                for Kustomize apps
+                              type: string
+                            version:
+                              description: Version controls which version of Kustomize
+                                to use for rendering manifests
+                              type: string
+                          type: object
+                        path:
+                          description: Path is a directory path within the Git repository,
+                            and is only valid for applications sourced from Git.
+                          type: string
+                        plugin:
+                          description: Plugin holds config management plugin specific
+                            options
+                          properties:
+                            env:
+                              description: Env is a list of environment variable entries
+                              items:
+                                description: EnvEntry represents an entry in the application's
+                                  environment
+                                properties:
+                                  name:
+                                    description: Name is the name of the variable,
+                                      usually expressed in uppercase
+                                    type: string
+                                  value:
+                                    description: Value is the value of the variable
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            name:
+                              type: string
+                          type: object
+                        repoURL:
+                          description: RepoURL is the URL to the repository (Git or
+                            Helm) that contains the application manifests
+                          type: string
+                        targetRevision:
+                          description: TargetRevision defines the revision of the
+                            source to sync the application to. In case of Git, this
+                            can be commit, tag, or branch. If omitted, will equal
+                            to HEAD. In case of Helm, this is a semver tag for the
+                            Chart's version.
+                          type: string
+                      required:
+                      - repoURL
+                      type: object
+                  required:
+                  - deployedAt
+                  - id
+                  - revision
+                  type: object
+                type: array
+              observedAt:
+                description: 'ObservedAt indicates when the application state was
+                  updated without querying latest git state Deprecated: controller
+                  no longer updates ObservedAt field'
+                format: date-time
+                type: string
+              operationState:
+                description: OperationState contains information about any ongoing
+                  operations, such as a sync
+                properties:
+                  finishedAt:
+                    description: FinishedAt contains time of operation completion
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message holds any pertinent messages when attempting
+                      to perform operation (typically errors).
+                    type: string
+                  operation:
+                    description: Operation is the original requested operation
+                    properties:
+                      info:
+                        description: Info is a list of informational items for this
+                          operation
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      initiatedBy:
+                        description: InitiatedBy contains information about who initiated
+                          the operations
+                        properties:
+                          automated:
+                            description: Automated is set to true if operation was
+                              initiated automatically by the application controller.
+                            type: boolean
+                          username:
+                            description: Username contains the name of a user who
+                              started operation
+                            type: string
+                        type: object
+                      retry:
+                        description: Retry controls the strategy to apply if a sync
+                          fails
+                        properties:
+                          backoff:
+                            description: Backoff controls how to backoff on subsequent
+                              retries of failed syncs
+                            properties:
+                              duration:
+                                description: Duration is the amount to back off. Default
+                                  unit is seconds, but could also be a duration (e.g.
+                                  "2m", "1h")
+                                type: string
+                              factor:
+                                description: Factor is a factor to multiply the base
+                                  duration after each failed retry
+                                format: int64
+                                type: integer
+                              maxDuration:
+                                description: MaxDuration is the maximum amount of
+                                  time allowed for the backoff strategy
+                                type: string
+                            type: object
+                          limit:
+                            description: Limit is the maximum number of attempts for
+                              retrying a failed sync. If set to 0, no retries will
+                              be performed.
+                            format: int64
+                            type: integer
+                        type: object
+                      sync:
+                        description: Sync contains parameters for the operation
+                        properties:
+                          dryRun:
+                            description: DryRun specifies to perform a `kubectl apply
+                              --dry-run` without actually performing the sync
+                            type: boolean
+                          manifests:
+                            description: Manifests is an optional field that overrides
+                              sync source with a local directory for development
+                            items:
+                              type: string
+                            type: array
+                          prune:
+                            description: Prune specifies to delete resources from
+                              the cluster that are no longer tracked in git
+                            type: boolean
+                          resources:
+                            description: Resources describes which resources shall
+                              be part of the sync
+                            items:
+                              description: SyncOperationResource contains resources
+                                to sync.
+                              properties:
+                                group:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            type: array
+                          revision:
+                            description: Revision is the revision (Git) or chart version
+                              (Helm) which to sync the application to If omitted,
+                              will use the revision specified in app spec.
+                            type: string
+                          source:
+                            description: Source overrides the source definition set
+                              in the application. This is typically set in a Rollback
+                              operation and is nil during a Sync operation
+                            properties:
+                              chart:
+                                description: Chart is a Helm chart name, and must
+                                  be specified for applications sourced from a Helm
+                                  repo.
+                                type: string
+                              directory:
+                                description: Directory holds path/directory specific
+                                  options
+                                properties:
+                                  exclude:
+                                    description: Exclude contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      excluded from being used during manifest generation
+                                    type: string
+                                  include:
+                                    description: Include contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      included during manifest generation
+                                    type: string
+                                  jsonnet:
+                                    description: Jsonnet holds options specific to
+                                      Jsonnet
+                                    properties:
+                                      extVars:
+                                        description: ExtVars is a list of Jsonnet
+                                          External Variables
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        description: Additional library search dirs
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        description: TLAS is a list of Jsonnet Top-level
+                                          Arguments
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    description: Recurse specifies whether to scan
+                                      a directory recursively for manifests
+                                    type: boolean
+                                type: object
+                              helm:
+                                description: Helm holds helm specific options
+                                properties:
+                                  fileParameters:
+                                    description: FileParameters are file parameters
+                                      to the helm template
+                                    items:
+                                      description: HelmFileParameter is a file parameter
+                                        that's passed to helm template during manifest
+                                        generation
+                                      properties:
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        path:
+                                          description: Path is the path to the file
+                                            containing the values for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  ignoreMissingValueFiles:
+                                    description: IgnoreMissingValueFiles prevents
+                                      helm template from failing when valueFiles do
+                                      not exist locally by not appending them to helm
+                                      template --values
+                                    type: boolean
+                                  parameters:
+                                    description: Parameters is a list of Helm parameters
+                                      which are passed to the helm template command
+                                      upon manifest generation
+                                    items:
+                                      description: HelmParameter is a parameter that's
+                                        passed to helm template during manifest generation
+                                      properties:
+                                        forceString:
+                                          description: ForceString determines whether
+                                            to tell Helm to interpret booleans and
+                                            numbers as strings
+                                          type: boolean
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        value:
+                                          description: Value is the value for the
+                                            Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  passCredentials:
+                                    description: PassCredentials pass credentials
+                                      to all domains (Helm's --pass-credentials)
+                                    type: boolean
+                                  releaseName:
+                                    description: ReleaseName is the Helm release name
+                                      to use. If omitted it will use the application
+                                      name
+                                    type: string
+                                  skipCrds:
+                                    description: SkipCrds skips custom resource definition
+                                      installation step (Helm's --skip-crds)
+                                    type: boolean
+                                  valueFiles:
+                                    description: ValuesFiles is a list of Helm value
+                                      files to use when generating a template
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    description: Values specifies Helm values to be
+                                      passed to helm template, typically defined as
+                                      a block
+                                    type: string
+                                  version:
+                                    description: Version is the Helm version to use
+                                      for templating ("3")
+                                    type: string
+                                type: object
+                              kustomize:
+                                description: Kustomize holds kustomize specific options
+                                properties:
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonAnnotations is a list of additional
+                                      annotations to add to rendered manifests
+                                    type: object
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels is a list of additional
+                                      labels to add to rendered manifests
+                                    type: object
+                                  forceCommonAnnotations:
+                                    description: ForceCommonAnnotations specifies
+                                      whether to force applying common annotations
+                                      to resources for Kustomize apps
+                                    type: boolean
+                                  forceCommonLabels:
+                                    description: ForceCommonLabels specifies whether
+                                      to force applying common labels to resources
+                                      for Kustomize apps
+                                    type: boolean
+                                  images:
+                                    description: Images is a list of Kustomize image
+                                      override specifications
+                                    items:
+                                      description: KustomizeImage represents a Kustomize
+                                        image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                      type: string
+                                    type: array
+                                  namePrefix:
+                                    description: NamePrefix is a prefix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  nameSuffix:
+                                    description: NameSuffix is a suffix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  version:
+                                    description: Version controls which version of
+                                      Kustomize to use for rendering manifests
+                                    type: string
+                                type: object
+                              path:
+                                description: Path is a directory path within the Git
+                                  repository, and is only valid for applications sourced
+                                  from Git.
+                                type: string
+                              plugin:
+                                description: Plugin holds config management plugin
+                                  specific options
+                                properties:
+                                  env:
+                                    description: Env is a list of environment variable
+                                      entries
+                                    items:
+                                      description: EnvEntry represents an entry in
+                                        the application's environment
+                                      properties:
+                                        name:
+                                          description: Name is the name of the variable,
+                                            usually expressed in uppercase
+                                          type: string
+                                        value:
+                                          description: Value is the value of the variable
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                type: object
+                              repoURL:
+                                description: RepoURL is the URL to the repository
+                                  (Git or Helm) that contains the application manifests
+                                type: string
+                              targetRevision:
+                                description: TargetRevision defines the revision of
+                                  the source to sync the application to. In case of
+                                  Git, this can be commit, tag, or branch. If omitted,
+                                  will equal to HEAD. In case of Helm, this is a semver
+                                  tag for the Chart's version.
+                                type: string
+                            required:
+                            - repoURL
+                            type: object
+                          syncOptions:
+                            description: SyncOptions provide per-sync sync-options,
+                              e.g. Validate=false
+                            items:
+                              type: string
+                            type: array
+                          syncStrategy:
+                            description: SyncStrategy describes how to perform the
+                              sync
+                            properties:
+                              apply:
+                                description: Apply will perform a `kubectl apply`
+                                  to perform the sync.
+                                properties:
+                                  force:
+                                    description: Force indicates whether or not to
+                                      supply the --force flag to `kubectl apply`.
+                                      The --force flag deletes and re-create the resource,
+                                      when PATCH encounters conflict and has retried
+                                      for 5 times.
+                                    type: boolean
+                                type: object
+                              hook:
+                                description: Hook will submit any referenced resources
+                                  to perform the sync. This is the default strategy
+                                properties:
+                                  force:
+                                    description: Force indicates whether or not to
+                                      supply the --force flag to `kubectl apply`.
+                                      The --force flag deletes and re-create the resource,
+                                      when PATCH encounters conflict and has retried
+                                      for 5 times.
+                                    type: boolean
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  phase:
+                    description: Phase is the current phase of the operation
+                    type: string
+                  retryCount:
+                    description: RetryCount contains time of operation retries
+                    format: int64
+                    type: integer
+                  startedAt:
+                    description: StartedAt contains time of operation start
+                    format: date-time
+                    type: string
+                  syncResult:
+                    description: SyncResult is the result of a Sync operation
+                    properties:
+                      resources:
+                        description: Resources contains a list of sync result items
+                          for each individual resource in a sync operation
+                        items:
+                          description: ResourceResult holds the operation result details
+                            of a specific resource
+                          properties:
+                            group:
+                              description: Group specifies the API group of the resource
+                              type: string
+                            hookPhase:
+                              description: HookPhase contains the state of any operation
+                                associated with this resource OR hook This can also
+                                contain values for non-hook resources.
+                              type: string
+                            hookType:
+                              description: HookType specifies the type of the hook.
+                                Empty for non-hook resources
+                              type: string
+                            kind:
+                              description: Kind specifies the API kind of the resource
+                              type: string
+                            message:
+                              description: Message contains an informational or error
+                                message for the last sync OR operation
+                              type: string
+                            name:
+                              description: Name specifies the name of the resource
+                              type: string
+                            namespace:
+                              description: Namespace specifies the target namespace
+                                of the resource
+                              type: string
+                            status:
+                              description: Status holds the final result of the sync.
+                                Will be empty if the resources is yet to be applied/pruned
+                                and is always zero-value for hooks
+                              type: string
+                            syncPhase:
+                              description: SyncPhase indicates the particular phase
+                                of the sync that this result was acquired in
+                              type: string
+                            version:
+                              description: Version specifies the API version of the
+                                resource
+                              type: string
+                          required:
+                          - group
+                          - kind
+                          - name
+                          - namespace
+                          - version
+                          type: object
+                        type: array
+                      revision:
+                        description: Revision holds the revision this sync operation
+                          was performed to
+                        type: string
+                      source:
+                        description: Source records the application source information
+                          of the sync, used for comparing auto-sync
+                        properties:
+                          chart:
+                            description: Chart is a Helm chart name, and must be specified
+                              for applications sourced from a Helm repo.
+                            type: string
+                          directory:
+                            description: Directory holds path/directory specific options
+                            properties:
+                              exclude:
+                                description: Exclude contains a glob pattern to match
+                                  paths against that should be explicitly excluded
+                                  from being used during manifest generation
+                                type: string
+                              include:
+                                description: Include contains a glob pattern to match
+                                  paths against that should be explicitly included
+                                  during manifest generation
+                                type: string
+                              jsonnet:
+                                description: Jsonnet holds options specific to Jsonnet
+                                properties:
+                                  extVars:
+                                    description: ExtVars is a list of Jsonnet External
+                                      Variables
+                                    items:
+                                      description: JsonnetVar represents a variable
+                                        to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  libs:
+                                    description: Additional library search dirs
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlas:
+                                    description: TLAS is a list of Jsonnet Top-level
+                                      Arguments
+                                    items:
+                                      description: JsonnetVar represents a variable
+                                        to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              recurse:
+                                description: Recurse specifies whether to scan a directory
+                                  recursively for manifests
+                                type: boolean
+                            type: object
+                          helm:
+                            description: Helm holds helm specific options
+                            properties:
+                              fileParameters:
+                                description: FileParameters are file parameters to
+                                  the helm template
+                                items:
+                                  description: HelmFileParameter is a file parameter
+                                    that's passed to helm template during manifest
+                                    generation
+                                  properties:
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    path:
+                                      description: Path is the path to the file containing
+                                        the values for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              ignoreMissingValueFiles:
+                                description: IgnoreMissingValueFiles prevents helm
+                                  template from failing when valueFiles do not exist
+                                  locally by not appending them to helm template --values
+                                type: boolean
+                              parameters:
+                                description: Parameters is a list of Helm parameters
+                                  which are passed to the helm template command upon
+                                  manifest generation
+                                items:
+                                  description: HelmParameter is a parameter that's
+                                    passed to helm template during manifest generation
+                                  properties:
+                                    forceString:
+                                      description: ForceString determines whether
+                                        to tell Helm to interpret booleans and numbers
+                                        as strings
+                                      type: boolean
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    value:
+                                      description: Value is the value for the Helm
+                                        parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              passCredentials:
+                                description: PassCredentials pass credentials to all
+                                  domains (Helm's --pass-credentials)
+                                type: boolean
+                              releaseName:
+                                description: ReleaseName is the Helm release name
+                                  to use. If omitted it will use the application name
+                                type: string
+                              skipCrds:
+                                description: SkipCrds skips custom resource definition
+                                  installation step (Helm's --skip-crds)
+                                type: boolean
+                              valueFiles:
+                                description: ValuesFiles is a list of Helm value files
+                                  to use when generating a template
+                                items:
+                                  type: string
+                                type: array
+                              values:
+                                description: Values specifies Helm values to be passed
+                                  to helm template, typically defined as a block
+                                type: string
+                              version:
+                                description: Version is the Helm version to use for
+                                  templating ("3")
+                                type: string
+                            type: object
+                          kustomize:
+                            description: Kustomize holds kustomize specific options
+                            properties:
+                              commonAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: CommonAnnotations is a list of additional
+                                  annotations to add to rendered manifests
+                                type: object
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels is a list of additional
+                                  labels to add to rendered manifests
+                                type: object
+                              forceCommonAnnotations:
+                                description: ForceCommonAnnotations specifies whether
+                                  to force applying common annotations to resources
+                                  for Kustomize apps
+                                type: boolean
+                              forceCommonLabels:
+                                description: ForceCommonLabels specifies whether to
+                                  force applying common labels to resources for Kustomize
+                                  apps
+                                type: boolean
+                              images:
+                                description: Images is a list of Kustomize image override
+                                  specifications
+                                items:
+                                  description: KustomizeImage represents a Kustomize
+                                    image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                  type: string
+                                type: array
+                              namePrefix:
+                                description: NamePrefix is a prefix appended to resources
+                                  for Kustomize apps
+                                type: string
+                              nameSuffix:
+                                description: NameSuffix is a suffix appended to resources
+                                  for Kustomize apps
+                                type: string
+                              version:
+                                description: Version controls which version of Kustomize
+                                  to use for rendering manifests
+                                type: string
+                            type: object
+                          path:
+                            description: Path is a directory path within the Git repository,
+                              and is only valid for applications sourced from Git.
+                            type: string
+                          plugin:
+                            description: Plugin holds config management plugin specific
+                              options
+                            properties:
+                              env:
+                                description: Env is a list of environment variable
+                                  entries
+                                items:
+                                  description: EnvEntry represents an entry in the
+                                    application's environment
+                                  properties:
+                                    name:
+                                      description: Name is the name of the variable,
+                                        usually expressed in uppercase
+                                      type: string
+                                    value:
+                                      description: Value is the value of the variable
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          repoURL:
+                            description: RepoURL is the URL to the repository (Git
+                              or Helm) that contains the application manifests
+                            type: string
+                          targetRevision:
+                            description: TargetRevision defines the revision of the
+                              source to sync the application to. In case of Git, this
+                              can be commit, tag, or branch. If omitted, will equal
+                              to HEAD. In case of Helm, this is a semver tag for the
+                              Chart's version.
+                            type: string
+                        required:
+                        - repoURL
+                        type: object
+                    required:
+                    - revision
+                    type: object
+                required:
+                - operation
+                - phase
+                - startedAt
+                type: object
+              reconciledAt:
+                description: ReconciledAt indicates when the application state was
+                  reconciled using the latest git version
+                format: date-time
+                type: string
+              resourceHealthSource:
+                description: 'ResourceHealthSource indicates where the resource health
+                  status is stored: inline if not set or appTree'
+                type: string
+              resources:
+                description: Resources is a list of Kubernetes resources managed by
+                  this application
+                items:
+                  description: 'ResourceStatus holds the current sync and health status
+                    of a resource TODO: describe members of this type'
+                  properties:
+                    group:
+                      type: string
+                    health:
+                      description: HealthStatus contains information about the currently
+                        observed health state of an application or resource
+                      properties:
+                        message:
+                          description: Message is a human-readable informational message
+                            describing the health status
+                          type: string
+                        status:
+                          description: Status holds the status code of the application
+                            or resource
+                          type: string
+                      type: object
+                    hook:
+                      type: boolean
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    requiresPruning:
+                      type: boolean
+                    status:
+                      description: SyncStatusCode is a type which represents possible
+                        comparison results
+                      type: string
+                    syncWave:
+                      format: int64
+                      type: integer
+                    version:
+                      type: string
+                  type: object
+                type: array
+              sourceType:
+                description: SourceType specifies the type of this application
+                type: string
+              summary:
+                description: Summary contains a list of URLs and container images
+                  used by this application
+                properties:
+                  externalURLs:
+                    description: ExternalURLs holds all external URLs of application
+                      child resources.
+                    items:
+                      type: string
+                    type: array
+                  images:
+                    description: Images holds all images of application child resources.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              sync:
+                description: Sync contains information about the application's current
+                  sync status
+                properties:
+                  comparedTo:
+                    description: ComparedTo contains information about what has been
+                      compared
+                    properties:
+                      destination:
+                        description: Destination is a reference to the application's
+                          destination used for comparison
+                        properties:
+                          name:
+                            description: Name is an alternate way of specifying the
+                              target cluster by its symbolic name
+                            type: string
+                          namespace:
+                            description: Namespace specifies the target namespace
+                              for the application's resources. The namespace will
+                              only be set for namespace-scoped resources that have
+                              not set a value for .metadata.namespace
+                            type: string
+                          server:
+                            description: Server specifies the URL of the target cluster
+                              and must be set to the Kubernetes control plane API
+                            type: string
+                        type: object
+                      source:
+                        description: Source is a reference to the application's source
+                          used for comparison
+                        properties:
+                          chart:
+                            description: Chart is a Helm chart name, and must be specified
+                              for applications sourced from a Helm repo.
+                            type: string
+                          directory:
+                            description: Directory holds path/directory specific options
+                            properties:
+                              exclude:
+                                description: Exclude contains a glob pattern to match
+                                  paths against that should be explicitly excluded
+                                  from being used during manifest generation
+                                type: string
+                              include:
+                                description: Include contains a glob pattern to match
+                                  paths against that should be explicitly included
+                                  during manifest generation
+                                type: string
+                              jsonnet:
+                                description: Jsonnet holds options specific to Jsonnet
+                                properties:
+                                  extVars:
+                                    description: ExtVars is a list of Jsonnet External
+                                      Variables
+                                    items:
+                                      description: JsonnetVar represents a variable
+                                        to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  libs:
+                                    description: Additional library search dirs
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlas:
+                                    description: TLAS is a list of Jsonnet Top-level
+                                      Arguments
+                                    items:
+                                      description: JsonnetVar represents a variable
+                                        to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              recurse:
+                                description: Recurse specifies whether to scan a directory
+                                  recursively for manifests
+                                type: boolean
+                            type: object
+                          helm:
+                            description: Helm holds helm specific options
+                            properties:
+                              fileParameters:
+                                description: FileParameters are file parameters to
+                                  the helm template
+                                items:
+                                  description: HelmFileParameter is a file parameter
+                                    that's passed to helm template during manifest
+                                    generation
+                                  properties:
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    path:
+                                      description: Path is the path to the file containing
+                                        the values for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              ignoreMissingValueFiles:
+                                description: IgnoreMissingValueFiles prevents helm
+                                  template from failing when valueFiles do not exist
+                                  locally by not appending them to helm template --values
+                                type: boolean
+                              parameters:
+                                description: Parameters is a list of Helm parameters
+                                  which are passed to the helm template command upon
+                                  manifest generation
+                                items:
+                                  description: HelmParameter is a parameter that's
+                                    passed to helm template during manifest generation
+                                  properties:
+                                    forceString:
+                                      description: ForceString determines whether
+                                        to tell Helm to interpret booleans and numbers
+                                        as strings
+                                      type: boolean
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    value:
+                                      description: Value is the value for the Helm
+                                        parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              passCredentials:
+                                description: PassCredentials pass credentials to all
+                                  domains (Helm's --pass-credentials)
+                                type: boolean
+                              releaseName:
+                                description: ReleaseName is the Helm release name
+                                  to use. If omitted it will use the application name
+                                type: string
+                              skipCrds:
+                                description: SkipCrds skips custom resource definition
+                                  installation step (Helm's --skip-crds)
+                                type: boolean
+                              valueFiles:
+                                description: ValuesFiles is a list of Helm value files
+                                  to use when generating a template
+                                items:
+                                  type: string
+                                type: array
+                              values:
+                                description: Values specifies Helm values to be passed
+                                  to helm template, typically defined as a block
+                                type: string
+                              version:
+                                description: Version is the Helm version to use for
+                                  templating ("3")
+                                type: string
+                            type: object
+                          kustomize:
+                            description: Kustomize holds kustomize specific options
+                            properties:
+                              commonAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: CommonAnnotations is a list of additional
+                                  annotations to add to rendered manifests
+                                type: object
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels is a list of additional
+                                  labels to add to rendered manifests
+                                type: object
+                              forceCommonAnnotations:
+                                description: ForceCommonAnnotations specifies whether
+                                  to force applying common annotations to resources
+                                  for Kustomize apps
+                                type: boolean
+                              forceCommonLabels:
+                                description: ForceCommonLabels specifies whether to
+                                  force applying common labels to resources for Kustomize
+                                  apps
+                                type: boolean
+                              images:
+                                description: Images is a list of Kustomize image override
+                                  specifications
+                                items:
+                                  description: KustomizeImage represents a Kustomize
+                                    image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                  type: string
+                                type: array
+                              namePrefix:
+                                description: NamePrefix is a prefix appended to resources
+                                  for Kustomize apps
+                                type: string
+                              nameSuffix:
+                                description: NameSuffix is a suffix appended to resources
+                                  for Kustomize apps
+                                type: string
+                              version:
+                                description: Version controls which version of Kustomize
+                                  to use for rendering manifests
+                                type: string
+                            type: object
+                          path:
+                            description: Path is a directory path within the Git repository,
+                              and is only valid for applications sourced from Git.
+                            type: string
+                          plugin:
+                            description: Plugin holds config management plugin specific
+                              options
+                            properties:
+                              env:
+                                description: Env is a list of environment variable
+                                  entries
+                                items:
+                                  description: EnvEntry represents an entry in the
+                                    application's environment
+                                  properties:
+                                    name:
+                                      description: Name is the name of the variable,
+                                        usually expressed in uppercase
+                                      type: string
+                                    value:
+                                      description: Value is the value of the variable
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          repoURL:
+                            description: RepoURL is the URL to the repository (Git
+                              or Helm) that contains the application manifests
+                            type: string
+                          targetRevision:
+                            description: TargetRevision defines the revision of the
+                              source to sync the application to. In case of Git, this
+                              can be commit, tag, or branch. If omitted, will equal
+                              to HEAD. In case of Helm, this is a semver tag for the
+                              Chart's version.
+                            type: string
+                        required:
+                        - repoURL
+                        type: object
+                    required:
+                    - destination
+                    - source
+                    type: object
+                  revision:
+                    description: Revision contains information about the revision
+                      the comparison has been performed to
+                    type: string
+                  status:
+                    description: Status is the sync state of the comparison
+                    type: string
+                required:
+                - status
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/hack/crds/managedcluster-crd.yaml
+++ b/hack/crds/managedcluster-crd.yaml
@@ -1,0 +1,204 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: managedclusters.cluster.open-cluster-management.io
+spec:
+  group: cluster.open-cluster-management.io
+  names:
+    kind: ManagedCluster
+    listKind: ManagedClusterList
+    plural: managedclusters
+    shortNames:
+      - mcl
+      - mcls
+    singular: managedcluster
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.hubAcceptsClient
+          name: Hub Accepted
+          type: boolean
+        - jsonPath: .spec.managedClusterClientConfigs[*].url
+          name: Managed Cluster URLs
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="ManagedClusterJoined")].status
+          name: Joined
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="ManagedClusterConditionAvailable")].status
+          name: Available
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: "ManagedCluster represents the desired state and current status of managed cluster. ManagedCluster is a cluster scoped resource. The name is the cluster UID. \n The cluster join process follows a double opt-in process: \n 1. Agent on managed cluster creates CSR on hub with cluster UID and agent name. 2. Agent on managed cluster creates ManagedCluster on hub. 3. Cluster admin on hub approves the CSR for UID and agent name of the ManagedCluster. 4. Cluster admin sets spec.acceptClient of ManagedCluster to true. 5. Cluster admin on managed cluster creates credential of kubeconfig to hub. \n Once the hub creates the cluster namespace, the Klusterlet agent on the ManagedCluster pushes the credential to the hub to use against the kube-apiserver of the ManagedCluster."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec represents a desired configuration for the agent on the managed cluster.
+              type: object
+              properties:
+                hubAcceptsClient:
+                  description: hubAcceptsClient represents that hub accepts the joining of Klusterlet agent on the managed cluster with the hub. The default value is false, and can only be set true when the user on hub has an RBAC rule to UPDATE on the virtual subresource of managedclusters/accept. When the value is set true, a namespace whose name is the same as the name of ManagedCluster is created on the hub. This namespace represents the managed cluster, also role/rolebinding is created on the namespace to grant the permision of access from the agent on the managed cluster. When the value is set to false, the namespace representing the managed cluster is deleted.
+                  type: boolean
+                leaseDurationSeconds:
+                  description: LeaseDurationSeconds is used to coordinate the lease update time of Klusterlet agents on the managed cluster. If its value is zero, the Klusterlet agent will update its lease every 60 seconds by default
+                  type: integer
+                  format: int32
+                  default: 60
+                managedClusterClientConfigs:
+                  description: ManagedClusterClientConfigs represents a list of the apiserver address of the managed cluster. If it is empty, the managed cluster has no accessible address for the hub to connect with it.
+                  type: array
+                  items:
+                    description: ClientConfig represents the apiserver address of the managed cluster. TODO include credential to connect to managed cluster kube-apiserver
+                    type: object
+                    properties:
+                      caBundle:
+                        description: CABundle is the ca bundle to connect to apiserver of the managed cluster. System certs are used if it is not set.
+                        type: string
+                        format: byte
+                      url:
+                        description: URL is the URL of apiserver endpoint of the managed cluster.
+                        type: string
+                taints:
+                  description: Taints is a property of managed cluster that allow the cluster to be repelled when scheduling. Taints, including 'ManagedClusterUnavailable' and 'ManagedClusterUnreachable', can not be added/removed by agent running on the managed cluster; while it's fine to add/remove other taints from either hub cluser or managed cluster.
+                  type: array
+                  items:
+                    description: The managed cluster this Taint is attached to has the "effect" on any placement that does not tolerate the Taint.
+                    type: object
+                    required:
+                      - effect
+                      - key
+                    properties:
+                      effect:
+                        description: Effect indicates the effect of the taint on placements that do not tolerate the taint. Valid effects are NoSelect, PreferNoSelect and NoSelectIfNew.
+                        type: string
+                        enum:
+                          - NoSelect
+                          - PreferNoSelect
+                          - NoSelectIfNew
+                      key:
+                        description: Key is the taint key applied to a cluster. e.g. bar or foo.example.com/bar. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      timeAdded:
+                        description: TimeAdded represents the time at which the taint was added.
+                        type: string
+                        format: date-time
+                        nullable: true
+                      value:
+                        description: Value is the taint value corresponding to the taint key.
+                        type: string
+                        maxLength: 1024
+            status:
+              description: Status represents the current status of joined managed cluster
+              type: object
+              properties:
+                allocatable:
+                  description: Allocatable represents the total allocatable resources on the managed cluster.
+                  type: object
+                  additionalProperties:
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    x-kubernetes-int-or-string: true
+                capacity:
+                  description: Capacity represents the total resource capacity from all nodeStatuses on the managed cluster.
+                  type: object
+                  additionalProperties:
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    x-kubernetes-int-or-string: true
+                clusterClaims:
+                  description: ClusterClaims represents cluster information that a managed cluster claims, for example a unique cluster identifier (id.k8s.io) and kubernetes version (kubeversion.open-cluster-management.io). They are written from the managed cluster. The set of claims is not uniform across a fleet, some claims can be vendor or version specific and may not be included from all managed clusters.
+                  type: array
+                  items:
+                    description: ManagedClusterClaim represents a ClusterClaim collected from a managed cluster.
+                    type: object
+                    properties:
+                      name:
+                        description: Name is the name of a ClusterClaim resource on managed cluster. It's a well known or customized name to identify the claim.
+                        type: string
+                        maxLength: 253
+                        minLength: 1
+                      value:
+                        description: Value is a claim-dependent string
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                conditions:
+                  description: Conditions contains the different condition statuses for this managed cluster.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                version:
+                  description: Version represents the kubernetes version of the managed cluster.
+                  type: object
+                  properties:
+                    kubernetes:
+                      description: Kubernetes is the kubernetes version of managed cluster.
+                      type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/hack/crds/work-crd.yaml
+++ b/hack/crds/work-crd.yaml
@@ -1,0 +1,383 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: manifestworks.work.open-cluster-management.io
+spec:
+  group: work.open-cluster-management.io
+  names:
+    kind: ManifestWork
+    listKind: ManifestWorkList
+    plural: manifestworks
+    singular: manifestwork
+  scope: Namespaced
+  preserveUnknownFields: false
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ManifestWork represents a manifests workload that hub wants to deploy on the managed cluster. A manifest workload is defined as a set of Kubernetes resources. ManifestWork must be created in the cluster namespace on the hub, so that agent on the corresponding managed cluster can access this resource and deploy on the managed cluster.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec represents a desired configuration of work to be deployed on the managed cluster.
+              type: object
+              properties:
+                deleteOption:
+                  description: DeleteOption represents deletion strategy when the manifestwork is deleted. Foreground deletion strategy is applied to all the resource in this manifestwork if it is not set.
+                  type: object
+                  properties:
+                    propagationPolicy:
+                      description: propagationPolicy can be Foreground, Orphan or SelectivelyOrphan SelectivelyOrphan should be rarely used.  It is provided for cases where particular resources is transfering ownership from one ManifestWork to another or another management unit. Setting this value will allow a flow like 1. create manifestwork/2 to manage foo 2. update manifestwork/1 to selectively orphan foo 3. remove foo from manifestwork/1 without impacting continuity because manifestwork/2 adopts it.
+                      type: string
+                      default: Foreground
+                      enum:
+                        - Foreground
+                        - Orphan
+                        - SelectivelyOrphan
+                    selectivelyOrphans:
+                      description: selectivelyOrphan represents a list of resources following orphan deletion stratecy
+                      type: object
+                      properties:
+                        orphaningRules:
+                          description: orphaningRules defines a slice of orphaningrule. Each orphaningrule identifies a single resource included in this manifestwork
+                          type: array
+                          items:
+                            description: OrphaningRule identifies a single resource included in this manifestwork to be orphaned
+                            type: object
+                            required:
+                              - name
+                              - resource
+                            properties:
+                              group:
+                                description: Group is the API Group of the Kubernetes resource, empty string indicates it is in core group.
+                                type: string
+                              name:
+                                description: Name is the name of the Kubernetes resource.
+                                type: string
+                              namespace:
+                                description: Name is the namespace of the Kubernetes resource, empty string indicates it is a cluster scoped resource.
+                                type: string
+                              resource:
+                                description: Resource is the resource name of the Kubernetes resource.
+                                type: string
+                executor:
+                  description: Executor is the configuration that makes the work agent to perform some pre-request processing/checking. e.g. the executor identity tells the work agent to check the executor has sufficient permission to write the workloads to the local managed cluster. Note that nil executor is still supported for backward-compatibility which indicates that the work agent will not perform any additional actions before applying resources.
+                  type: object
+                  properties:
+                    subject:
+                      description: Subject is the subject identity which the work agent uses to talk to the local cluster when applying the resources.
+                      type: object
+                      required:
+                        - type
+                      properties:
+                        serviceAccount:
+                          description: ServiceAccount is for identifying which service account to use by the work agent. Only required if the type is "ServiceAccount".
+                          type: object
+                          required:
+                            - name
+                            - namespace
+                          properties:
+                            name:
+                              description: Name is the name of the service account.
+                              type: string
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$
+                            namespace:
+                              description: Namespace is the namespace of the service account.
+                              type: string
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$
+                        type:
+                          description: 'Type is the type of the subject identity. Supported types are: "ServiceAccount".'
+                          type: string
+                          enum:
+                            - ServiceAccount
+                manifestConfigs:
+                  description: ManifestConfigs represents the configurations of manifests defined in workload field.
+                  type: array
+                  items:
+                    description: ManifestConfigOption represents the configurations of a manifest defined in workload field.
+                    type: object
+                    required:
+                      - resourceIdentifier
+                    properties:
+                      feedbackRules:
+                        description: FeedbackRules defines what resource status field should be returned. If it is not set or empty, no feedback rules will be honored.
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - type
+                          properties:
+                            jsonPaths:
+                              description: JsonPaths defines the json path under status field to be synced.
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                  - name
+                                  - path
+                                properties:
+                                  name:
+                                    description: Name represents the alias name for this field
+                                    type: string
+                                  path:
+                                    description: Path represents the json path of the field under status. The path must point to a field with single value in the type of integer, bool or string. If the path points to a non-existing field, no value will be returned. If the path points to a structure, map or slice, no value will be returned and the status conddition of StatusFeedBackSynced will be set as false. Ref to https://kubernetes.io/docs/reference/kubectl/jsonpath/ on how to write a jsonPath.
+                                    type: string
+                                  version:
+                                    description: Version is the version of the Kubernetes resource. If it is not specified, the resource with the semantically latest version is used to resolve the path.
+                                    type: string
+                            type:
+                              description: Type defines the option of how status can be returned. It can be jsonPaths or wellKnownStatus. If the type is JSONPaths, user should specify the jsonPaths field If the type is WellKnownStatus, certain common fields of status defined by a rule only for types in in k8s.io/api and open-cluster-management/api will be reported, If these status fields do not exist, no values will be reported.
+                              type: string
+                              enum:
+                                - WellKnownStatus
+                                - JSONPaths
+                      resourceIdentifier:
+                        description: ResourceIdentifier represents the group, resource, name and namespace of a resoure. iff this refers to a resource not created by this manifest work, the related rules will not be executed.
+                        type: object
+                        required:
+                          - name
+                          - resource
+                        properties:
+                          group:
+                            description: Group is the API Group of the Kubernetes resource, empty string indicates it is in core group.
+                            type: string
+                          name:
+                            description: Name is the name of the Kubernetes resource.
+                            type: string
+                          namespace:
+                            description: Name is the namespace of the Kubernetes resource, empty string indicates it is a cluster scoped resource.
+                            type: string
+                          resource:
+                            description: Resource is the resource name of the Kubernetes resource.
+                            type: string
+                      updateStrategy:
+                        description: UpdateStrategy defines the strategy to update this manifest. UpdateStrategy is Update if it is not set, optional
+                        type: object
+                        required:
+                          - type
+                        properties:
+                          serverSideApply:
+                            description: serverSideApply defines the configuration for server side apply. It is honored only when type of updateStrategy is ServerSideApply
+                            type: object
+                            properties:
+                              fieldManager:
+                                description: FieldManager is the manager to apply the resource. It is work-agent by default, but can be other name with work-agent as the prefix.
+                                type: string
+                                default: work-agent
+                                pattern: ^work-agent
+                              force:
+                                description: Force represents to force apply the manifest.
+                                type: boolean
+                          type:
+                            description: type defines the strategy to update this manifest, default value is Update. Update type means to update resource by an update call. CreateOnly type means do not update resource based on current manifest. ServerSideApply type means to update resource using server side apply with work-controller as the field manager. If there is conflict, the related Applied condition of manifest will be in the status of False with the reason of ApplyConflict.
+                            type: string
+                            default: Update
+                            enum:
+                              - Update
+                              - CreateOnly
+                              - ServerSideApply
+                workload:
+                  description: Workload represents the manifest workload to be deployed on a managed cluster.
+                  type: object
+                  properties:
+                    manifests:
+                      description: Manifests represents a list of kuberenetes resources to be deployed on a managed cluster.
+                      type: array
+                      items:
+                        description: Manifest represents a resource to be deployed on managed cluster.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                        x-kubernetes-embedded-resource: true
+            status:
+              description: Status represents the current status of work.
+              type: object
+              properties:
+                conditions:
+                  description: 'Conditions contains the different condition statuses for this work. Valid condition types are: 1. Applied represents workload in ManifestWork is applied successfully on managed cluster. 2. Progressing represents workload in ManifestWork is being applied on managed cluster. 3. Available represents workload in ManifestWork exists on the managed cluster. 4. Degraded represents the current state of workload does not match the desired state for a certain period.'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                resourceStatus:
+                  description: ResourceStatus represents the status of each resource in manifestwork deployed on a managed cluster. The Klusterlet agent on managed cluster syncs the condition from the managed cluster to the hub.
+                  type: object
+                  properties:
+                    manifests:
+                      description: 'Manifests represents the condition of manifests deployed on managed cluster. Valid condition types are: 1. Progressing represents the resource is being applied on managed cluster. 2. Applied represents the resource is applied successfully on managed cluster. 3. Available represents the resource exists on the managed cluster. 4. Degraded represents the current state of resource does not match the desired state for a certain period.'
+                      type: array
+                      items:
+                        description: ManifestCondition represents the conditions of the resources deployed on a managed cluster.
+                        type: object
+                        properties:
+                          conditions:
+                            description: Conditions represents the conditions of this resource on a managed cluster.
+                            type: array
+                            items:
+                              description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                              type: object
+                              required:
+                                - lastTransitionTime
+                                - message
+                                - reason
+                                - status
+                                - type
+                              properties:
+                                lastTransitionTime:
+                                  description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                  type: string
+                                  format: date-time
+                                message:
+                                  description: message is a human readable message indicating details about the transition. This may be an empty string.
+                                  type: string
+                                  maxLength: 32768
+                                observedGeneration:
+                                  description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                                  type: integer
+                                  format: int64
+                                  minimum: 0
+                                reason:
+                                  description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                                  type: string
+                                  maxLength: 1024
+                                  minLength: 1
+                                  pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                status:
+                                  description: status of the condition, one of True, False, Unknown.
+                                  type: string
+                                  enum:
+                                    - "True"
+                                    - "False"
+                                    - Unknown
+                                type:
+                                  description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                  type: string
+                                  maxLength: 316
+                                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          resourceMeta:
+                            description: ResourceMeta represents the group, version, kind, name and namespace of a resoure.
+                            type: object
+                            properties:
+                              group:
+                                description: Group is the API Group of the Kubernetes resource.
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Kubernetes resource.
+                                type: string
+                              name:
+                                description: Name is the name of the Kubernetes resource.
+                                type: string
+                              namespace:
+                                description: Name is the namespace of the Kubernetes resource.
+                                type: string
+                              ordinal:
+                                description: Ordinal represents the index of the manifest on spec.
+                                type: integer
+                                format: int32
+                              resource:
+                                description: Resource is the resource name of the Kubernetes resource.
+                                type: string
+                              version:
+                                description: Version is the version of the Kubernetes resource.
+                                type: string
+                          statusFeedback:
+                            description: StatusFeedback represents the values of the feild synced back defined in statusFeedbacks
+                            type: object
+                            properties:
+                              values:
+                                description: Values represents the synced value of the interested field.
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                    - fieldValue
+                                    - name
+                                  properties:
+                                    fieldValue:
+                                      description: Value is the value of the status field. The value of the status field can only be integer, string or boolean.
+                                      type: object
+                                      required:
+                                        - type
+                                      properties:
+                                        boolean:
+                                          description: Boolean is bool value when type is boolean.
+                                          type: boolean
+                                        integer:
+                                          description: Integer is the integer value when type is integer.
+                                          type: integer
+                                          format: int64
+                                        string:
+                                          description: String is the string value when when type is string.
+                                          type: string
+                                        type:
+                                          description: Type represents the type of the value, it can be integer, string or boolean.
+                                          type: string
+                                          enum:
+                                            - Integer
+                                            - String
+                                            - Boolean
+                                    name:
+                                      description: Name represents the alias name for this field. It is the same as what is specified in StatuFeedbackRule in the spec.
+                                      type: string
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/hack/e2e/appproj.yaml
+++ b/hack/e2e/appproj.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: default
+  namespace: argocd
+spec:
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  destinations:
+  - namespace: '*'
+    server: '*'
+  sourceRepos:
+  - '*'
+  sourceNamespaces:
+  - '*'

--- a/hack/e2e/mca.yaml
+++ b/hack/e2e/mca.yaml
@@ -1,0 +1,7 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: argocd
+  namespace: cluster1
+spec:
+  installNamespace: argocd

--- a/internal/addon/charts/argocd-agent-addon/Chart.yaml
+++ b/internal/addon/charts/argocd-agent-addon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: argocd-agent-addon
 description: Argo CD Agent Addon
 type: application
-version: 0.25.2
-appVersion: 0.25.2
+version: 0.26.0
+appVersion: 0.26.0

--- a/internal/basic/application/application_controller.go
+++ b/internal/basic/application/application_controller.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+const (
+	// Application annotation that dictates which managed cluster this Application should be pulled to
+	AnnotationKeyOCMManagedCluster = "apps.open-cluster-management.io/ocm-managed-cluster"
+	// Application annotation that dictates which managed cluster namespace this Application should be pulled to
+	AnnotationKeyOCMManagedClusterAppNamespace = "apps.open-cluster-management.io/ocm-managed-cluster-app-namespace"
+	// Application and ManifestWork annotation that shows which ApplicationSet is the grand parent of this work
+	AnnotationKeyAppSet = "apps.open-cluster-management.io/hosting-applicationset"
+	// Application annotation that enables the skip reconcilation of an application
+	AnnotationKeyAppSkipReconcile = "argocd.argoproj.io/skip-reconcile"
+	// ManifestWork annotation that shows the namespace of the hub Application.
+	AnnotationKeyHubApplicationNamespace = "apps.open-cluster-management.io/hub-application-namespace"
+	// ManifestWork annotation that shows the name of the hub Application.
+	AnnotationKeyHubApplicationName = "apps.open-cluster-management.io/hub-application-name"
+	// Application and ManifestWork label that shows that ApplicationSet is the grand parent of this work
+	LabelKeyAppSet = "apps.open-cluster-management.io/application-set"
+	// Application and ManifestWork label that enables the pull controller to wrap the Application in ManifestWork payload
+	LabelKeyPull = "apps.open-cluster-management.io/pull-to-ocm-managed-cluster"
+	// ResourcesFinalizerName is the finalizer value which we inject to finalize deletion of an application
+	ResourcesFinalizerName string = "resources-finalizer.argocd.argoproj.io"
+)
+
+// ApplicationReconciler reconciles a Application object
+type ApplicationReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups=argoproj.io,resources=applications,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
+
+// ApplicationPredicateFunctions defines which Application this controller should wrap inside ManifestWork's payload
+var ApplicationPredicateFunctions = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		newObj := e.ObjectNew.(*unstructured.Unstructured)
+		return containsValidPullLabel(newObj.GetLabels()) &&
+			containsValidPullAnnotation(newObj.GetAnnotations())
+	},
+	CreateFunc: func(e event.CreateEvent) bool {
+		obj := e.Object.(*unstructured.Unstructured)
+		return containsValidPullLabel(obj.GetLabels()) &&
+			containsValidPullAnnotation(obj.GetAnnotations())
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		obj := e.Object.(*unstructured.Unstructured)
+		return containsValidPullLabel(obj.GetLabels()) &&
+			containsValidPullAnnotation(obj.GetAnnotations())
+	},
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	applicationGVK := &unstructured.Unstructured{}
+	applicationGVK.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Application",
+	})
+	return ctrl.NewControllerManagedBy(mgr).
+		For(applicationGVK).
+		WithEventFilter(ApplicationPredicateFunctions).
+		Complete(r)
+}
+
+// Reconcile create/update/delete ManifestWork with the Application as its payload
+func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+	log.Info("reconciling Application...")
+
+	application := &unstructured.Unstructured{}
+	application.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Application",
+	})
+	if err := r.Get(ctx, req.NamespacedName, application); err != nil {
+		log.Error(err, "unable to fetch Application")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	managedClusterName := application.GetAnnotations()[AnnotationKeyOCMManagedCluster]
+	mwName := generateManifestWorkName(application.GetName(), application.GetUID())
+
+	// the Application is being deleted, find the ManifestWork and delete that as well
+	if application.GetDeletionTimestamp() != nil {
+		// remove finalizer from Application but do not 'commit' yet
+		if len(application.GetFinalizers()) != 0 {
+			f := application.GetFinalizers()
+			for i := 0; i < len(f); i++ {
+				if f[i] == ResourcesFinalizerName {
+					f = append(f[:i], f[i+1:]...)
+					i--
+				}
+			}
+			application.SetFinalizers(f)
+		}
+
+		// delete the ManifestWork associated with this Application
+		var work workv1.ManifestWork
+		err := r.Get(ctx, types.NamespacedName{Name: mwName, Namespace: managedClusterName}, &work)
+		if errors.IsNotFound(err) {
+			// already deleted ManifestWork, commit the Application finalizer removal
+			if err = r.Update(ctx, application); err != nil {
+				log.Error(err, "unable to update Application")
+				return ctrl.Result{}, err
+			}
+		} else if err != nil {
+			log.Error(err, "unable to fetch ManifestWork")
+			return ctrl.Result{}, err
+		}
+
+		if err := r.Delete(ctx, &work); err != nil {
+			log.Error(err, "unable to delete ManifestWork")
+			return ctrl.Result{}, err
+		}
+
+		// deleted ManifestWork, commit the Application finalizer removal
+		if err := r.Update(ctx, application); err != nil {
+			log.Error(err, "unable to update Application")
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// verify the ManagedCluster actually exists
+	var managedCluster clusterv1.ManagedCluster
+	if err := r.Get(ctx, types.NamespacedName{Name: managedClusterName}, &managedCluster); err != nil {
+		log.Error(err, "unable to fetch ManagedCluster")
+		return ctrl.Result{}, err
+	}
+
+	log.Info("generating ManifestWork for Application")
+	w := generateManifestWork(mwName, managedClusterName, application)
+
+	// create or update the ManifestWork depends if it already exists or not
+	var mw workv1.ManifestWork
+	err := r.Get(ctx, types.NamespacedName{Name: mwName, Namespace: managedClusterName}, &mw)
+	if errors.IsNotFound(err) {
+		err = r.Client.Create(ctx, w)
+		if err != nil {
+			log.Error(err, "unable to create ManifestWork")
+			return ctrl.Result{}, err
+		}
+	} else if err == nil {
+		mw.Spec = w.Spec
+		mw.Annotations = w.Annotations
+		mw.Labels = w.Labels
+		err = r.Client.Update(ctx, &mw)
+		if err != nil {
+			log.Error(err, "unable to update ManifestWork")
+			return ctrl.Result{}, err
+		}
+	} else {
+		log.Error(err, "unable to fetch ManifestWork")
+		return ctrl.Result{}, err
+	}
+
+	// remove the operation field from application if it exists
+	if _, ok := application.Object["operation"]; ok {
+		delete(application.Object, "operation")
+		if err := r.Update(ctx, application); err != nil {
+			log.Error(err, "unable to remove operation from Application")
+			return ctrl.Result{}, err
+		}
+	}
+
+	log.Info("done reconciling Application")
+
+	return ctrl.Result{}, nil
+}

--- a/internal/basic/application/application_controller_test.go
+++ b/internal/basic/application/application_controller_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+var _ = Describe("Application Pull controller", func() {
+
+	const (
+		appName      = "app-1"
+		appName2     = "app-2"
+		appNamespace = "default"
+		clusterName  = "cluster1"
+	)
+
+	appKey := types.NamespacedName{Name: appName, Namespace: appNamespace}
+	appKey2 := types.NamespacedName{Name: appName2, Namespace: appNamespace}
+	ctx := context.Background()
+
+	Context("When Application without OCM pull label is created", func() {
+		It("Should not create ManifestWork", func() {
+			By("Creating the Application without OCM pull label")
+			app1 := &unstructured.Unstructured{}
+			app1.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "argoproj.io",
+				Version: "v1alpha1",
+				Kind:    "Application",
+			})
+			app1.SetName(appName)
+			app1.SetNamespace(appNamespace)
+			app1.SetAnnotations(map[string]string{AnnotationKeyOCMManagedCluster: clusterName})
+
+			// Set required spec fields
+			_ = unstructured.SetNestedField(app1.Object, "default", "spec", "project")
+			_ = unstructured.SetNestedField(app1.Object, "default", "spec", "source", "repoURL")
+			_ = unstructured.SetNestedMap(app1.Object, map[string]interface{}{"server": KubernetesInternalAPIServerAddr}, "spec", "destination")
+
+			Expect(k8sClient.Create(ctx, app1)).Should(Succeed())
+			app1 = &unstructured.Unstructured{}
+			app1.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "argoproj.io",
+				Version: "v1alpha1",
+				Kind:    "Application",
+			})
+			Expect(k8sClient.Get(ctx, appKey, app1)).Should(Succeed())
+
+			mwKey := types.NamespacedName{Name: generateManifestWorkName(app1.GetName(), app1.GetUID()), Namespace: clusterName}
+			mw := workv1.ManifestWork{}
+			Consistently(func() bool {
+				if err := k8sClient.Get(ctx, mwKey, &mw); err != nil {
+					return false
+				}
+				return true
+			}).Should(BeFalse())
+		})
+	})
+
+	Context("When Application with OCM pull label is created/updated/deleted", func() {
+		It("Should create/update/delete ManifestWork", func() {
+			By("Creating the OCM ManagedCluster")
+			managedCluster := clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, &managedCluster)).Should(Succeed())
+
+			By("Creating the OCM ManagedCluster namespace")
+			managedClusterNs := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, &managedClusterNs)).Should(Succeed())
+
+			By("Creating the Application with OCM pull label")
+			app2 := &unstructured.Unstructured{}
+			app2.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "argoproj.io",
+				Version: "v1alpha1",
+				Kind:    "Application",
+			})
+			app2.SetName(appName2)
+			app2.SetNamespace(appNamespace)
+			app2.SetLabels(map[string]string{LabelKeyPull: strconv.FormatBool(true)})
+			app2.SetAnnotations(map[string]string{AnnotationKeyOCMManagedCluster: clusterName})
+			app2.SetFinalizers([]string{ResourcesFinalizerName})
+
+			// Set required spec fields
+			_ = unstructured.SetNestedField(app2.Object, "default", "spec", "project")
+			_ = unstructured.SetNestedField(app2.Object, "default", "spec", "source", "repoURL")
+			_ = unstructured.SetNestedMap(app2.Object, map[string]interface{}{"server": KubernetesInternalAPIServerAddr}, "spec", "destination")
+
+			Expect(k8sClient.Create(ctx, app2)).Should(Succeed())
+			app2 = &unstructured.Unstructured{}
+			app2.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "argoproj.io",
+				Version: "v1alpha1",
+				Kind:    "Application",
+			})
+			Expect(k8sClient.Get(ctx, appKey2, app2)).Should(Succeed())
+
+			mwKey := types.NamespacedName{Name: generateManifestWorkName(app2.GetName(), app2.GetUID()), Namespace: clusterName}
+			mw := workv1.ManifestWork{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, mwKey, &mw); err != nil {
+					return false
+				}
+				return true
+			}).Should(BeTrue())
+
+			By("Updating the Application")
+			oldRv := mw.GetResourceVersion()
+			_ = unstructured.SetNestedField(app2.Object, "somethingelse", "spec", "project")
+			Expect(k8sClient.Update(ctx, app2)).Should(Succeed())
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, mwKey, &mw); err != nil {
+					return false
+				}
+				return oldRv != mw.GetResourceVersion()
+			}).Should(BeTrue())
+
+			By("Updating the Application with operation")
+			operation := map[string]interface{}{
+				"info": []interface{}{
+					map[string]interface{}{
+						"name":  "Reason",
+						"value": "ApplicationSet RollingSync triggered a sync of this Application resource.",
+					},
+				},
+				"initiatedBy": map[string]interface{}{
+					"automated": true,
+					"username":  "applicationset-controller",
+				},
+				"retry": map[string]interface{}{},
+				"sync": map[string]interface{}{
+					"syncOptions": []interface{}{
+						"CreateNamespace=true",
+					},
+				},
+			}
+			Expect(unstructured.SetNestedField(app2.Object, operation, "operation")).Should(Succeed())
+			Expect(k8sClient.Update(ctx, app2)).Should(Succeed())
+			Eventually(func() bool {
+				updatedApp := &unstructured.Unstructured{}
+				updatedApp.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "argoproj.io",
+					Version: "v1alpha1",
+					Kind:    "Application",
+				})
+				err := k8sClient.Get(ctx, appKey2, updatedApp)
+				if err != nil {
+					return false
+				}
+				_, ok := updatedApp.Object["operation"]
+				return !ok
+			}).Should(BeTrue())
+
+			By("Deleting the Application")
+			Expect(k8sClient.Delete(ctx, app2)).Should(Succeed())
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, mwKey, &mw); err != nil {
+					return true
+				}
+				return false
+			}).Should(BeTrue())
+		})
+	})
+})

--- a/internal/basic/application/application_status_controller.go
+++ b/internal/basic/application/application_status_controller.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicationlicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+// ApplicationStatusReconciler reconciles a Application object
+type ApplicationStatusReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups=argoproj.io,resources=applications,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch
+
+// ManifestWorkPredicateFunctions defines which ManifestWork this controller should watch
+var ManifestWorkPredicateFunctions = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		newManifestWork := e.ObjectNew.(*workv1.ManifestWork)
+		return containsValidPullLabel(newManifestWork.Labels) && containsValidManifestWorkHubApplicationAnnotations(*newManifestWork)
+
+	},
+	CreateFunc: func(e event.CreateEvent) bool {
+		manifestWork := e.Object.(*workv1.ManifestWork)
+		return containsValidPullLabel(manifestWork.Labels) && containsValidManifestWorkHubApplicationAnnotations(*manifestWork)
+	},
+
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (re *ApplicationStatusReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&workv1.ManifestWork{}).
+		WithEventFilter(ManifestWorkPredicateFunctions).
+		Complete(re)
+}
+
+// Reconcile populates the Application status based on the associated ManifestWork's status feedback
+// Reconcile populates the Application status based on the associated ManifestWork's status feedback
+func (r *ApplicationStatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+	log.Info("reconciling Application for status update..")
+	defer log.Info("done reconciling Application for status update")
+
+	var manifestWork workv1.ManifestWork
+	if err := r.Get(ctx, req.NamespacedName, &manifestWork); err != nil {
+		log.Error(err, "unable to fetch ManifestWork")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Check if the ManifestWork is being deleted
+	if manifestWork.ObjectMeta.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	// Extract status feedbacks for healthStatus and syncStatus
+	resourceManifests := manifestWork.Status.ResourceStatus.Manifests
+	healthStatus := ""
+	syncStatus := ""
+	operationStatePhase := ""
+	operationStateStartedAt := ""
+	syncRevision := ""
+	if len(resourceManifests) > 0 {
+		statusFeedbacks := resourceManifests[0].StatusFeedbacks.Values
+		for _, statusFeedback := range statusFeedbacks {
+			if statusFeedback.Name == "healthStatus" {
+				healthStatus = *statusFeedback.Value.String
+			}
+			if statusFeedback.Name == "syncStatus" {
+				syncStatus = *statusFeedback.Value.String
+			}
+			if statusFeedback.Name == "operationStatePhase" {
+				operationStatePhase = *statusFeedback.Value.String
+			}
+			if statusFeedback.Name == "operationStateStartedAt" {
+				operationStateStartedAt = *statusFeedback.Value.String
+			}
+			if statusFeedback.Name == "syncRevision" {
+				syncRevision = *statusFeedback.Value.String
+			}
+		}
+	}
+	if operationStateStartedAt == "" {
+		operationStateStartedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	// If status values are missing, log and return
+	if len(healthStatus) == 0 || len(syncStatus) == 0 {
+		log.Info("healthStatus and syncStatus are both not in ManifestWork status feedback yet")
+		return ctrl.Result{}, nil
+	}
+
+	// Retrieve Application reference from annotations
+	applicationNamespace := manifestWork.Annotations[AnnotationKeyHubApplicationNamespace]
+	applicationName := manifestWork.Annotations[AnnotationKeyHubApplicationName]
+
+	// Fetch the Application as an unstructured object
+	application := &unstructured.Unstructured{}
+	application.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Application",
+	})
+
+	if err := r.Get(ctx, types.NamespacedName{Namespace: applicationNamespace, Name: applicationName}, application); err != nil {
+		log.Error(err, "unable to fetch Application")
+		return ctrl.Result{}, err
+	}
+
+	// Update the Application's status fields dynamically
+	if healthStatus == "Healthy" {
+		// If the health status is Healthy then simulate Progressing first then set to Healthy for ApplicationSet controller
+		if err := unstructured.SetNestedField(application.Object, "Progressing", "status", "health", "status"); err != nil {
+			log.Error(err, "unable to set healthStatus in Application status")
+			return ctrl.Result{}, err
+		}
+
+		log.Info("updating Application health status to Progressing")
+		if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			return r.Client.Update(ctx, application)
+		}); err != nil {
+			log.Error(err, "unable to update Application")
+			return ctrl.Result{}, err
+		}
+	}
+	if err := unstructured.SetNestedField(application.Object, healthStatus, "status", "health", "status"); err != nil {
+		log.Error(err, "unable to set healthStatus in Application status")
+		return ctrl.Result{}, err
+	}
+	if err := unstructured.SetNestedField(application.Object, syncStatus, "status", "sync", "status"); err != nil {
+		log.Error(err, "unable to set syncStatus in Application status")
+		return ctrl.Result{}, err
+	}
+	if err := unstructured.SetNestedField(application.Object, operationStatePhase, "status", "operationState", "phase"); err != nil {
+		log.Error(err, "unable to set syncStatus in Application status")
+		return ctrl.Result{}, err
+	}
+	if err := unstructured.SetNestedField(application.Object, operationStateStartedAt, "status", "operationState", "startedAt"); err != nil {
+		log.Error(err, "unable to set syncStatus in Application status")
+		return ctrl.Result{}, err
+	}
+	if err := unstructured.SetNestedField(application.Object, map[string]interface{}{}, "status", "operationState", "operation"); err != nil {
+		// Application required field, set it to empty object
+		log.Error(err, "unable to set operation field in Application status")
+		return ctrl.Result{}, err
+	}
+	if err := unstructured.SetNestedField(application.Object, syncRevision, "status", "sync", "revision"); err != nil {
+		log.Error(err, "unable to set syncStatus in Application status")
+		return ctrl.Result{}, err
+	}
+
+	log.Info("updating Application status with ManifestWork status feedbacks")
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		return r.Client.Update(ctx, application)
+	}); err != nil {
+		log.Error(err, "unable to update Application")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/internal/basic/application/application_status_controller_test.go
+++ b/internal/basic/application/application_status_controller_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+var _ = Describe("Application Pull controller", func() {
+
+	const (
+		appName      = "app-5"
+		workName     = "work-1"
+		appNamespace = "default"
+		clusterName  = "default"
+	)
+
+	appKey := types.NamespacedName{Name: appName, Namespace: appNamespace}
+	workKey := types.NamespacedName{Name: workName, Namespace: clusterName}
+	ctx := context.Background()
+
+	Context("When ManifestWork is created/updated", func() {
+		It("Should update Application status", func() {
+			By("Creating the Application")
+			app1 := &unstructured.Unstructured{}
+			app1.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "argoproj.io",
+				Version: "v1alpha1",
+				Kind:    "Application",
+			})
+			app1.SetName(appName)
+			app1.SetNamespace(appNamespace)
+			app1.Object["spec"] = map[string]interface{}{
+				"project": "default", // Required field
+				"source": map[string]interface{}{
+					"repoURL": "default",
+				},
+				"destination": map[string]interface{}{ // Required field
+					"server": KubernetesInternalAPIServerAddr,
+				},
+			}
+			Expect(k8sClient.Create(ctx, app1)).Should(Succeed())
+
+			By("Creating the ManifestWork")
+			work1 := workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workName,
+					Namespace: clusterName,
+					Annotations: map[string]string{
+						AnnotationKeyHubApplicationNamespace: appNamespace,
+						AnnotationKeyHubApplicationName:      appName,
+					},
+					Labels: map[string]string{
+						LabelKeyPull: strconv.FormatBool(true),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &work1)).Should(Succeed())
+			Expect(k8sClient.Get(ctx, workKey, &work1)).Should(Succeed())
+
+			By("Updating the ManifestWork status")
+			healthy := "Healthy"
+			synced := "Synced"
+			operationStateStartedAt := "2025-04-24T19:53:38Z"
+			operationStatePhase := "Succeeded"
+			syncRevision := "4773b9f1f8fd425f84174c338012771c4e9a989c"
+			work1.Status = workv1.ManifestWorkStatus{
+				ResourceStatus: workv1.ManifestResourceStatus{
+					Manifests: []workv1.ManifestCondition{{
+						Conditions: []metav1.Condition{{
+							Type:               workv1.WorkApplied,
+							Status:             metav1.ConditionTrue,
+							Reason:             workv1.WorkApplied,
+							Message:            workv1.WorkApplied,
+							LastTransitionTime: work1.CreationTimestamp,
+						}},
+						StatusFeedbacks: workv1.StatusFeedbackResult{
+							Values: []workv1.FeedbackValue{
+								{Name: "healthStatus", Value: workv1.FieldValue{String: &healthy, Type: "String"}},
+								{Name: "syncStatus", Value: workv1.FieldValue{String: &synced, Type: "String"}},
+								{Name: "operationStateStartedAt", Value: workv1.FieldValue{String: &operationStateStartedAt, Type: "String"}},
+								{Name: "operationStatePhase", Value: workv1.FieldValue{String: &operationStatePhase, Type: "String"}},
+								{Name: "syncRevision", Value: workv1.FieldValue{String: &syncRevision, Type: "String"}},
+							}},
+					}},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, &work1)).Should(Succeed())
+
+			// Verify that the Application status is updated
+			Eventually(func() bool {
+				app := &unstructured.Unstructured{}
+				app.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "argoproj.io",
+					Version: "v1alpha1",
+					Kind:    "Application",
+				})
+				if err := k8sClient.Get(ctx, appKey, app); err != nil {
+					return false
+				}
+
+				// Get the health and sync status from the Application's status
+				healthStatus, _, _ := unstructured.NestedString(app.Object, "status", "health", "status")
+				syncStatus, _, _ := unstructured.NestedString(app.Object, "status", "sync", "status")
+				operationStateStartedAtStatus, _, _ := unstructured.NestedString(app.Object, "status", "operationState", "startedAt")
+				operationStatePhaseStatus, _, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
+				syncRevisionStatus, _, _ := unstructured.NestedString(app.Object, "status", "sync", "revision")
+
+				return healthStatus == "Healthy" && syncStatus == "Synced" &&
+					operationStateStartedAtStatus == "2025-04-24T19:53:38Z" &&
+					operationStatePhaseStatus == "Succeeded" &&
+					syncRevisionStatus == "4773b9f1f8fd425f84174c338012771c4e9a989c"
+			}).Should(BeTrue())
+		})
+	})
+})

--- a/internal/basic/application/cluster_controller.go
+++ b/internal/basic/application/cluster_controller.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+// ClusterReconciler reconciles a ManagedCluster object
+type ClusterReconciler struct {
+	client.Client
+	Scheme          *runtime.Scheme
+	ArgoCDNamespace string
+}
+
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;delete
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&clusterv1.ManagedCluster{}).
+		WithEventFilter(predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool { return false },
+		}).
+		Complete(r)
+}
+
+// Reconcile create/delete Secrets to the corresponding ManagedCluster resources
+func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+	log.Info("reconciling ManagedCluster...")
+
+	managedCluster := &clusterv1.ManagedCluster{}
+	err := r.Get(ctx, req.NamespacedName, managedCluster)
+
+	if err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			log.Error(err, "unable to fetch ManagedCluster")
+			return ctrl.Result{}, err
+		}
+		// If the ManagedCluster resource is not found, it has been deleted.
+		// Proceed with cleaning up the associated Secret.
+		log.Info("ManagedCluster resource not found, cleaning up Secret")
+		if cleanupErr := r.deleteSecret(ctx, req.Name); cleanupErr != nil {
+			log.Error(cleanupErr, "unable to delete Secret")
+			return ctrl.Result{}, cleanupErr
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// If the ManagedCluster is being deleted, clean up the Secret
+	if !managedCluster.GetDeletionTimestamp().IsZero() {
+		log.Info("ManagedCluster is being deleted, cleaning up Secret")
+		if cleanupErr := r.deleteSecret(ctx, req.Name); cleanupErr != nil {
+			log.Error(cleanupErr, "unable to delete Secret")
+			return ctrl.Result{}, cleanupErr
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// ManagedCluster is created, ensure the Secret exists
+	log.Info("ManagedCluster is created, ensuring Secret exists")
+	if createErr := r.createSecret(ctx, managedCluster); createErr != nil {
+		log.Error(createErr, "unable to create Secret")
+		return ctrl.Result{}, createErr
+	}
+
+	log.Info("done reconciling ManagedCluster")
+	return ctrl.Result{}, nil
+}
+
+// createSecret creates a Secret for the given ManagedCluster
+func (r *ClusterReconciler) createSecret(ctx context.Context, cluster *clusterv1.ManagedCluster) error {
+	secret := &corev1.Secret{
+		ObjectMeta: ctrl.ObjectMeta{
+			Name:      fmt.Sprintf("%s-secret", cluster.Name),
+			Namespace: r.ArgoCDNamespace,
+			Labels: map[string]string{
+				"argocd.argoproj.io/secret-type": "cluster",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			"name":   cluster.Name,
+			"server": fmt.Sprintf("https://%s-control-plane:6443", cluster.Name),
+		},
+	}
+
+	existingSecret := &corev1.Secret{}
+	err := r.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, existingSecret)
+	if err == nil {
+		return nil
+	}
+	if client.IgnoreNotFound(err) != nil {
+		return err
+	}
+	if err := r.Create(ctx, secret); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// deleteSecret deletes the Secret associated with a ManagedCluster
+func (r *ClusterReconciler) deleteSecret(ctx context.Context, clusterName string) error {
+	secretName := fmt.Sprintf("%s-secret", clusterName)
+	secret := &corev1.Secret{}
+	err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: r.ArgoCDNamespace}, secret)
+	if err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	if err := r.Delete(ctx, secret); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/basic/application/cluster_controller_test.go
+++ b/internal/basic/application/cluster_controller_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+var _ = Describe("Cluster Controller", func() {
+
+	const (
+		clusterName  = "cluster3"
+		clusterName2 = "cluster4"
+		argocdNs     = "argocd"
+	)
+
+	secretKey := types.NamespacedName{Name: clusterName + "-secret", Namespace: argocdNs}
+	secretKey2 := types.NamespacedName{Name: clusterName2 + "-secret", Namespace: argocdNs}
+	ctx := context.Background()
+
+	BeforeEach(func() {
+		argocdNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: argocdNs,
+			},
+		}
+		_ = k8sClient.Create(ctx, argocdNamespace)
+	})
+
+	Context("When a ManagedCluster is created", func() {
+		It("Should create a corresponding Secret with correct content", func() {
+			By("Creating the ManagedCluster")
+			managedCluster := &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, managedCluster)).Should(Succeed())
+
+			By("Ensuring the Secret is created with correct content")
+			secret := &corev1.Secret{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, secretKey, secret); err != nil {
+					return false
+				}
+				name, nameOk := secret.Data["name"]
+				server, serverOk := secret.Data["server"]
+				return nameOk && serverOk &&
+					string(name) == clusterName &&
+					string(server) == "https://"+clusterName+"-control-plane:6443"
+			}).Should(BeTrue())
+		})
+	})
+
+	Context("When a ManagedCluster is deleted", func() {
+		It("Should delete the corresponding Secret", func() {
+			By("Creating the ManagedCluster")
+			managedCluster2 := &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName2,
+				},
+			}
+			Expect(k8sClient.Create(ctx, managedCluster2)).Should(Succeed())
+
+			By("Ensuring the Secret is created")
+			secret := &corev1.Secret{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, secretKey2, secret); err != nil {
+					return false
+				}
+				return true
+			}).Should(BeTrue())
+
+			By("Deleting the ManagedCluster")
+			Expect(k8sClient.Delete(ctx, managedCluster2)).Should(Succeed())
+
+			By("Ensuring the Secret is deleted")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, secretKey2, secret)
+				return err != nil
+			}).Should(BeTrue())
+		})
+	})
+})

--- a/internal/basic/application/helper.go
+++ b/internal/basic/application/helper.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"strconv"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+const (
+	// KubernetesInternalAPIServerAddr is address of the k8s API server when accessing internal to the cluster
+	KubernetesInternalAPIServerAddr = "https://kubernetes.default.svc"
+)
+
+func containsValidPullLabel(labels map[string]string) bool {
+	if len(labels) == 0 {
+		return false
+	}
+
+	if pullLabelStr, ok := labels[LabelKeyPull]; ok {
+		isPull, err := strconv.ParseBool(pullLabelStr)
+		if err != nil {
+			return false
+		}
+		return isPull
+	}
+
+	return false
+}
+
+func containsValidPullAnnotation(annos map[string]string) bool {
+	if len(annos) == 0 {
+		return false
+	}
+
+	managedClusterName, ok := annos[AnnotationKeyOCMManagedCluster]
+	return ok && len(managedClusterName) > 0
+}
+
+func containsValidManifestWorkHubApplicationAnnotations(manifestWork workv1.ManifestWork) bool {
+	annos := manifestWork.GetAnnotations()
+	if len(annos) == 0 {
+		return false
+	}
+
+	namespace, ok := annos[AnnotationKeyHubApplicationNamespace]
+	name, ok2 := annos[AnnotationKeyHubApplicationName]
+
+	return ok && ok2 && len(namespace) > 0 && len(name) > 0
+}
+
+// generateAppNamespace returns the intended namespace for the Application in the following priority
+// 1) Annotation specified custom namespace
+// 2) Application's namespace value
+// 3) Fallsback to 'argocd'
+func generateAppNamespace(namespace string, annos map[string]string) string {
+	appNamespace := annos[AnnotationKeyOCMManagedClusterAppNamespace]
+	if len(appNamespace) > 0 {
+		return appNamespace
+	}
+	appNamespace = namespace
+	if len(appNamespace) > 0 {
+		return appNamespace
+	}
+	return "argocd"
+}
+
+// generateManifestWorkName returns the ManifestWork name for a given application.
+// It uses the Application name with the suffix of the first 5 characters of the UID
+func generateManifestWorkName(name string, uid types.UID) string {
+	return name + "-" + string(uid)[0:5]
+}
+
+// getAppSetOwnerName returns the applicationSet resource name if the given application contains an applicationSet owner
+func getAppSetOwnerName(ownerRefs []metav1.OwnerReference) string {
+	if len(ownerRefs) > 0 {
+		for _, ownerRef := range ownerRefs {
+			if strings.EqualFold(ownerRef.APIVersion, "argoproj.io/v1alpha1") &&
+				strings.EqualFold(ownerRef.Kind, "ApplicationSet") {
+				return ownerRef.Name
+			}
+		}
+	}
+	return ""
+}
+
+// prepareApplicationForWorkPayload modifies the Application:
+// - reset the meta
+// - set the namespace value
+// - ensures the Application Destination is set to in-cluster resource deployment
+// - ensures the operation field is also set if present
+func prepareApplicationForWorkPayload(application *unstructured.Unstructured) unstructured.Unstructured {
+	newApp := &unstructured.Unstructured{}
+	newApp.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Application",
+	})
+	newApp.SetNamespace(generateAppNamespace(application.GetNamespace(), application.GetAnnotations()))
+	newApp.SetName(application.GetName())
+	newApp.SetFinalizers(application.GetFinalizers())
+
+	// set the operation field
+	if operation, ok := application.Object["operation"].(map[string]interface{}); ok {
+		newApp.Object["operation"] = operation
+	}
+
+	// set the spec field
+	if newSpec, ok := application.Object["spec"].(map[string]interface{}); ok {
+		if destination, ok := newSpec["destination"].(map[string]interface{}); ok {
+			// empty the name
+			destination["name"] = ""
+			// always set for in-cluster destination
+			destination["server"] = KubernetesInternalAPIServerAddr
+		}
+		newApp.Object["spec"] = newSpec
+	}
+
+	// copy the labels except for the ocm specific labels
+	labels := make(map[string]string)
+	for key, value := range application.GetLabels() {
+		if key != LabelKeyPull {
+			labels[key] = value
+		}
+	}
+	newApp.SetLabels(labels)
+
+	// copy the annos except for the ocm specific annos
+	annotations := make(map[string]string)
+	for key, value := range application.GetAnnotations() {
+		if key != AnnotationKeyOCMManagedCluster &&
+			key != AnnotationKeyOCMManagedClusterAppNamespace &&
+			key != AnnotationKeyAppSkipReconcile {
+			annotations[key] = value
+		}
+	}
+	newApp.SetAnnotations(annotations)
+
+	appSetOwnerName := getAppSetOwnerName(application.GetOwnerReferences())
+	if appSetOwnerName != "" {
+		labels[LabelKeyAppSet] = strconv.FormatBool(true)
+		annotations[AnnotationKeyAppSet] = application.GetNamespace() + "/" + appSetOwnerName
+		newApp.SetLabels(labels)
+		newApp.SetAnnotations(annotations)
+	}
+
+	return *newApp
+}
+
+// generateManifestWork creates the ManifestWork that wraps the Application as payload
+// With the status sync feedback of Application's health status and sync status.
+// The Application payload Spec Destination values are modified so that the Application is always performing in-cluster resource deployments.
+// If the Application is generated from an ApplicationSet, custom label and annotation are inserted.
+func generateManifestWork(name, namespace string, app *unstructured.Unstructured) *workv1.ManifestWork {
+	workLabels := map[string]string{
+		LabelKeyPull: strconv.FormatBool(true),
+	}
+
+	workAnnos := map[string]string{
+		AnnotationKeyHubApplicationNamespace: app.GetNamespace(),
+		AnnotationKeyHubApplicationName:      app.GetName(),
+	}
+
+	appSetOwnerName := getAppSetOwnerName(app.GetOwnerReferences())
+	if appSetOwnerName != "" {
+		workLabels[LabelKeyAppSet] = strconv.FormatBool(true)
+		workAnnos[AnnotationKeyAppSet] = app.GetNamespace() + "/" + appSetOwnerName
+	}
+
+	application := prepareApplicationForWorkPayload(app)
+
+	return &workv1.ManifestWork{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      workLabels,
+			Annotations: workAnnos,
+		},
+		Spec: workv1.ManifestWorkSpec{
+			Workload: workv1.ManifestsTemplate{
+				Manifests: []workv1.Manifest{{RawExtension: runtime.RawExtension{Object: &application}}},
+			},
+			ManifestConfigs: []workv1.ManifestConfigOption{
+				{
+					ResourceIdentifier: workv1.ResourceIdentifier{
+						Group:     "argoproj.io",
+						Resource:  "applications",
+						Namespace: application.GetNamespace(),
+						Name:      application.GetName(),
+					},
+					FeedbackRules: []workv1.FeedbackRule{
+						{Type: workv1.JSONPathsType, JsonPaths: []workv1.JsonPath{{Name: "healthStatus", Path: ".status.health.status"}}},
+						{Type: workv1.JSONPathsType, JsonPaths: []workv1.JsonPath{{Name: "syncStatus", Path: ".status.sync.status"}}},
+						{Type: workv1.JSONPathsType, JsonPaths: []workv1.JsonPath{{Name: "operationStateStartedAt", Path: ".status.operationState.startedAt"}}},
+						{Type: workv1.JSONPathsType, JsonPaths: []workv1.JsonPath{{Name: "operationStatePhase", Path: ".status.operationState.phase"}}},
+						{Type: workv1.JSONPathsType, JsonPaths: []workv1.JsonPath{{Name: "syncRevision", Path: ".status.sync.revision"}}},
+					},
+					UpdateStrategy: &workv1.UpdateStrategy{
+						Type: workv1.UpdateStrategyTypeServerSideApply,
+						ServerSideApply: &workv1.ServerSideApplyConfig{
+							Force: true,
+							IgnoreFields: []workv1.IgnoreField{
+								{
+									Condition: workv1.IgnoreFieldsConditionOnSpokeChange,
+									JSONPaths: []string{".operation"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/basic/application/helper_test.go
+++ b/internal/basic/application/helper_test.go
@@ -1,0 +1,489 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+func Test_containsValidPullLabel(t *testing.T) {
+	type args struct {
+		labels map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "valid pull label",
+			args: args{
+				map[string]string{LabelKeyPull: "true"},
+			},
+			want: true,
+		},
+		{
+			name: "valid pull label case",
+			args: args{
+				map[string]string{LabelKeyPull: "True"},
+			},
+			want: true,
+		},
+		{
+			name: "invalid pull label",
+			args: args{
+				map[string]string{LabelKeyPull + "a": "true"},
+			},
+			want: false,
+		},
+		{
+			name: "empty value",
+			args: args{
+				map[string]string{LabelKeyPull: ""},
+			},
+			want: false,
+		},
+		{
+			name: "false value",
+			args: args{
+				map[string]string{LabelKeyPull: "false"},
+			},
+			want: false,
+		},
+		{
+			name: "no pull label",
+			args: args{
+				map[string]string{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsValidPullLabel(tt.args.labels); got != tt.want {
+				t.Errorf("containsValidPullLabel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_containsValidPullAnnotation(t *testing.T) {
+	type args struct {
+		annos map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "valid pull annotation",
+			args: args{
+				map[string]string{AnnotationKeyOCMManagedCluster: "cluster1"},
+			},
+			want: true,
+		},
+		{
+			name: "invalid pull annotation",
+			args: args{
+				map[string]string{AnnotationKeyOCMManagedCluster + "a": "cluster1"},
+			},
+			want: false,
+		},
+		{
+			name: "empty value",
+			args: args{
+				map[string]string{AnnotationKeyOCMManagedCluster: ""},
+			},
+			want: false,
+		},
+		{
+			name: "no pull annotation",
+			args: args{
+				map[string]string{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsValidPullAnnotation(tt.args.annos); got != tt.want {
+				t.Errorf("containsValidPullAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_containsValidManifestWorkHubApplicationAnnotations(t *testing.T) {
+	type args struct {
+		manifestWork workv1.ManifestWork
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "valid application annotations",
+			args: args{
+				workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							AnnotationKeyHubApplicationNamespace: "namespace1",
+							AnnotationKeyHubApplicationName:      "app-name1",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "missing application namespace annotation",
+			args: args{
+				workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							AnnotationKeyHubApplicationName: "app-name1",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "missing application name annotation",
+			args: args{
+				workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							AnnotationKeyHubApplicationNamespace: "namespace1",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty value",
+			args: args{
+				workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							AnnotationKeyHubApplicationNamespace: "",
+							AnnotationKeyHubApplicationName:      "",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "no application annotation",
+			args: args{
+				workv1.ManifestWork{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsValidManifestWorkHubApplicationAnnotations(tt.args.manifestWork); got != tt.want {
+				t.Errorf("containsValidManifestWorkHubApplicationAnnotations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_generateAppNamespace(t *testing.T) {
+	type args struct {
+		namespace string
+		annos     map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "annotation only",
+			args: args{
+				annos: map[string]string{AnnotationKeyOCMManagedClusterAppNamespace: "gitops"},
+			},
+			want: "gitops",
+		},
+		{
+			name: "annotation and namespace",
+			args: args{
+				annos:     map[string]string{AnnotationKeyOCMManagedClusterAppNamespace: "gitops"},
+				namespace: "argocd",
+			},
+			want: "gitops",
+		},
+		{
+			name: "namespace only",
+			args: args{
+				namespace: "gitops",
+			},
+			want: "gitops",
+		},
+		{
+			name: "annotation and namespace not found",
+			args: args{},
+			want: "argocd",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := generateAppNamespace(tt.args.namespace, tt.args.annos); got != tt.want {
+				t.Errorf("generateAppNamespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_generateManifestWorkName(t *testing.T) {
+	type args struct {
+		name string
+		uid  types.UID
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "generate name",
+			args: args{
+				name: "app1",
+				uid:  "abcdefghijk",
+			},
+			want: "app1-abcde",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := generateManifestWorkName(tt.args.name, tt.args.uid); got != tt.want {
+				t.Errorf("generateManifestWorkName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_prepareApplicationForWorkPayload(t *testing.T) {
+	// Create an unstructured application object as input
+	app := &unstructured.Unstructured{}
+	app.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Application",
+	})
+	app.SetName("app1")
+	app.SetNamespace("argocd")
+	app.SetFinalizers([]string{"app1-final"})
+	app.SetAnnotations(map[string]string{
+		AnnotationKeyAppSkipReconcile: "true",
+	})
+	app.Object["spec"] = map[string]interface{}{
+		"destination": map[string]interface{}{
+			"name":   "originalName",
+			"server": "originalServer",
+		},
+	}
+	app.Object["operation"] = map[string]interface{}{
+		"info": []interface{}{
+			map[string]interface{}{
+				"name":  "Reason",
+				"value": "ApplicationSet RollingSync triggered a sync of this Application resource.",
+			},
+		},
+		"initiatedBy": map[string]interface{}{
+			"automated": true,
+			"username":  "applicationset-controller",
+		},
+		"retry": map[string]interface{}{},
+		"sync": map[string]interface{}{
+			"syncOptions": []interface{}{
+				"CreateNamespace=true",
+			},
+		},
+	}
+
+	type args struct {
+		application *unstructured.Unstructured
+	}
+	tests := []struct {
+		name string
+		args args
+		want *unstructured.Unstructured
+	}{
+		{
+			name: "modified app",
+			args: args{application: app},
+			want: func() *unstructured.Unstructured {
+				expectedApp := &unstructured.Unstructured{}
+				expectedApp.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "argoproj.io",
+					Version: "v1alpha1",
+					Kind:    "Application",
+				})
+				expectedApp.SetName("app1")
+				expectedApp.SetNamespace("argocd")
+				expectedApp.SetFinalizers([]string{"app1-final"})
+				expectedApp.SetLabels(map[string]string{
+					// Add expected labels here except for LabelKeyPull
+				})
+				expectedApp.SetAnnotations(map[string]string{
+					// Add expected annotations here except for AnnotationKeyAppSkipReconcile
+				})
+				expectedApp.Object["spec"] = map[string]interface{}{
+					"destination": map[string]interface{}{
+						"name":   "",
+						"server": KubernetesInternalAPIServerAddr,
+					},
+				}
+				expectedApp.Object["operation"] = map[string]interface{}{
+					"info": []interface{}{
+						map[string]interface{}{
+							"name":  "Reason",
+							"value": "ApplicationSet RollingSync triggered a sync of this Application resource.",
+						},
+					},
+					"initiatedBy": map[string]interface{}{
+						"automated": true,
+						"username":  "applicationset-controller",
+					},
+					"retry": map[string]interface{}{},
+					"sync": map[string]interface{}{
+						"syncOptions": []interface{}{
+							"CreateNamespace=true",
+						},
+					},
+				}
+				return expectedApp
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := prepareApplicationForWorkPayload(tt.args.application)
+			if got.GetName() != tt.want.GetName() {
+				t.Errorf("prepareApplicationForWorkPayload() Name = %v, want %v", got.GetName(), tt.want.GetName())
+			}
+			if got.GetNamespace() != tt.want.GetNamespace() {
+				t.Errorf("prepareApplicationForWorkPayload() Namespace = %v, want %v", got.GetNamespace(), tt.want.GetNamespace())
+			}
+			if !reflect.DeepEqual(got.GetFinalizers(), tt.want.GetFinalizers()) {
+				t.Errorf("prepareApplicationForWorkPayload() Finalizers = %v, want %v", got.GetFinalizers(), tt.want.GetFinalizers())
+			}
+			gotSpec, _, _ := unstructured.NestedMap(got.Object, "spec")
+			wantSpec, _, _ := unstructured.NestedMap(tt.want.Object, "spec")
+			if !reflect.DeepEqual(gotSpec, wantSpec) {
+				t.Errorf("prepareApplicationForWorkPayload() Spec = %v, want %v", gotSpec, wantSpec)
+			}
+			gotOperation, _, _ := unstructured.NestedMap(got.Object, "operation")
+			wantOperation, _, _ := unstructured.NestedMap(tt.want.Object, "operation")
+			if !reflect.DeepEqual(gotOperation, wantOperation) {
+				t.Errorf("prepareApplicationForWorkPayload() Operation = %v, want %v", gotOperation, wantOperation)
+			}
+			if !reflect.DeepEqual(got.GetLabels(), tt.want.GetLabels()) {
+				t.Errorf("prepareApplicationForWorkPayload() Labels = %v, want %v", got.GetLabels(), tt.want.GetLabels())
+			}
+			if !reflect.DeepEqual(got.GetAnnotations(), tt.want.GetAnnotations()) {
+				t.Errorf("prepareApplicationForWorkPayload() Annotations = %v, want %v", got.GetAnnotations(), tt.want.GetAnnotations())
+			}
+		})
+	}
+}
+
+func Test_generateManifestWork(t *testing.T) {
+	app := &unstructured.Unstructured{}
+	app.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Application",
+	})
+	app.SetName("app1")
+	app.SetNamespace("argocd")
+	app.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion: "argoproj.io/v1alpha1",
+			Kind:       "ApplicationSet",
+			Name:       "appset1",
+		},
+	})
+	app.SetFinalizers([]string{ResourcesFinalizerName})
+
+	type args struct {
+		name      string
+		namespace string
+		app       *unstructured.Unstructured
+	}
+	type results struct {
+		workLabel map[string]string
+		workAnno  map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want results
+	}{
+		{
+			name: "sunny",
+			args: args{
+				name:      "app1-abcde",
+				namespace: "cluster1",
+				app:       app,
+			},
+			want: results{
+				workLabel: map[string]string{
+					LabelKeyPull:   strconv.FormatBool(true),
+					LabelKeyAppSet: strconv.FormatBool(true),
+				},
+				workAnno: map[string]string{
+					AnnotationKeyAppSet:                  "argocd/appset1",
+					AnnotationKeyHubApplicationNamespace: "argocd",
+					AnnotationKeyHubApplicationName:      "app1",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generateManifestWork(tt.args.name, tt.args.namespace, tt.args.app)
+			// Compare annotations
+			if !reflect.DeepEqual(got.ObjectMeta.Annotations, tt.want.workAnno) {
+				t.Errorf("generateManifestWork() annotations = %v, want %v", got.ObjectMeta.Annotations, tt.want.workAnno)
+			}
+			// Compare labels
+			if !reflect.DeepEqual(got.ObjectMeta.Labels, tt.want.workLabel) {
+				t.Errorf("generateManifestWork() labels = %v, want %v", got.ObjectMeta.Labels, tt.want.workLabel)
+			}
+			// Compare operation
+			if got.Spec.ManifestConfigs[0].UpdateStrategy.ServerSideApply.IgnoreFields[0].JSONPaths[0] != ".operation" {
+				t.Errorf("generateManifestWork() does not contain operation ignore field")
+			}
+		})
+	}
+}

--- a/internal/basic/application/suite_test.go
+++ b/internal/basic/application/suite_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "hack", "crds")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// Register only necessary schemes for cluster and work APIs
+	err = clusterv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = workv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Register and start the Application controllers
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&ApplicationReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&ApplicationStatusReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&ClusterReconciler{
+		Client:          k8sManager.GetClient(),
+		Scheme:          k8sManager.GetScheme(),
+		ArgoCDNamespace: "argocd",
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = k8sManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/test/e2e/basic_e2e_full_test.go
+++ b/test/e2e/basic_e2e_full_test.go
@@ -1,0 +1,313 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025 Open Cluster Management.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"open-cluster-management.io/argocd-pull-integration/test/utils"
+)
+
+var _ = Describe("ArgoCD Basic Pull Model Full Integration E2E", Label("basic-full"), Ordered, func() {
+	SetDefaultEventuallyTimeout(10 * time.Minute)
+	SetDefaultEventuallyPollingInterval(5 * time.Second)
+
+	const (
+		appSetName      = "test-appset"
+		appNamespace    = "argocd"
+		manifestWorkNs  = "cluster1"
+		targetNamespace = "guestbook"
+	)
+
+	BeforeAll(func() {
+		By("Verifying test environment is ready")
+		cmd := exec.Command("kubectl", "config", "get-contexts", hubContext)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Hub context should exist")
+
+		cmd = exec.Command("kubectl", "config", "get-contexts", cluster1Context)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Spoke context should exist")
+
+		By("Verifying ManagedClusterAddon is ready")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "--context", hubContext,
+				"get", "managedclusteraddon", "argocd",
+				"-n", manifestWorkNs,
+				"-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("True"))
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "--context", hubContext,
+				"get", "managedclusteraddon", "argocd",
+				"-n", manifestWorkNs,
+				"-o", "jsonpath={.status.conditions[?(@.type=='Progressing')].status}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("False"))
+		}).Should(Succeed())
+
+		fmt.Fprintf(GinkgoWriter, "ManagedClusterAddon argocd is ready\n")
+	})
+
+	AfterAll(func() {
+		// No cleanup - leave resources for debugging
+		fmt.Fprintf(GinkgoWriter, "\n")
+		fmt.Fprintf(GinkgoWriter, "Full integration test complete - resources left for debugging\n")
+	})
+
+	Context("Application Sync via ApplicationSet and ManifestWork", func() {
+		var appName string
+
+		It("should create ApplicationSet", func() {
+			By("creating test ApplicationSet on hub")
+			appSetYaml := fmt.Sprintf(`
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  generators:
+  - clusterDecisionResource:
+      configMapRef: ocm-placement-generator
+      labelSelector:
+        matchLabels:
+          cluster.open-cluster-management.io/placement: app-placement
+      requeueAfterSeconds: 30
+  template:
+    metadata:
+      annotations:
+        apps.open-cluster-management.io/ocm-managed-cluster: '{{name}}'
+        apps.open-cluster-management.io/ocm-managed-cluster-app-namespace: argocd
+        argocd.argoproj.io/skip-reconcile: "true"
+      labels:
+        apps.open-cluster-management.io/pull-to-ocm-managed-cluster: "true"
+      name: '{{name}}-app'
+    spec:
+      destination:
+        namespace: %s
+        server: https://kubernetes.default.svc
+      project: default
+      source:
+        path: guestbook
+        repoURL: https://github.com/argoproj/argocd-example-apps.git
+        targetRevision: HEAD
+      syncPolicy:
+        automated:
+          prune: true
+        syncOptions:
+        - CreateNamespace=true
+`, appSetName, appNamespace, targetNamespace)
+
+			cmd := exec.Command("kubectl", "--context", hubContext, "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(appSetYaml)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying ApplicationSet is created on hub")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "applicationset", appSetName,
+					"-n", appNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("verifying ApplicationSet has no errors")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "applicationset", appSetName,
+					"-n", appNamespace,
+					"-o", "jsonpath={.status.conditions[?(@.type=='ErrorOccurred')].status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("False"))
+			}).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "ApplicationSet %s created successfully\n", appSetName)
+		})
+
+		It("should create Application from ApplicationSet", func() {
+			By("verifying Application is created by ApplicationSet")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "application",
+					"-n", appNamespace,
+					"-o", "jsonpath={.items[*].metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty())
+				appName = strings.TrimSpace(output)
+			}).Should(Succeed())
+
+			By("verifying Application has correct labels and annotations")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "application", appName,
+					"-n", appNamespace,
+					"-o", "jsonpath={.metadata.labels.apps\\.open-cluster-management\\.io/pull-to-ocm-managed-cluster}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("true"))
+			}).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "Application %s created by ApplicationSet\n", appName)
+		})
+
+		It("should create ManifestWork for Application", func() {
+			By("verifying ManifestWork is created with pattern <appname>-<uid-first-5-chars>")
+			var manifestWorkName string
+			Eventually(func(g Gomega) {
+				// Get the Application UID to construct expected ManifestWork name
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "application", appName,
+					"-n", appNamespace,
+					"-o", "jsonpath={.metadata.uid}")
+				uidOutput, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(uidOutput).NotTo(BeEmpty())
+
+				// ManifestWork name is appname + "-" + first 5 chars of UID
+				expectedMWName := appName + "-" + uidOutput[:5]
+
+				cmd = exec.Command("kubectl", "--context", hubContext,
+					"get", "manifestwork", expectedMWName,
+					"-n", manifestWorkNs)
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				manifestWorkName = expectedMWName
+			}).Should(Succeed())
+
+			By("verifying ManifestWork contains Application payload")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "manifestwork", manifestWorkName,
+					"-n", manifestWorkNs,
+					"-o", "jsonpath={.spec.workload.manifests[0].kind}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Application"))
+			}).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "ManifestWork %s created successfully\n", manifestWorkName)
+		})
+
+		It("should pull Application to spoke cluster", func() {
+			By("verifying Application is pulled to spoke cluster")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "application", appName,
+					"-n", appNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("verifying Application sync status on spoke")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "application", appName,
+					"-n", appNamespace,
+					"-o", "jsonpath={.status.sync.status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Synced"))
+			}).Should(Succeed())
+
+			By("verifying Application health status on spoke")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "application", appName,
+					"-n", appNamespace,
+					"-o", "jsonpath={.status.health.status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Healthy"))
+			}).Should(Succeed())
+		})
+
+		It("should deploy application resources on spoke", func() {
+			By("verifying guestbook namespace is created")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "namespace", targetNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("verifying guestbook deployment is created")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "deployment", "guestbook-ui",
+					"-n", targetNamespace,
+					"-o", "jsonpath={.status.availableReplicas}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("1"))
+			}).Should(Succeed())
+		})
+
+		It("should sync Application status back to hub", func() {
+			By("verifying ManifestWork status is updated")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "manifestwork",
+					"-n", manifestWorkNs,
+					"-o", "jsonpath={.items[0].status.conditions[?(@.type=='Applied')].status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"))
+			}).Should(Succeed())
+
+			By("verifying Application sync status on hub is updated")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "application", appName,
+					"-n", appNamespace,
+					"-o", "jsonpath={.status.sync.status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Synced"))
+			}).Should(Succeed())
+
+			By("verifying Application health status on hub is updated")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "application", appName,
+					"-n", appNamespace,
+					"-o", "jsonpath={.status.health.status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Healthy"))
+			}).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "Application status successfully synced back to hub\n")
+		})
+	})
+})


### PR DESCRIPTION
## Overview

This PR integrates the basic pull model into the main project, enabling deployment of either basic or advanced pull models using a single Docker image with different launch parameters.

## Changes

### Core Architecture
- **Single Binary with Mode Flag**: Added `--mode` flag to support `controller` (advanced), `basic`, `addon`, and `cleanup` modes
- **Separate Schemes**: Basic mode uses isolated scheme without GitOpsCluster CRD to avoid conflicts
- **Code Organization**: Moved basic controllers to `internal/basic/application/`

### Helm Charts
- **argocd-pull-integration**: Basic pull model chart (uses `--mode=basic`)
- **argocd-agent-addon**: Advanced pull model chart (existing, uses `--mode=controller`)
- Both charts use the same Docker image with different args

### CI/CD Updates
- **GitHub Actions**: Updated workflows to build, test, and release both charts
- **Versioning**: Both charts released together with same version
- **Chart Upload**: Both charts uploaded to OCM Helm repository

### Testing
- **E2E Tests**: Added `test-e2e-basic` and `test-e2e-basic-full` targets
- **Optimized Setup**: Implemented faster ArgoCD deployment by scaling down unnecessary components
- **CI Integration**: Basic e2e tests run automatically in GitHub Actions

## Deployment
Users can choose deployment model:
- **Basic**: `helm install argocd-pull-integration charts/argocd-pull-integration`
- **Advanced**: `helm install argocd-agent-addon charts/argocd-agent-addon`