### PR TITLE
Fix orphaned ManifestWork cleanup for Applications without finalizers in Basic pull model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,7 @@ test-e2e-basic: manifests generate fmt vet ## Run e2e tests for basic pull model
 	$(KUBECTL) config use-context kind-$(HUB_CLUSTER)
 	$(KUBECTL) create namespace argocd --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUBECTL) apply -n argocd --force -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+	sleep 30
 	$(KUBECTL) -n argocd scale deployment/argocd-dex-server --replicas 0
 	$(KUBECTL) -n argocd scale deployment/argocd-repo-server --replicas 0
 	$(KUBECTL) -n argocd scale deployment/argocd-server --replicas 0

--- a/charts/argocd-agent-addon/Chart.yaml
+++ b/charts/argocd-agent-addon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.26.0
-description: Argo CD Agent Addon for Open Cluster Management
+appVersion: 0.26.1
+description: Argo CD Agent Add-on for Open Cluster Management (Advanced Pull Model)
 name: argocd-agent-addon
 type: application
-version: 0.26.0
+version: 0.26.1

--- a/charts/argocd-agent-addon/values.yaml
+++ b/charts/argocd-agent-addon/values.yaml
@@ -1,6 +1,6 @@
 # Controller manager image settings
 # For development (main branch): use "latest" tag
-# For release branches: update tag to match the release version (e.g., "0.26.0")
+# For release branches: update tag to match the release version (e.g., "0.26.1")
 image: quay.io/open-cluster-management/argocd-pull-integration
 tag: latest
 replicas: 1

--- a/charts/argocd-pull-integration/Chart.yaml
+++ b/charts/argocd-pull-integration/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.26.0
-description: A Helm chart for OCM Argo CD Pull Model Integration
+appVersion: 0.26.1
+description: Argo CD Pull Integration Add-on for Open Cluster Management (Basic Pull Model)
 name: argocd-pull-integration
 type: application
-version: 0.26.0
+version: 0.26.1

--- a/charts/argocd-pull-integration/values.yaml
+++ b/charts/argocd-pull-integration/values.yaml
@@ -1,6 +1,6 @@
 # Controller manager image settings
 # For development (main branch): use "latest" tag
-# For release branches: update tag to match the release version (e.g., "0.26.0")
+# For release branches: update tag to match the release version (e.g., "0.26.1")
 image: quay.io/open-cluster-management/argocd-pull-integration
 tag: latest
 replicas: 1

--- a/internal/addon/charts/argocd-agent-addon/Chart.yaml
+++ b/internal/addon/charts/argocd-agent-addon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: argocd-agent-addon
 description: Argo CD Agent Addon
 type: application
-version: 0.26.0
-appVersion: 0.26.0
+version: 0.26.1
+appVersion: 0.26.1

--- a/internal/basic/application/manifestwork_cleanup_controller.go
+++ b/internal/basic/application/manifestwork_cleanup_controller.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+// ManifestWorkCleanupReconciler periodically cleans up orphaned ManifestWorks
+// whose parent Applications no longer exist
+type ManifestWorkCleanupReconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Interval time.Duration
+}
+
+// Start begins the periodic cleanup process
+func (r *ManifestWorkCleanupReconciler) Start(ctx context.Context) error {
+	log := log.FromContext(ctx)
+	log.Info("Starting ManifestWork cleanup controller", "interval", r.Interval.String())
+
+	ticker := time.NewTicker(r.Interval)
+	defer ticker.Stop()
+
+	// Run cleanup immediately on startup
+	if err := r.cleanup(ctx); err != nil {
+		log.Error(err, "initial cleanup failed")
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("Stopping ManifestWork cleanup controller")
+			return nil
+		case <-ticker.C:
+			if err := r.cleanup(ctx); err != nil {
+				log.Error(err, "periodic cleanup failed")
+			}
+		}
+	}
+}
+
+// cleanup finds and deletes orphaned ManifestWorks
+func (r *ManifestWorkCleanupReconciler) cleanup(ctx context.Context) error {
+	log := log.FromContext(ctx)
+	log.Info("Running periodic ManifestWork cleanup")
+
+	// List all ManifestWorks that have the pull label
+	var manifestWorkList workv1.ManifestWorkList
+	if err := r.List(ctx, &manifestWorkList, client.MatchingLabels{
+		LabelKeyPull: "true",
+	}); err != nil {
+		log.Error(err, "unable to list ManifestWorks")
+		return err
+	}
+
+	log.Info("Found ManifestWorks with pull label", "count", len(manifestWorkList.Items))
+
+	orphanedCount := 0
+	deletedCount := 0
+
+	// Check each ManifestWork to see if its parent Application still exists
+	for _, work := range manifestWorkList.Items {
+		if !containsValidManifestWorkHubApplicationAnnotations(work) {
+			log.V(1).Info("ManifestWork missing required annotations, skipping", "name", work.Name, "namespace", work.Namespace)
+			continue
+		}
+
+		annos := work.GetAnnotations()
+		appNamespace := annos[AnnotationKeyHubApplicationNamespace]
+		appName := annos[AnnotationKeyHubApplicationName]
+
+		// Check if the Application still exists
+		application := &unstructured.Unstructured{}
+		application.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "argoproj.io",
+			Version: "v1alpha1",
+			Kind:    "Application",
+		})
+
+		err := r.Get(ctx, types.NamespacedName{Name: appName, Namespace: appNamespace}, application)
+		if errors.IsNotFound(err) {
+			// Application doesn't exist, this ManifestWork is orphaned
+			orphanedCount++
+			log.Info("Found orphaned ManifestWork", "manifestwork", work.Name, "namespace", work.Namespace, "application", appName)
+
+			if err := r.Delete(ctx, &work); err != nil {
+				if errors.IsNotFound(err) {
+					// Already deleted, that's fine
+					deletedCount++
+					continue
+				}
+				log.Error(err, "unable to delete orphaned ManifestWork", "name", work.Name, "namespace", work.Namespace)
+				continue
+			}
+			deletedCount++
+			log.Info("Deleted orphaned ManifestWork", "manifestwork", work.Name, "namespace", work.Namespace)
+		} else if err != nil {
+			log.Error(err, "unable to check Application existence", "application", appName, "namespace", appNamespace)
+			continue
+		}
+	}
+
+	log.Info("Periodic ManifestWork cleanup completed", "orphaned", orphanedCount, "deleted", deletedCount)
+	return nil
+}

--- a/internal/basic/application/manifestwork_cleanup_controller_test.go
+++ b/internal/basic/application/manifestwork_cleanup_controller_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+var _ = Describe("ManifestWork Cleanup Controller", func() {
+	const (
+		appName4     = "app-cleanup-4"
+		appName5     = "app-cleanup-5"
+		appNamespace = "default"
+		clusterName3 = "cluster-cleanup-test"
+	)
+
+	appKey4 := types.NamespacedName{Name: appName4, Namespace: appNamespace}
+	appKey5 := types.NamespacedName{Name: appName5, Namespace: appNamespace}
+	ctx := context.Background()
+
+	Context("When ManifestWork cleanup runs", func() {
+		It("Should delete orphaned ManifestWorks", func() {
+			By("Creating the OCM ManagedCluster")
+			managedCluster3 := clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName3,
+				},
+			}
+			_ = k8sClient.Delete(ctx, &managedCluster3) // Clean up if exists from previous run
+			Expect(k8sClient.Create(ctx, &managedCluster3)).Should(Succeed())
+
+			By("Creating the OCM ManagedCluster namespace")
+			managedClusterNs3 := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName3,
+				},
+			}
+			_ = k8sClient.Delete(ctx, &managedClusterNs3) // Clean up if exists from previous run
+			Expect(k8sClient.Create(ctx, &managedClusterNs3)).Should(Succeed())
+
+			By("Creating Application app-4")
+			app4 := &unstructured.Unstructured{}
+			app4.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "argoproj.io",
+				Version: "v1alpha1",
+				Kind:    "Application",
+			})
+			app4.SetName(appName4)
+			app4.SetNamespace(appNamespace)
+			app4.SetLabels(map[string]string{LabelKeyPull: strconv.FormatBool(true)})
+			app4.SetAnnotations(map[string]string{AnnotationKeyOCMManagedCluster: clusterName3})
+
+			// Set required spec fields
+			_ = unstructured.SetNestedField(app4.Object, "default", "spec", "project")
+			_ = unstructured.SetNestedField(app4.Object, "default", "spec", "source", "repoURL")
+			_ = unstructured.SetNestedMap(app4.Object, map[string]interface{}{"server": KubernetesInternalAPIServerAddr}, "spec", "destination")
+
+			Expect(k8sClient.Create(ctx, app4)).Should(Succeed())
+			app4 = &unstructured.Unstructured{}
+			app4.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "argoproj.io",
+				Version: "v1alpha1",
+				Kind:    "Application",
+			})
+			Expect(k8sClient.Get(ctx, appKey4, app4)).Should(Succeed())
+
+			By("Creating Application app-5")
+			app5 := &unstructured.Unstructured{}
+			app5.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "argoproj.io",
+				Version: "v1alpha1",
+				Kind:    "Application",
+			})
+			app5.SetName(appName5)
+			app5.SetNamespace(appNamespace)
+			app5.SetLabels(map[string]string{LabelKeyPull: strconv.FormatBool(true)})
+			app5.SetAnnotations(map[string]string{AnnotationKeyOCMManagedCluster: clusterName3})
+
+			// Set required spec fields
+			_ = unstructured.SetNestedField(app5.Object, "default", "spec", "project")
+			_ = unstructured.SetNestedField(app5.Object, "default", "spec", "source", "repoURL")
+			_ = unstructured.SetNestedMap(app5.Object, map[string]interface{}{"server": KubernetesInternalAPIServerAddr}, "spec", "destination")
+
+			Expect(k8sClient.Create(ctx, app5)).Should(Succeed())
+			app5 = &unstructured.Unstructured{}
+			app5.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "argoproj.io",
+				Version: "v1alpha1",
+				Kind:    "Application",
+			})
+			Expect(k8sClient.Get(ctx, appKey5, app5)).Should(Succeed())
+
+			By("Waiting for ManifestWorks to be created")
+			mwKey4 := types.NamespacedName{Name: generateManifestWorkName(app4.GetName(), app4.GetUID()), Namespace: clusterName3}
+			mwKey5 := types.NamespacedName{Name: generateManifestWorkName(app5.GetName(), app5.GetUID()), Namespace: clusterName3}
+
+			Eventually(func() bool {
+				mw4 := workv1.ManifestWork{}
+				return k8sClient.Get(ctx, mwKey4, &mw4) == nil
+			}).Should(BeTrue())
+
+			Eventually(func() bool {
+				mw5 := workv1.ManifestWork{}
+				return k8sClient.Get(ctx, mwKey5, &mw5) == nil
+			}).Should(BeTrue())
+
+			By("Deleting Application app-5 (will be orphaned)")
+			Expect(k8sClient.Delete(ctx, app5)).Should(Succeed())
+
+			By("Waiting for app-5 to be deleted")
+			Eventually(func() bool {
+				tempApp := &unstructured.Unstructured{}
+				tempApp.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "argoproj.io",
+					Version: "v1alpha1",
+					Kind:    "Application",
+				})
+				err := k8sClient.Get(ctx, appKey5, tempApp)
+				return err != nil
+			}).Should(BeTrue())
+
+			By("Verifying ManifestWork for app-5 still exists initially")
+			mw5 := workv1.ManifestWork{}
+			Expect(k8sClient.Get(ctx, mwKey5, &mw5)).Should(Succeed())
+
+			By("Running cleanup controller once")
+			cleanupReconciler := &ManifestWorkCleanupReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Interval: 5 * time.Minute,
+			}
+			Expect(cleanupReconciler.cleanup(ctx)).Should(Succeed())
+
+			By("Verifying orphaned ManifestWork for app-5 is deleted")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, mwKey5, &mw5)
+				return err != nil
+			}).Should(BeTrue())
+
+			By("Verifying ManifestWork for app-4 still exists (not orphaned)")
+			mw4 := workv1.ManifestWork{}
+			Expect(k8sClient.Get(ctx, mwKey4, &mw4)).Should(Succeed())
+
+			By("Cleaning up app-4")
+			Expect(k8sClient.Delete(ctx, app4)).Should(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
Fix orphaned ManifestWork cleanup for Applications without finalizers in **Basic pull model**

This PR implements a two-tier cleanup mechanism:

1. Immediate Cleanup: Enhanced the ApplicationReconciler to detect when an Application is not found during reconciliation. When this occurs, the controller searches for any ManifestWorks with matching hub-application-name and hub-application-namespace annotations and deletes them.

2. Periodic Cleanup: Added a new ManifestWorkCleanupController that runs every 5 minutes as a safety net. This controller lists all ManifestWorks with the pull label, checks if their corresponding hub Applications still exist, and deletes any orphaned ManifestWorks. This handles edge cases where the immediate cleanup might fail or be missed.
