### PR TITLE
fix: use server-side apply for ArgoCD install to avoid CRD annotation size limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ test-e2e-basic: manifests generate fmt vet ## Run e2e tests for basic pull model
 	@echo "===== Installing ArgoCD on hub cluster (optimized) ====="
 	$(KUBECTL) config use-context kind-$(HUB_CLUSTER)
 	$(KUBECTL) create namespace argocd --dry-run=client -o yaml | $(KUBECTL) apply -f -
-	$(KUBECTL) apply -n argocd --server-side --force -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+	$(KUBECTL) apply -n argocd --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 	sleep 30
 	$(KUBECTL) -n argocd scale deployment/argocd-dex-server --replicas 0
 	$(KUBECTL) -n argocd scale deployment/argocd-repo-server --replicas 0


### PR DESCRIPTION
## Description
This PR switches the E2E test setup from client-side apply to Server-Side Apply (SSA) when installing the ApplicationSet CRD.

## The Problem:
Currently, the E2E suite uses standard kubectl apply, which performs a client-side apply. Because the ApplicationSet CRD has grown significantly in size, it now exceeds the 262,144-byte limit for metadata annotations, causing the E2E tests to fail during the setup phase.

https://github.com/open-cluster-management-io/argocd-pull-integration/issues/172

## The Solution:
By using the --server-side flag, we shift the responsibility of field management to the API server, effectively bypassing the 256KB size limit and making the installation more robust.

## Changes
- Modified Makefile (or relevant setup script) to include --server-side