### PR TITLE
feat: adopt ApplicationSet with destination-based mapping for advanced pull model

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,47 @@ graph LR
 1. Create a OCM `GitOpsCluster` CR that references an OCM Placement to select target clusters
 2. The controller automatically deploys OCM argocd-agent add-on, configures secure gRPC communication, manages certificates, and sets up cluster registration
 3. argocd-agent connects to hub Argo CD and synchronizes applications with **full status feedback**
+4. Use `ApplicationSet` with `clusterDecisionResource` generator to automatically create Applications for all selected clusters using `spec.destination.name` for routing
+
+**ApplicationSet Integration:**
+
+The advanced pull model uses **destination-based mapping** where Applications are routed to managed clusters based on `spec.destination.name`. This enables natural `ApplicationSet` integration:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: my-appset
+  namespace: argocd  # Same namespace as ArgoCD
+spec:
+  generators:
+  - clusterDecisionResource:
+      configMapRef: ocm-placement-generator
+      labelSelector:
+        matchLabels:
+          cluster.open-cluster-management.io/placement: placement
+      requeueAfterSeconds: 30
+  template:
+    metadata:
+      name: '{{name}}-myapp'
+    spec:
+      destination:
+        name: '{{name}}'           # Routes to agent by cluster name
+        namespace: my-namespace
+      project: default
+      source:
+        repoURL: https://github.com/myorg/myrepo.git
+        path: manifests
+        targetRevision: HEAD
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+```
+
+The `clusterDecisionResource` generator reads from OCM `PlacementDecision` resources to discover target clusters. Each cluster gets its own Application with `destination.name` set to the cluster name, which the argocd-agent principal uses to route the Application to the correct agent.
 
 For detailed argocd-agent architecture and operational modes, see [argocd-agent Documentation](https://argocd-agent.readthedocs.io/).
 

--- a/charts/argocd-agent-addon/crds/argocd-operator-crds.yaml
+++ b/charts/argocd-agent-addon/crds/argocd-operator-crds.yaml
@@ -110,6 +110,10 @@ spec:
                       a failed sync. If set to 0, no retries will be performed.
                     format: int64
                     type: integer
+                  refresh:
+                    description: 'Refresh indicates if the latest revision should
+                      be used on retry instead of the initial one (default: false)'
+                    type: boolean
                 type: object
               sync:
                 description: Sync contains parameters for the operation
@@ -1438,10 +1442,357 @@ spec:
                     description: DrySource specifies where the dry "don't repeat yourself"
                       manifest source lives.
                     properties:
+                      directory:
+                        description: Directory specifies path/directory specific options
+                        properties:
+                          exclude:
+                            description: Exclude contains a glob pattern to match
+                              paths against that should be explicitly excluded from
+                              being used during manifest generation
+                            type: string
+                          include:
+                            description: Include contains a glob pattern to match
+                              paths against that should be explicitly included during
+                              manifest generation
+                            type: string
+                          jsonnet:
+                            description: Jsonnet holds options specific to Jsonnet
+                            properties:
+                              extVars:
+                                description: ExtVars is a list of Jsonnet External
+                                  Variables
+                                items:
+                                  description: JsonnetVar represents a variable to
+                                    be passed to jsonnet during manifest generation
+                                  properties:
+                                    code:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              libs:
+                                description: Additional library search dirs
+                                items:
+                                  type: string
+                                type: array
+                              tlas:
+                                description: TLAS is a list of Jsonnet Top-level Arguments
+                                items:
+                                  description: JsonnetVar represents a variable to
+                                    be passed to jsonnet during manifest generation
+                                  properties:
+                                    code:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          recurse:
+                            description: Recurse specifies whether to scan a directory
+                              recursively for manifests
+                            type: boolean
+                        type: object
+                      helm:
+                        description: Helm specifies helm specific options
+                        properties:
+                          apiVersions:
+                            description: |-
+                              APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                              Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                            items:
+                              type: string
+                            type: array
+                          fileParameters:
+                            description: FileParameters are file parameters to the
+                              helm template
+                            items:
+                              description: HelmFileParameter is a file parameter that's
+                                passed to helm template during manifest generation
+                              properties:
+                                name:
+                                  description: Name is the name of the Helm parameter
+                                  type: string
+                                path:
+                                  description: Path is the path to the file containing
+                                    the values for the Helm parameter
+                                  type: string
+                              type: object
+                            type: array
+                          ignoreMissingValueFiles:
+                            description: IgnoreMissingValueFiles prevents helm template
+                              from failing when valueFiles do not exist locally by
+                              not appending them to helm template --values
+                            type: boolean
+                          kubeVersion:
+                            description: |-
+                              KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                              uses the Kubernetes version of the target cluster.
+                            type: string
+                          namespace:
+                            description: Namespace is an optional namespace to template
+                              with. If left empty, defaults to the app's destination
+                              namespace.
+                            type: string
+                          parameters:
+                            description: Parameters is a list of Helm parameters which
+                              are passed to the helm template command upon manifest
+                              generation
+                            items:
+                              description: HelmParameter is a parameter that's passed
+                                to helm template during manifest generation
+                              properties:
+                                forceString:
+                                  description: ForceString determines whether to tell
+                                    Helm to interpret booleans and numbers as strings
+                                  type: boolean
+                                name:
+                                  description: Name is the name of the Helm parameter
+                                  type: string
+                                value:
+                                  description: Value is the value for the Helm parameter
+                                  type: string
+                              type: object
+                            type: array
+                          passCredentials:
+                            description: PassCredentials pass credentials to all domains
+                              (Helm's --pass-credentials)
+                            type: boolean
+                          releaseName:
+                            description: ReleaseName is the Helm release name to use.
+                              If omitted it will use the application name
+                            type: string
+                          skipCrds:
+                            description: SkipCrds skips custom resource definition
+                              installation step (Helm's --skip-crds)
+                            type: boolean
+                          skipSchemaValidation:
+                            description: SkipSchemaValidation skips JSON schema validation
+                              (Helm's --skip-schema-validation)
+                            type: boolean
+                          skipTests:
+                            description: SkipTests skips test manifest installation
+                              step (Helm's --skip-tests).
+                            type: boolean
+                          valueFiles:
+                            description: ValuesFiles is a list of Helm value files
+                              to use when generating a template
+                            items:
+                              type: string
+                            type: array
+                          values:
+                            description: Values specifies Helm values to be passed
+                              to helm template, typically defined as a block. ValuesObject
+                              takes precedence over Values, so use one or the other.
+                            type: string
+                          valuesObject:
+                            description: ValuesObject specifies Helm values to be
+                              passed to helm template, defined as a map. This takes
+                              precedence over Values.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          version:
+                            description: Version is the Helm version to use for templating
+                              ("3")
+                            type: string
+                        type: object
+                      kustomize:
+                        description: Kustomize specifies kustomize specific options
+                        properties:
+                          apiVersions:
+                            description: |-
+                              APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                              Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                            items:
+                              type: string
+                            type: array
+                          commonAnnotations:
+                            additionalProperties:
+                              type: string
+                            description: CommonAnnotations is a list of additional
+                              annotations to add to rendered manifests
+                            type: object
+                          commonAnnotationsEnvsubst:
+                            description: CommonAnnotationsEnvsubst specifies whether
+                              to apply env variables substitution for annotation values
+                            type: boolean
+                          commonLabels:
+                            additionalProperties:
+                              type: string
+                            description: CommonLabels is a list of additional labels
+                              to add to rendered manifests
+                            type: object
+                          components:
+                            description: Components specifies a list of kustomize
+                              components to add to the kustomization before building
+                            items:
+                              type: string
+                            type: array
+                          forceCommonAnnotations:
+                            description: ForceCommonAnnotations specifies whether
+                              to force applying common annotations to resources for
+                              Kustomize apps
+                            type: boolean
+                          forceCommonLabels:
+                            description: ForceCommonLabels specifies whether to force
+                              applying common labels to resources for Kustomize apps
+                            type: boolean
+                          ignoreMissingComponents:
+                            description: IgnoreMissingComponents prevents kustomize
+                              from failing when components do not exist locally by
+                              not appending them to kustomization file
+                            type: boolean
+                          images:
+                            description: Images is a list of Kustomize image override
+                              specifications
+                            items:
+                              description: KustomizeImage represents a Kustomize image
+                                definition in the format [old_image_name=]<image_name>:<image_tag>
+                              type: string
+                            type: array
+                          kubeVersion:
+                            description: |-
+                              KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                              uses the Kubernetes version of the target cluster.
+                            type: string
+                          labelIncludeTemplates:
+                            description: LabelIncludeTemplates specifies whether to
+                              apply common labels to resource templates or not
+                            type: boolean
+                          labelWithoutSelector:
+                            description: LabelWithoutSelector specifies whether to
+                              apply common labels to resource selectors or not
+                            type: boolean
+                          namePrefix:
+                            description: NamePrefix is a prefix appended to resources
+                              for Kustomize apps
+                            type: string
+                          nameSuffix:
+                            description: NameSuffix is a suffix appended to resources
+                              for Kustomize apps
+                            type: string
+                          namespace:
+                            description: Namespace sets the namespace that Kustomize
+                              adds to all resources
+                            type: string
+                          patches:
+                            description: Patches is a list of Kustomize patches
+                            items:
+                              properties:
+                                options:
+                                  additionalProperties:
+                                    type: boolean
+                                  type: object
+                                patch:
+                                  type: string
+                                path:
+                                  type: string
+                                target:
+                                  properties:
+                                    annotationSelector:
+                                      type: string
+                                    group:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    labelSelector:
+                                      type: string
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    version:
+                                      type: string
+                                  type: object
+                              type: object
+                            type: array
+                          replicas:
+                            description: Replicas is a list of Kustomize Replicas
+                              override specifications
+                            items:
+                              properties:
+                                count:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number of replicas
+                                  x-kubernetes-int-or-string: true
+                                name:
+                                  description: Name of Deployment or StatefulSet
+                                  type: string
+                              required:
+                              - count
+                              - name
+                              type: object
+                            type: array
+                          version:
+                            description: Version controls which version of Kustomize
+                              to use for rendering manifests
+                            type: string
+                        type: object
                       path:
                         description: Path is a directory path within the Git repository
                           where the manifests are located
                         type: string
+                      plugin:
+                        description: Plugin specifies config management plugin specific
+                          options
+                        properties:
+                          env:
+                            description: Env is a list of environment variable entries
+                            items:
+                              description: EnvEntry represents an entry in the application's
+                                environment
+                              properties:
+                                name:
+                                  description: Name is the name of the variable, usually
+                                    expressed in uppercase
+                                  type: string
+                                value:
+                                  description: Value is the value of the variable
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          parameters:
+                            items:
+                              properties:
+                                array:
+                                  description: Array is the value of an array type
+                                    parameter.
+                                  items:
+                                    type: string
+                                  type: array
+                                map:
+                                  additionalProperties:
+                                    type: string
+                                  description: Map is the value of a map type parameter.
+                                  type: object
+                                name:
+                                  description: Name is the name identifying a parameter.
+                                  type: string
+                                string:
+                                  description: String_ is the value of a string type
+                                    parameter.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
                       repoURL:
                         description: RepoURL is the URL to the git repository that
                           contains the application manifests
@@ -1474,11 +1825,15 @@ spec:
                       path:
                         description: |-
                           Path is a directory path within the git repository where hydrated manifests should be committed to and synced
-                          from. If hydrateTo is set, this is just the path from which hydrated manifests will be synced.
+                          from. The Path should never point to the root of the repo. If hydrateTo is set, this is just the path from which
+                          hydrated manifests will be synced.
+                        minLength: 1
+                        pattern: ^.{2,}|[^./]$
                         type: string
                       targetBranch:
-                        description: TargetBranch is the branch to which hydrated
-                          manifests should be committed
+                        description: |-
+                          TargetBranch is the branch from which hydrated manifests will be synced.
+                          If HydrateTo is not set, this is also the branch to which hydrated manifests are committed.
                         type: string
                     required:
                     - path
@@ -1937,6 +2292,10 @@ spec:
                           a failed sync. If set to 0, no retries will be performed.
                         format: int64
                         type: integer
+                      refresh:
+                        description: 'Refresh indicates if the latest revision should
+                          be used on retry instead of the initial one (default: false)'
+                        type: boolean
                     type: object
                   syncOptions:
                     description: Options allow you to specify whole app sync-options
@@ -2905,6 +3264,11 @@ spec:
                               be performed.
                             format: int64
                             type: integer
+                          refresh:
+                            description: 'Refresh indicates if the latest revision
+                              should be used on retry instead of the initial one (default:
+                              false)'
+                            type: boolean
                         type: object
                       sync:
                         description: Sync contains parameters for the operation
@@ -4841,10 +5205,380 @@ spec:
                             description: DrySource specifies where the dry "don't
                               repeat yourself" manifest source lives.
                             properties:
+                              directory:
+                                description: Directory specifies path/directory specific
+                                  options
+                                properties:
+                                  exclude:
+                                    description: Exclude contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      excluded from being used during manifest generation
+                                    type: string
+                                  include:
+                                    description: Include contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      included during manifest generation
+                                    type: string
+                                  jsonnet:
+                                    description: Jsonnet holds options specific to
+                                      Jsonnet
+                                    properties:
+                                      extVars:
+                                        description: ExtVars is a list of Jsonnet
+                                          External Variables
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        description: Additional library search dirs
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        description: TLAS is a list of Jsonnet Top-level
+                                          Arguments
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    description: Recurse specifies whether to scan
+                                      a directory recursively for manifests
+                                    type: boolean
+                                type: object
+                              helm:
+                                description: Helm specifies helm specific options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  fileParameters:
+                                    description: FileParameters are file parameters
+                                      to the helm template
+                                    items:
+                                      description: HelmFileParameter is a file parameter
+                                        that's passed to helm template during manifest
+                                        generation
+                                      properties:
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        path:
+                                          description: Path is the path to the file
+                                            containing the values for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  ignoreMissingValueFiles:
+                                    description: IgnoreMissingValueFiles prevents
+                                      helm template from failing when valueFiles do
+                                      not exist locally by not appending them to helm
+                                      template --values
+                                    type: boolean
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is an optional namespace
+                                      to template with. If left empty, defaults to
+                                      the app's destination namespace.
+                                    type: string
+                                  parameters:
+                                    description: Parameters is a list of Helm parameters
+                                      which are passed to the helm template command
+                                      upon manifest generation
+                                    items:
+                                      description: HelmParameter is a parameter that's
+                                        passed to helm template during manifest generation
+                                      properties:
+                                        forceString:
+                                          description: ForceString determines whether
+                                            to tell Helm to interpret booleans and
+                                            numbers as strings
+                                          type: boolean
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        value:
+                                          description: Value is the value for the
+                                            Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  passCredentials:
+                                    description: PassCredentials pass credentials
+                                      to all domains (Helm's --pass-credentials)
+                                    type: boolean
+                                  releaseName:
+                                    description: ReleaseName is the Helm release name
+                                      to use. If omitted it will use the application
+                                      name
+                                    type: string
+                                  skipCrds:
+                                    description: SkipCrds skips custom resource definition
+                                      installation step (Helm's --skip-crds)
+                                    type: boolean
+                                  skipSchemaValidation:
+                                    description: SkipSchemaValidation skips JSON schema
+                                      validation (Helm's --skip-schema-validation)
+                                    type: boolean
+                                  skipTests:
+                                    description: SkipTests skips test manifest installation
+                                      step (Helm's --skip-tests).
+                                    type: boolean
+                                  valueFiles:
+                                    description: ValuesFiles is a list of Helm value
+                                      files to use when generating a template
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    description: Values specifies Helm values to be
+                                      passed to helm template, typically defined as
+                                      a block. ValuesObject takes precedence over
+                                      Values, so use one or the other.
+                                    type: string
+                                  valuesObject:
+                                    description: ValuesObject specifies Helm values
+                                      to be passed to helm template, defined as a
+                                      map. This takes precedence over Values.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  version:
+                                    description: Version is the Helm version to use
+                                      for templating ("3")
+                                    type: string
+                                type: object
+                              kustomize:
+                                description: Kustomize specifies kustomize specific
+                                  options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonAnnotations is a list of additional
+                                      annotations to add to rendered manifests
+                                    type: object
+                                  commonAnnotationsEnvsubst:
+                                    description: CommonAnnotationsEnvsubst specifies
+                                      whether to apply env variables substitution
+                                      for annotation values
+                                    type: boolean
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels is a list of additional
+                                      labels to add to rendered manifests
+                                    type: object
+                                  components:
+                                    description: Components specifies a list of kustomize
+                                      components to add to the kustomization before
+                                      building
+                                    items:
+                                      type: string
+                                    type: array
+                                  forceCommonAnnotations:
+                                    description: ForceCommonAnnotations specifies
+                                      whether to force applying common annotations
+                                      to resources for Kustomize apps
+                                    type: boolean
+                                  forceCommonLabels:
+                                    description: ForceCommonLabels specifies whether
+                                      to force applying common labels to resources
+                                      for Kustomize apps
+                                    type: boolean
+                                  ignoreMissingComponents:
+                                    description: IgnoreMissingComponents prevents
+                                      kustomize from failing when components do not
+                                      exist locally by not appending them to kustomization
+                                      file
+                                    type: boolean
+                                  images:
+                                    description: Images is a list of Kustomize image
+                                      override specifications
+                                    items:
+                                      description: KustomizeImage represents a Kustomize
+                                        image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                      type: string
+                                    type: array
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  labelIncludeTemplates:
+                                    description: LabelIncludeTemplates specifies whether
+                                      to apply common labels to resource templates
+                                      or not
+                                    type: boolean
+                                  labelWithoutSelector:
+                                    description: LabelWithoutSelector specifies whether
+                                      to apply common labels to resource selectors
+                                      or not
+                                    type: boolean
+                                  namePrefix:
+                                    description: NamePrefix is a prefix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  nameSuffix:
+                                    description: NameSuffix is a suffix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  namespace:
+                                    description: Namespace sets the namespace that
+                                      Kustomize adds to all resources
+                                    type: string
+                                  patches:
+                                    description: Patches is a list of Kustomize patches
+                                    items:
+                                      properties:
+                                        options:
+                                          additionalProperties:
+                                            type: boolean
+                                          type: object
+                                        patch:
+                                          type: string
+                                        path:
+                                          type: string
+                                        target:
+                                          properties:
+                                            annotationSelector:
+                                              type: string
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            labelSelector:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    type: array
+                                  replicas:
+                                    description: Replicas is a list of Kustomize Replicas
+                                      override specifications
+                                    items:
+                                      properties:
+                                        count:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number of replicas
+                                          x-kubernetes-int-or-string: true
+                                        name:
+                                          description: Name of Deployment or StatefulSet
+                                          type: string
+                                      required:
+                                      - count
+                                      - name
+                                      type: object
+                                    type: array
+                                  version:
+                                    description: Version controls which version of
+                                      Kustomize to use for rendering manifests
+                                    type: string
+                                type: object
                               path:
                                 description: Path is a directory path within the Git
                                   repository where the manifests are located
                                 type: string
+                              plugin:
+                                description: Plugin specifies config management plugin
+                                  specific options
+                                properties:
+                                  env:
+                                    description: Env is a list of environment variable
+                                      entries
+                                    items:
+                                      description: EnvEntry represents an entry in
+                                        the application's environment
+                                      properties:
+                                        name:
+                                          description: Name is the name of the variable,
+                                            usually expressed in uppercase
+                                          type: string
+                                        value:
+                                          description: Value is the value of the variable
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        array:
+                                          description: Array is the value of an array
+                                            type parameter.
+                                          items:
+                                            type: string
+                                          type: array
+                                        map:
+                                          additionalProperties:
+                                            type: string
+                                          description: Map is the value of a map type
+                                            parameter.
+                                          type: object
+                                        name:
+                                          description: Name is the name identifying
+                                            a parameter.
+                                          type: string
+                                        string:
+                                          description: String_ is the value of a string
+                                            type parameter.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
                               repoURL:
                                 description: RepoURL is the URL to the git repository
                                   that contains the application manifests
@@ -4877,11 +5611,15 @@ spec:
                               path:
                                 description: |-
                                   Path is a directory path within the git repository where hydrated manifests should be committed to and synced
-                                  from. If hydrateTo is set, this is just the path from which hydrated manifests will be synced.
+                                  from. The Path should never point to the root of the repo. If hydrateTo is set, this is just the path from which
+                                  hydrated manifests will be synced.
+                                minLength: 1
+                                pattern: ^.{2,}|[^./]$
                                 type: string
                               targetBranch:
-                                description: TargetBranch is the branch to which hydrated
-                                  manifests should be committed
+                                description: |-
+                                  TargetBranch is the branch from which hydrated manifests will be synced.
+                                  If HydrateTo is not set, this is also the branch to which hydrated manifests are committed.
                                 type: string
                             required:
                             - path
@@ -4920,10 +5658,380 @@ spec:
                             description: DrySource specifies where the dry "don't
                               repeat yourself" manifest source lives.
                             properties:
+                              directory:
+                                description: Directory specifies path/directory specific
+                                  options
+                                properties:
+                                  exclude:
+                                    description: Exclude contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      excluded from being used during manifest generation
+                                    type: string
+                                  include:
+                                    description: Include contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      included during manifest generation
+                                    type: string
+                                  jsonnet:
+                                    description: Jsonnet holds options specific to
+                                      Jsonnet
+                                    properties:
+                                      extVars:
+                                        description: ExtVars is a list of Jsonnet
+                                          External Variables
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        description: Additional library search dirs
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        description: TLAS is a list of Jsonnet Top-level
+                                          Arguments
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    description: Recurse specifies whether to scan
+                                      a directory recursively for manifests
+                                    type: boolean
+                                type: object
+                              helm:
+                                description: Helm specifies helm specific options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  fileParameters:
+                                    description: FileParameters are file parameters
+                                      to the helm template
+                                    items:
+                                      description: HelmFileParameter is a file parameter
+                                        that's passed to helm template during manifest
+                                        generation
+                                      properties:
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        path:
+                                          description: Path is the path to the file
+                                            containing the values for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  ignoreMissingValueFiles:
+                                    description: IgnoreMissingValueFiles prevents
+                                      helm template from failing when valueFiles do
+                                      not exist locally by not appending them to helm
+                                      template --values
+                                    type: boolean
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is an optional namespace
+                                      to template with. If left empty, defaults to
+                                      the app's destination namespace.
+                                    type: string
+                                  parameters:
+                                    description: Parameters is a list of Helm parameters
+                                      which are passed to the helm template command
+                                      upon manifest generation
+                                    items:
+                                      description: HelmParameter is a parameter that's
+                                        passed to helm template during manifest generation
+                                      properties:
+                                        forceString:
+                                          description: ForceString determines whether
+                                            to tell Helm to interpret booleans and
+                                            numbers as strings
+                                          type: boolean
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        value:
+                                          description: Value is the value for the
+                                            Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  passCredentials:
+                                    description: PassCredentials pass credentials
+                                      to all domains (Helm's --pass-credentials)
+                                    type: boolean
+                                  releaseName:
+                                    description: ReleaseName is the Helm release name
+                                      to use. If omitted it will use the application
+                                      name
+                                    type: string
+                                  skipCrds:
+                                    description: SkipCrds skips custom resource definition
+                                      installation step (Helm's --skip-crds)
+                                    type: boolean
+                                  skipSchemaValidation:
+                                    description: SkipSchemaValidation skips JSON schema
+                                      validation (Helm's --skip-schema-validation)
+                                    type: boolean
+                                  skipTests:
+                                    description: SkipTests skips test manifest installation
+                                      step (Helm's --skip-tests).
+                                    type: boolean
+                                  valueFiles:
+                                    description: ValuesFiles is a list of Helm value
+                                      files to use when generating a template
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    description: Values specifies Helm values to be
+                                      passed to helm template, typically defined as
+                                      a block. ValuesObject takes precedence over
+                                      Values, so use one or the other.
+                                    type: string
+                                  valuesObject:
+                                    description: ValuesObject specifies Helm values
+                                      to be passed to helm template, defined as a
+                                      map. This takes precedence over Values.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  version:
+                                    description: Version is the Helm version to use
+                                      for templating ("3")
+                                    type: string
+                                type: object
+                              kustomize:
+                                description: Kustomize specifies kustomize specific
+                                  options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonAnnotations is a list of additional
+                                      annotations to add to rendered manifests
+                                    type: object
+                                  commonAnnotationsEnvsubst:
+                                    description: CommonAnnotationsEnvsubst specifies
+                                      whether to apply env variables substitution
+                                      for annotation values
+                                    type: boolean
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels is a list of additional
+                                      labels to add to rendered manifests
+                                    type: object
+                                  components:
+                                    description: Components specifies a list of kustomize
+                                      components to add to the kustomization before
+                                      building
+                                    items:
+                                      type: string
+                                    type: array
+                                  forceCommonAnnotations:
+                                    description: ForceCommonAnnotations specifies
+                                      whether to force applying common annotations
+                                      to resources for Kustomize apps
+                                    type: boolean
+                                  forceCommonLabels:
+                                    description: ForceCommonLabels specifies whether
+                                      to force applying common labels to resources
+                                      for Kustomize apps
+                                    type: boolean
+                                  ignoreMissingComponents:
+                                    description: IgnoreMissingComponents prevents
+                                      kustomize from failing when components do not
+                                      exist locally by not appending them to kustomization
+                                      file
+                                    type: boolean
+                                  images:
+                                    description: Images is a list of Kustomize image
+                                      override specifications
+                                    items:
+                                      description: KustomizeImage represents a Kustomize
+                                        image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                      type: string
+                                    type: array
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  labelIncludeTemplates:
+                                    description: LabelIncludeTemplates specifies whether
+                                      to apply common labels to resource templates
+                                      or not
+                                    type: boolean
+                                  labelWithoutSelector:
+                                    description: LabelWithoutSelector specifies whether
+                                      to apply common labels to resource selectors
+                                      or not
+                                    type: boolean
+                                  namePrefix:
+                                    description: NamePrefix is a prefix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  nameSuffix:
+                                    description: NameSuffix is a suffix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  namespace:
+                                    description: Namespace sets the namespace that
+                                      Kustomize adds to all resources
+                                    type: string
+                                  patches:
+                                    description: Patches is a list of Kustomize patches
+                                    items:
+                                      properties:
+                                        options:
+                                          additionalProperties:
+                                            type: boolean
+                                          type: object
+                                        patch:
+                                          type: string
+                                        path:
+                                          type: string
+                                        target:
+                                          properties:
+                                            annotationSelector:
+                                              type: string
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            labelSelector:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    type: array
+                                  replicas:
+                                    description: Replicas is a list of Kustomize Replicas
+                                      override specifications
+                                    items:
+                                      properties:
+                                        count:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number of replicas
+                                          x-kubernetes-int-or-string: true
+                                        name:
+                                          description: Name of Deployment or StatefulSet
+                                          type: string
+                                      required:
+                                      - count
+                                      - name
+                                      type: object
+                                    type: array
+                                  version:
+                                    description: Version controls which version of
+                                      Kustomize to use for rendering manifests
+                                    type: string
+                                type: object
                               path:
                                 description: Path is a directory path within the Git
                                   repository where the manifests are located
                                 type: string
+                              plugin:
+                                description: Plugin specifies config management plugin
+                                  specific options
+                                properties:
+                                  env:
+                                    description: Env is a list of environment variable
+                                      entries
+                                    items:
+                                      description: EnvEntry represents an entry in
+                                        the application's environment
+                                      properties:
+                                        name:
+                                          description: Name is the name of the variable,
+                                            usually expressed in uppercase
+                                          type: string
+                                        value:
+                                          description: Value is the value of the variable
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        array:
+                                          description: Array is the value of an array
+                                            type parameter.
+                                          items:
+                                            type: string
+                                          type: array
+                                        map:
+                                          additionalProperties:
+                                            type: string
+                                          description: Map is the value of a map type
+                                            parameter.
+                                          type: object
+                                        name:
+                                          description: Name is the name identifying
+                                            a parameter.
+                                          type: string
+                                        string:
+                                          description: String_ is the value of a string
+                                            type parameter.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
                               repoURL:
                                 description: RepoURL is the URL to the git repository
                                   that contains the application manifests
@@ -4956,11 +6064,15 @@ spec:
                               path:
                                 description: |-
                                   Path is a directory path within the git repository where hydrated manifests should be committed to and synced
-                                  from. If hydrateTo is set, this is just the path from which hydrated manifests will be synced.
+                                  from. The Path should never point to the root of the repo. If hydrateTo is set, this is just the path from which
+                                  hydrated manifests will be synced.
+                                minLength: 1
+                                pattern: ^.{2,}|[^./]$
                                 type: string
                               targetBranch:
-                                description: TargetBranch is the branch to which hydrated
-                                  manifests should be committed
+                                description: |-
+                                  TargetBranch is the branch from which hydrated manifests will be synced.
+                                  If HydrateTo is not set, this is also the branch to which hydrated manifests are committed.
                                 type: string
                             required:
                             - path
@@ -6279,8 +7391,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -6300,6 +7634,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -6591,6 +7927,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -6961,8 +8299,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -6982,6 +8542,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -7273,6 +8835,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -7644,8 +9208,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -7665,6 +9451,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -7956,6 +9744,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -8305,8 +10095,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -8326,6 +10338,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -8617,6 +10631,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -8991,8 +11007,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -9012,6 +11250,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -9303,6 +11543,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -9673,8 +11915,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -9694,6 +12158,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -9985,6 +12451,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -10356,8 +12824,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -10377,6 +13067,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -10668,6 +13360,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -11017,8 +13711,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -11038,6 +13954,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -11329,6 +14247,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -11686,8 +14606,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -11707,6 +14849,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -11998,6 +15142,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -12153,12 +15299,16 @@ spec:
                                     - project
                                     - repo
                                     type: object
+                                  continueOnRepoNotFoundError:
+                                    type: boolean
                                   filters:
                                     items:
                                       properties:
                                         branchMatch:
                                           type: string
                                         targetBranchMatch:
+                                          type: string
+                                        titleMatch:
                                           type: string
                                       type: object
                                     type: array
@@ -12578,8 +15728,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -12599,6 +15971,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -12890,6 +16264,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -13465,8 +16841,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -13486,6 +17084,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -13777,6 +17377,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -14143,8 +17745,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -14164,6 +17988,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -14455,6 +18281,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -14831,8 +18659,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -14852,6 +18902,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -15143,6 +19195,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -15513,8 +19567,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -15534,6 +19810,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -15825,6 +20103,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -16196,8 +20476,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -16217,6 +20719,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -16508,6 +21012,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -16857,8 +21363,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -16878,6 +21606,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -17169,6 +21899,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -17526,8 +22258,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -17547,6 +22501,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -17838,6 +22794,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -17993,12 +22951,16 @@ spec:
                                     - project
                                     - repo
                                     type: object
+                                  continueOnRepoNotFoundError:
+                                    type: boolean
                                   filters:
                                     items:
                                       properties:
                                         branchMatch:
                                           type: string
                                         targetBranchMatch:
+                                          type: string
+                                        titleMatch:
                                           type: string
                                       type: object
                                     type: array
@@ -18418,8 +23380,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -18439,6 +23623,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -18730,6 +23916,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -19305,8 +24493,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -19326,6 +24736,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -19617,6 +25029,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -19987,8 +25401,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -20008,6 +25644,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -20299,6 +25937,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -20655,8 +26295,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -20676,6 +26538,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -20967,6 +26831,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -21122,12 +26988,16 @@ spec:
                           - project
                           - repo
                           type: object
+                        continueOnRepoNotFoundError:
+                          type: boolean
                         filters:
                           items:
                             properties:
                               branchMatch:
                                 type: string
                               targetBranchMatch:
+                                type: string
+                              titleMatch:
                                 type: string
                             type: object
                           type: array
@@ -21547,8 +27417,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -21568,6 +27660,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -21859,6 +27953,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -22434,8 +28530,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -22455,6 +28773,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -22746,6 +29066,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -22827,6 +29149,8 @@ spec:
                 type: object
               strategy:
                 properties:
+                  deletionOrder:
+                    type: string
                   rollingSync:
                     properties:
                       steps:
@@ -23187,8 +29511,230 @@ spec:
                         properties:
                           drySource:
                             properties:
+                              directory:
+                                properties:
+                                  exclude:
+                                    type: string
+                                  include:
+                                    type: string
+                                  jsonnet:
+                                    properties:
+                                      extVars:
+                                        items:
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        items:
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    type: boolean
+                                type: object
+                              helm:
+                                properties:
+                                  apiVersions:
+                                    items:
+                                      type: string
+                                    type: array
+                                  fileParameters:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        path:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  ignoreMissingValueFiles:
+                                    type: boolean
+                                  kubeVersion:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        forceString:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  passCredentials:
+                                    type: boolean
+                                  releaseName:
+                                    type: string
+                                  skipCrds:
+                                    type: boolean
+                                  skipSchemaValidation:
+                                    type: boolean
+                                  skipTests:
+                                    type: boolean
+                                  valueFiles:
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    type: string
+                                  valuesObject:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  version:
+                                    type: string
+                                type: object
+                              kustomize:
+                                properties:
+                                  apiVersions:
+                                    items:
+                                      type: string
+                                    type: array
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  commonAnnotationsEnvsubst:
+                                    type: boolean
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  components:
+                                    items:
+                                      type: string
+                                    type: array
+                                  forceCommonAnnotations:
+                                    type: boolean
+                                  forceCommonLabels:
+                                    type: boolean
+                                  ignoreMissingComponents:
+                                    type: boolean
+                                  images:
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeVersion:
+                                    type: string
+                                  labelIncludeTemplates:
+                                    type: boolean
+                                  labelWithoutSelector:
+                                    type: boolean
+                                  namePrefix:
+                                    type: string
+                                  nameSuffix:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                  patches:
+                                    items:
+                                      properties:
+                                        options:
+                                          additionalProperties:
+                                            type: boolean
+                                          type: object
+                                        patch:
+                                          type: string
+                                        path:
+                                          type: string
+                                        target:
+                                          properties:
+                                            annotationSelector:
+                                              type: string
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            labelSelector:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    type: array
+                                  replicas:
+                                    items:
+                                      properties:
+                                        count:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        name:
+                                          type: string
+                                      required:
+                                      - count
+                                      - name
+                                      type: object
+                                    type: array
+                                  version:
+                                    type: string
+                                type: object
                               path:
                                 type: string
+                              plugin:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        array:
+                                          items:
+                                            type: string
+                                          type: array
+                                        map:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        name:
+                                          type: string
+                                        string:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
                               repoURL:
                                 type: string
                               targetRevision:
@@ -23208,6 +29754,8 @@ spec:
                           syncSource:
                             properties:
                               path:
+                                minLength: 1
+                                pattern: ^.{2,}|[^./]$
                                 type: string
                               targetBranch:
                                 type: string
@@ -23499,6 +30047,8 @@ spec:
                               limit:
                                 format: int64
                                 type: integer
+                              refresh:
+                                type: boolean
                             type: object
                           syncOptions:
                             items:
@@ -23604,6 +30154,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              resourcesCount:
+                format: int64
+                type: integer
             type: object
         required:
         - metadata
@@ -23668,13 +30221,17 @@ spec:
                 description: ClusterResourceBlacklist contains list of blacklisted
                   cluster level resources
                 items:
-                  description: |-
-                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
-                    concepts during lookup stages without having partially valid types
+                  description: ClusterResourceRestrictionItem is a cluster resource
+                    that is restricted by the project's whitelist or blacklist
                   properties:
                     group:
                       type: string
                     kind:
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the restricted resource. Glob patterns using Go's filepath.Match syntax are supported.
+                        Unlike the group and kind fields, if no name is specified, all resources of the specified group/kind are matched.
                       type: string
                   required:
                   - group
@@ -23685,13 +30242,17 @@ spec:
                 description: ClusterResourceWhitelist contains list of whitelisted
                   cluster level resources
                 items:
-                  description: |-
-                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
-                    concepts during lookup stages without having partially valid types
+                  description: ClusterResourceRestrictionItem is a cluster resource
+                    that is restricted by the project's whitelist or blacklist
                   properties:
                     group:
                       type: string
                     kind:
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the restricted resource. Glob patterns using Go's filepath.Match syntax are supported.
+                        Unlike the group and kind fields, if no name is specified, all resources of the specified group/kind are matched.
                       type: string
                   required:
                   - group
@@ -24214,15 +30775,13 @@ spec:
                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                           If specified, the CSI driver will create or update the volume with the attributes defined
                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                          will be set by the persistentvolume controller if it exists.
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                           exists.
                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                         type: string
                       volumeMode:
                         description: |-
@@ -24275,17 +30834,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: argocds.argoproj.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: webhook-service
-          namespace: system
-          path: /convert
-      conversionReviewVersions:
-      - v1alpha1
-      - v1beta1
   group: argoproj.io
   names:
     kind: ArgoCD
@@ -24343,8 +30891,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -24400,6 +30949,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -24490,7 +31076,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -24768,8 +31354,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -24825,6 +31412,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -24939,8 +31563,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -24996,6 +31621,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -25236,8 +31898,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -25293,6 +31956,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -25387,7 +32087,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -25508,7 +32208,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -25660,7 +32360,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -25852,7 +32552,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -26017,6 +32717,18 @@ spec:
                   - name
                   type: object
                 type: array
+              networkPolicy:
+                description: NetworkPolicy controls whether the operator should create
+                  NetworkPolicy resources for this Argo CD instance.
+                properties:
+                  enabled:
+                    default: true
+                    description: |-
+                      Enabled defines whether NetworkPolicy resources should be created for this Argo CD instance.
+                      When enabled, the operator will reconcile NetworkPolicies for Argo CD components.
+                      When disabled, the operator will remove any previously-created NetworkPolicies.
+                    type: boolean
+                type: object
               nodePlacement:
                 description: NodePlacement defines NodeSelectors and Taints for Argo
                   CD workloads
@@ -26084,8 +32796,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -26141,6 +32854,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -26227,7 +32977,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -26278,6 +33028,13 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  sourceNamespaces:
+                    description: SourceNamespaces is a list of namespaces from which
+                      the notifications controller will watch for ArgoCD Application
+                      resources.
+                    items:
+                      type: string
+                    type: array
                   version:
                     description: Version is the Argo CD Notifications image tag. (optional)
                     type: string
@@ -26293,15 +33050,20 @@ spec:
                   ArgoCD.
                 properties:
                   enabled:
-                    description: Enabled will toggle Prometheus support globally for
-                      ArgoCD.
+                    description: |-
+                      Enabled will toggle Prometheus support globally for ArgoCD.
+                      When set to true, ServiceMonitors and PrometheusRules will be created for Argo CD metrics.
+                      The Prometheus CR, Route, and Ingress are deprecated and will no longer be created.
                     type: boolean
                   host:
-                    description: Host is the hostname to use for Ingress/Route resources.
+                    description: |-
+                      Host is the hostname to use for Ingress/Route resources.
+                      Deprecated: This field is no longer used and will be ignored.
                     type: string
                   ingress:
-                    description: Ingress defines the desired state for an Ingress
-                      for the Prometheus component.
+                    description: |-
+                      Ingress defines the desired state for an Ingress for the Prometheus component.
+                      Deprecated: This field is no longer used and will be ignored.
                     properties:
                       annotations:
                         additionalProperties:
@@ -26353,8 +33115,9 @@ spec:
                     - enabled
                     type: object
                   route:
-                    description: Route defines the desired state for an OpenShift
-                      Route for the Prometheus component.
+                    description: |-
+                      Route defines the desired state for an OpenShift Route for the Prometheus component.
+                      Deprecated: This field is no longer used and will be ignored.
                     properties:
                       annotations:
                         additionalProperties:
@@ -26460,7 +33223,9 @@ spec:
                     - enabled
                     type: object
                   size:
-                    description: Size is the replica count for the Prometheus StatefulSet.
+                    description: |-
+                      Size is the replica count for the Prometheus StatefulSet.
+                      Deprecated: This field is no longer used and will be ignored.
                     format: int32
                     type: integer
                 required:
@@ -26520,7 +33285,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -26592,8 +33357,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -26649,6 +33415,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -26764,8 +33567,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -26821,6 +33625,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -26883,8 +33724,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -26911,8 +33752,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -27589,7 +34431,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -27644,10 +34486,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -27659,6 +34501,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -28187,7 +35082,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -28288,8 +35183,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -28345,6 +35241,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -28407,8 +35340,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -28435,8 +35368,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -29113,7 +36047,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -29168,10 +36102,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -29183,6 +36117,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -30433,15 +37420,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -30623,12 +37608,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -30707,7 +37690,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -31129,6 +38112,111 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -31263,7 +38351,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -31718,8 +38805,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -31775,6 +38863,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -31985,7 +39110,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -32193,7 +39318,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -32274,7 +39399,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -32350,7 +39475,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -32653,8 +39778,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -32710,6 +39836,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -32805,7 +39968,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -33620,15 +40783,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -33810,12 +40971,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -33894,7 +41053,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -34316,6 +41475,111 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -34450,7 +41714,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -34912,6 +42175,13 @@ spec:
                     description: Agent defines configurations for the Agent component
                       of Argo CD Agent.
                     properties:
+                      allowedNamespaces:
+                        description: |-
+                          AllowedNamespaces is a list of additional namespaces the agent is allowed to
+                          manage applications in. Supports glob patterns.
+                        items:
+                          type: string
+                        type: array
                       client:
                         description: Client defines the client options for the Agent
                           component.
@@ -34946,6 +42216,20 @@ spec:
                         description: Creds is the credential identifier for the agent
                           authentication
                         type: string
+                      destinationBasedMapping:
+                        description: DestinationBasedMapping defines the options for
+                          destination based mapping for the Agent component.
+                        properties:
+                          createNamespace:
+                            description: |-
+                              CreateNamespace enables automatic creation of target namespaces on the managed cluster
+                              when destination-based mapping is enabled.
+                            type: boolean
+                          enabled:
+                            description: Enabled is the flag to enable destination
+                              based mapping for the Agent component.
+                            type: boolean
+                        type: object
                       enabled:
                         description: Enabled is the flag to enable the Agent component
                           during Argo CD installation. (optional, default `false`)
@@ -34957,8 +42241,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -35014,6 +42299,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -35116,6 +42438,10 @@ spec:
                         description: Auth is the authentication method for the Principal
                           component.
                         type: string
+                      destinationBasedMapping:
+                        description: DestinationBasedMapping is the flag to enable
+                          destination based mapping for the Principal component.
+                        type: boolean
                       enabled:
                         description: Enabled is the flag to enable the Principal component
                           during Argo CD installation. (optional, default `false`)
@@ -35128,8 +42454,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -35185,6 +42512,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -35440,8 +42804,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -35497,6 +42862,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -35605,8 +43007,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -35662,6 +43065,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -35724,8 +43164,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -35752,8 +43192,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -36430,7 +43871,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -36485,10 +43926,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -36500,6 +43941,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -37043,7 +44537,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -37178,8 +44672,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -37235,6 +44730,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -37297,8 +44829,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -37325,8 +44857,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -38003,7 +45536,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -38058,10 +45591,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -38073,6 +45606,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -39315,15 +46901,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -39505,12 +47089,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -39589,7 +47171,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -40011,6 +47593,111 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -40145,7 +47832,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -40531,7 +48217,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -40723,7 +48409,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -40813,8 +48499,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -40870,6 +48557,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -40935,7 +48659,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -41119,6 +48843,18 @@ spec:
                   - name
                   type: object
                 type: array
+              networkPolicy:
+                description: NetworkPolicy controls whether the operator should create
+                  NetworkPolicy resources for this Argo CD instance.
+                properties:
+                  enabled:
+                    default: true
+                    description: |-
+                      Enabled defines whether NetworkPolicy resources are created for this Argo CD instance.
+                      When enabled, the operator will reconcile NetworkPolicies for Argo CD components.
+                      When disabled, the operator will remove any previously-created NetworkPolicies.
+                    type: boolean
+                type: object
               nodePlacement:
                 description: NodePlacement defines NodeSelectors and Taints for Argo
                   CD workloads
@@ -41186,8 +48922,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -41243,6 +48980,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -41329,7 +49103,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -41380,6 +49154,13 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  sourceNamespaces:
+                    description: SourceNamespaces is a list of namespaces from which
+                      the notifications controller will watch for ArgoCD Notification
+                      resources.
+                    items:
+                      type: string
+                    type: array
                   version:
                     description: Version is the Argo CD Notifications image tag. (optional)
                     type: string
@@ -41395,15 +49176,20 @@ spec:
                   ArgoCD.
                 properties:
                   enabled:
-                    description: Enabled will toggle Prometheus support globally for
-                      ArgoCD.
+                    description: |-
+                      Enabled will toggle Prometheus support globally for ArgoCD.
+                      When set to true, ServiceMonitors and PrometheusRules will be created for Argo CD metrics.
+                      The Prometheus CR, Route, and Ingress are deprecated and will no longer be created.
                     type: boolean
                   host:
-                    description: Host is the hostname to use for Ingress/Route resources.
+                    description: |-
+                      Host is the hostname to use for Ingress/Route resources.
+                      Deprecated: This field is no longer used and will be ignored.
                     type: string
                   ingress:
-                    description: Ingress defines the desired state for an Ingress
-                      for the Prometheus component.
+                    description: |-
+                      Ingress defines the desired state for an Ingress for the Prometheus component.
+                      Deprecated: This field is no longer used and will be ignored.
                     properties:
                       annotations:
                         additionalProperties:
@@ -41455,8 +49241,9 @@ spec:
                     - enabled
                     type: object
                   route:
-                    description: Route defines the desired state for an OpenShift
-                      Route for the Prometheus component.
+                    description: |-
+                      Route defines the desired state for an OpenShift Route for the Prometheus component.
+                      Deprecated: This field is no longer used and will be ignored.
                     properties:
                       annotations:
                         additionalProperties:
@@ -41562,7 +49349,9 @@ spec:
                     - enabled
                     type: object
                   size:
-                    description: Size is the replica count for the Prometheus StatefulSet.
+                    description: |-
+                      Size is the replica count for the Prometheus StatefulSet.
+                      Deprecated: This field is no longer used and will be ignored.
                     format: int32
                     type: integer
                 required:
@@ -41631,7 +49420,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -41712,8 +49501,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -41769,6 +49559,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -41884,8 +49711,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -41941,6 +49769,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -42003,8 +49868,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -42031,8 +49896,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -42709,7 +50575,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -42764,10 +50630,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -42779,6 +50645,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -43317,7 +51236,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -43418,8 +51337,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -43475,6 +51395,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -43537,8 +51494,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -43565,8 +51522,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -44243,7 +52201,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -44298,10 +52256,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -44313,6 +52271,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -44813,6 +52824,237 @@ spec:
                       - name
                       type: object
                     type: array
+                  systemCATrust:
+                    description: Custom certificates to inject into the repo server
+                      container and its plugins to trust source hosting sites
+                    properties:
+                      clusterTrustBundles:
+                        description: ClusterTrustBundles is a list of projected ClusterTrustBundle
+                          volume definitions from where to take the trust certs.
+                        items:
+                          description: |-
+                            ClusterTrustBundleProjection describes how to select a set of
+                            ClusterTrustBundle objects and project their contents into the pod
+                            filesystem.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                Select all ClusterTrustBundles that match this label selector.  Only has
+                                effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                interpreted as "match nothing".  If set but empty, interpreted as "match
+                                everything".
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            name:
+                              description: |-
+                                Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                with signerName and labelSelector.
+                              type: string
+                            optional:
+                              description: |-
+                                If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                aren't available.  If using name, then the named ClusterTrustBundle is
+                                allowed not to exist.  If using signerName, then the combination of
+                                signerName and labelSelector is allowed to match zero
+                                ClusterTrustBundles.
+                              type: boolean
+                            path:
+                              description: Relative path from the volume root to write
+                                the bundle.
+                              type: string
+                            signerName:
+                              description: |-
+                                Select all ClusterTrustBundles that match this signer name.
+                                Mutually-exclusive with name.  The contents of all selected
+                                ClusterTrustBundles will be unified and deduplicated.
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      configMaps:
+                        description: ConfigMaps is a list of projected ConfigMap volume
+                          definitions from where to take the trust certs.
+                        items:
+                          description: |-
+                            Adapts a ConfigMap into a projected volume.
+
+                            The contents of the target ConfigMap's Data field will be presented in a
+                            projected volume as files using the keys in the Data field as the file names,
+                            unless the items element is populated with specific mappings of keys to paths.
+                            Note that this is identical to a configmap volume source without the default
+                            mode.
+                          properties:
+                            items:
+                              description: |-
+                                items if unspecified, each key-value pair in the Data field of the referenced
+                                ConfigMap will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      dropImageCertificates:
+                        description: DropImageCertificates will remove all certs that
+                          are present in the image, leaving only those explicitly
+                          configured here.
+                        type: boolean
+                      secrets:
+                        description: Secrets is a list of projected Secret volume
+                          definitions from where to take the trust certs.
+                        items:
+                          description: |-
+                            Adapts a secret into a projected volume.
+
+                            The contents of the target Secret's Data field will be presented in a
+                            projected volume as files using the keys in the Data field as the file names.
+                            Note that this is identical to a secret volume source without the default
+                            mode.
+                          properties:
+                            items:
+                              description: |-
+                                items if unspecified, each key-value pair in the Data field of the referenced
+                                Secret will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the Secret,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: optional field specify whether the Secret
+                                or its key must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
                   verifytls:
                     description: VerifyTLS defines whether repo server API should
                       be accessed using strict TLS validation
@@ -45563,15 +53805,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -45753,12 +53993,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -45837,7 +54075,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -46259,6 +54497,111 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -46393,7 +54736,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -46852,8 +55194,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -46909,6 +55252,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -47135,8 +55515,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -47192,6 +55573,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -47254,8 +55672,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -47282,8 +55700,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -47960,7 +56379,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -48015,10 +56434,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -48030,6 +56449,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -48563,7 +57035,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -48776,8 +57248,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -48833,6 +57306,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -48895,8 +57405,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -48923,8 +57433,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -49601,7 +58112,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -49656,10 +58167,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -49671,6 +58182,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -50913,15 +59477,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -51103,12 +59665,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -51187,7 +59747,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -51609,6 +60169,111 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -51743,7 +60408,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -52052,8 +60716,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -52109,6 +60774,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -52187,7 +60889,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -52988,15 +61690,13 @@ spec:
                                             volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                             If specified, the CSI driver will create or update the volume with the attributes defined
                                             in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
+                                            it can be changed after the claim is created. An empty string or nil value indicates that no
+                                            VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                            this field can be reset to its previous value (including nil) to cancel the modification.
                                             If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                             set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                             exists.
                                             More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                            (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                           type: string
                                         volumeMode:
                                           description: |-
@@ -53178,12 +61878,10 @@ spec:
                               description: |-
                                 glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                                 Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  description: endpoints is the endpoint name that
+                                    details Glusterfs topology.
                                   type: string
                                 path:
                                   description: |-
@@ -53262,7 +61960,7 @@ spec:
                               description: |-
                                 iscsi represents an ISCSI Disk resource that is attached to a
                                 kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                               properties:
                                 chapAuthDiscovery:
                                   description: chapAuthDiscovery defines whether support
@@ -53688,6 +62386,111 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                         type: object
+                                      podCertificate:
+                                        description: |-
+                                          Projects an auto-rotating credential bundle (private key and certificate
+                                          chain) that the pod can use either as a TLS client or server.
+
+                                          Kubelet generates a private key and uses it to send a
+                                          PodCertificateRequest to the named signer.  Once the signer approves the
+                                          request and issues a certificate chain, Kubelet writes the key and
+                                          certificate chain to the pod filesystem.  The pod does not start until
+                                          certificates have been issued for each podCertificate projected volume
+                                          source in its spec.
+
+                                          Kubelet will begin trying to rotate the certificate at the time indicated
+                                          by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                          timestamp.
+
+                                          Kubelet can write a single file, indicated by the credentialBundlePath
+                                          field, or separate files, indicated by the keyPath and
+                                          certificateChainPath fields.
+
+                                          The credential bundle is a single file in PEM format.  The first PEM
+                                          entry is the private key (in PKCS#8 format), and the remaining PEM
+                                          entries are the certificate chain issued by the signer (typically,
+                                          signers will return their certificate chain in leaf-to-root order).
+
+                                          Prefer using the credential bundle format, since your application code
+                                          can read it atomically.  If you use keyPath and certificateChainPath,
+                                          your application must make two separate file reads. If these coincide
+                                          with a certificate rotation, it is possible that the private key and leaf
+                                          certificate you read may not correspond to each other.  Your application
+                                          will need to check for this condition, and re-read until they are
+                                          consistent.
+
+                                          The named signer controls chooses the format of the certificate it
+                                          issues; consult the signer implementation's documentation to learn how to
+                                          use the certificates it issues.
+                                        properties:
+                                          certificateChainPath:
+                                            description: |-
+                                              Write the certificate chain at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          credentialBundlePath:
+                                            description: |-
+                                              Write the credential bundle at this path in the projected volume.
+
+                                              The credential bundle is a single file that contains multiple PEM blocks.
+                                              The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                              key.
+
+                                              The remaining blocks are CERTIFICATE blocks, containing the issued
+                                              certificate chain from the signer (leaf and any intermediates).
+
+                                              Using credentialBundlePath lets your Pod's application code make a single
+                                              atomic read that retrieves a consistent key and certificate chain.  If you
+                                              project them to separate files, your application code will need to
+                                              additionally check that the leaf certificate was issued to the key.
+                                            type: string
+                                          keyPath:
+                                            description: |-
+                                              Write the key at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          keyType:
+                                            description: |-
+                                              The type of keypair Kubelet will generate for the pod.
+
+                                              Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                              "ECDSAP521", and "ED25519".
+                                            type: string
+                                          maxExpirationSeconds:
+                                            description: |-
+                                              maxExpirationSeconds is the maximum lifetime permitted for the
+                                              certificate.
+
+                                              Kubelet copies this value verbatim into the PodCertificateRequests it
+                                              generates for this projection.
+
+                                              If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                              will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                              value is 7862400 (91 days).
+
+                                              The signer implementation is then free to issue a certificate with any
+                                              lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                              seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                              `kubernetes.io` signers will never issue certificates with a lifetime
+                                              longer than 24 hours.
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            description: Kubelet's generated CSRs
+                                              will be addressed to this signer.
+                                            type: string
+                                        required:
+                                        - keyType
+                                        - signerName
+                                        type: object
                                       secret:
                                         description: secret information about the
                                           secret data to project
@@ -53822,7 +62625,6 @@ spec:
                               description: |-
                                 rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                                 Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
                                   description: |-
@@ -54129,7 +62931,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -54232,6 +63034,9 @@ spec:
                   for all ArgoCD components.
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: spec.sso and spec.oidcConfig cannot both be set
+              rule: '!(has(self.sso) && has(self.oidcConfig))'
           status:
             description: ArgoCDStatus defines the observed state of ArgoCD
             properties:
@@ -54388,7 +63193,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: imageupdaters.argocd-image-updater.argoproj.io
 spec:
   group: argocd-image-updater.argoproj.io
@@ -54430,7 +63235,7 @@ spec:
               applicationRefs:
                 description: |-
                   ApplicationRefs indicates the set of applications to be managed.
-                  ApplicationRefs is a list of rules to select Argo CD Applications within the `spec.namespace`.
+                  ApplicationRefs is a list of rules to select Argo CD Applications within the ImageUpdater CR's namespace.
                   Each reference can also provide specific overrides for the global settings defined above.
                 items:
                   description: ApplicationRef contains various criteria by which to
@@ -54440,6 +63245,7 @@ spec:
                       description: |-
                         CommonUpdateSettings overrides the global CommonUpdateSettings for applications
                         matched by this selector.
+                        This field is ignored when UseAnnotations is true.
                       properties:
                         allowTags:
                           description: |-
@@ -54486,6 +63292,7 @@ spec:
                         Images contains a list of configurations that how images should be updated.
                         These rules apply to applications selected by namePattern in ApplicationRefs, and each
                         image can override global/ApplicationRef settings.
+                        This field is ignored when UseAnnotations is true.
                       items:
                         description: |-
                           ImageConfig defines how a specific container image should be discovered, updated,
@@ -54565,25 +63372,23 @@ spec:
                                     description: |-
                                       Name is the dot-separated path to the Helm key for the image repository/name part.
                                       Example: "image.repository", "frontend.deployment.image.name".
-                                      This field is required if the Helm target is used.
+                                      If neither spec nor name/tag are set, defaults to "image.name".
+                                      If spec is set, this field is ignored.
                                     type: string
                                   spec:
                                     description: |-
-                                      Spec is an optional dot-separated path to a Helm key where the full image string
+                                      Spec is the dot-separated path to a Helm key where the full image string
                                       (e.g., "image/name:1.0") should be written.
                                       Use this if your Helm chart expects the entire image reference in a single field,
-                                      rather than separate name/tag fields. If this is set, other Helm parameter-related
-                                      options will be ignored.
+                                      rather than separate name/tag fields. If this is set, name and tag will be ignored.
                                     type: string
                                   tag:
                                     description: |-
                                       Tag is the dot-separated path to the Helm key for the image tag part.
                                       Example: "image.tag", "frontend.deployment.image.version".
-                                      This field is required if the Helm target is used.
+                                      If neither spec nor name/tag are set, defaults to "image.tag".
+                                      If spec is set, this field is ignored.
                                     type: string
-                                required:
-                                - name
-                                - tag
                                 type: object
                               kustomize:
                                 description: |-
@@ -54610,7 +63415,6 @@ spec:
                         - alias
                         - imageName
                         type: object
-                      minItems: 1
                       type: array
                       x-kubernetes-list-map-keys:
                       - alias
@@ -54666,10 +63470,21 @@ spec:
                       description: NamePattern indicates the glob pattern for application
                         name
                       type: string
+                    useAnnotations:
+                      default: false
+                      description: |-
+                        UseAnnotations When true, read image configuration from Application's
+                        argocd-image-updater.argoproj.io/* annotations instead of
+                        requiring explicit Images[] configuration in this CR.
+                        When this field is set to true, only namePattern and labelSelectors are used for
+                        application selection. All other fields (CommonUpdateSettings, WriteBackConfig, Images)
+                        are ignored.
+                      type: boolean
                     writeBackConfig:
                       description: |-
                         WriteBackConfig overrides the global WriteBackConfig settings for applications
                         matched by this selector.
+                        This field is ignored when UseAnnotations is true.
                       properties:
                         gitConfig:
                           description: |-
@@ -54707,9 +63522,13 @@ spec:
                       - method
                       type: object
                   required:
-                  - images
                   - namePattern
                   type: object
+                  x-kubernetes-validations:
+                  - message: Either useAnnotations must be true, or images must be
+                      provided with at least one item
+                    rule: '!(has(self.useAnnotations) && self.useAnnotations == true)
+                      ? (has(self.images) && size(self.images) > 0) : true'
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -54764,8 +63583,10 @@ spec:
               namespace:
                 description: |-
                   Namespace indicates the target namespace of the applications.
-                  This is the namespace where the controller will look for Argo CD Applications
-                  matching the criteria in ApplicationRefs.
+
+                  Deprecated: This field is deprecated and will be removed in a future release.
+                  The controller now uses the ImageUpdater CR's namespace (metadata.namespace)
+                  to determine which namespace to search for applications. This field is ignored.
                 type: string
               writeBackConfig:
                 description: |-
@@ -54809,7 +63630,6 @@ spec:
                 type: object
             required:
             - applicationRefs
-            - namespace
             type: object
           status:
             description: ImageUpdaterStatus defines the observed state of ImageUpdater

--- a/charts/argocd-agent-addon/templates/applicationset-placement-rbac.yaml
+++ b/charts/argocd-agent-addon/templates/applicationset-placement-rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-applicationset-placement
+  namespace: {{ .Values.global.argoCDNamespace }}
+rules:
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - placementdecisions
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-applicationset-placement
+  namespace: {{ .Values.global.argoCDNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-applicationset-placement
+subjects:
+- kind: ServiceAccount
+  name: argocd-applicationset-controller
+  namespace: {{ .Values.global.argoCDNamespace }}

--- a/charts/argocd-agent-addon/templates/argocd-operator/argocd.yaml
+++ b/charts/argocd-agent-addon/templates/argocd-operator/argocd.yaml
@@ -11,6 +11,7 @@ spec:
   argoCDAgent:
     principal:
       enabled: true
+      destinationBasedMapping: true
       auth: "mtls:CN=system:open-cluster-management:cluster:([^:]+):addon:argocd-agent-addon:agent:argocd-agent-addon-agent"
       server:
         enableWebSocket: false

--- a/charts/argocd-agent-addon/templates/argocd-operator/operator.yaml
+++ b/charts/argocd-agent-addon/templates/argocd-operator/operator.yaml
@@ -150,8 +150,17 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - certificates.k8s.io
+  resources:
+  - clustertrustbundles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - config.openshift.io
   resources:
+  - authentications
   - clusterversions
   verbs:
   - get

--- a/charts/argocd-agent-addon/templates/ocm-placement-generator-cm.yaml
+++ b/charts/argocd-agent-addon/templates/ocm-placement-generator-cm.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ocm-placement-generator
+  namespace: {{ .Values.global.argoCDNamespace }}
+data:
+  apiVersion: cluster.open-cluster-management.io/v1beta1
+  kind: placementdecisions
+  statusListKey: decisions
+  matchKey: clusterName

--- a/internal/addon/OPERATOR_SYNC.md
+++ b/internal/addon/OPERATOR_SYNC.md
@@ -1,0 +1,148 @@
+# Syncing argocd-operator Manifests
+
+This document describes how to update the embedded argocd-operator manifests in this
+repo when the upstream [argocd-operator](https://github.com/argoproj-labs/argocd-operator)
+releases a new version.
+
+## What This Repo Embeds
+
+The argocd-operator is deployed on both hub and spoke clusters. This repo carries
+a copy of its manifests in two locations (which must stay in sync):
+
+| Location | Purpose |
+|----------|---------|
+| `charts/argocd-agent-addon/crds/argocd-operator-crds.yaml` | CRDs installed on the hub via Helm |
+| `charts/argocd-agent-addon/templates/argocd-operator/operator.yaml` | Operator deployment manifests (hub) |
+| `charts/argocd-agent-addon/templates/argocd-operator/argocd.yaml` | Hub ArgoCD CR (principal config) |
+| `internal/addon/charts/argocd-agent-addon/crds/argocd-operator-crds.yaml` | CRDs installed on spokes via addon |
+| `internal/addon/charts/argocd-agent-addon/templates/operator.yaml` | Operator deployment manifests (spoke) |
+| `internal/addon/charts/argocd-agent-addon/templates/argocd.yaml` | Spoke ArgoCD CR (agent config) |
+
+### What each file contains
+
+**`argocd-operator-crds.yaml`** — All 8 CRDs from the operator, concatenated:
+- `applications.argoproj.io`
+- `applicationsets.argoproj.io`
+- `appprojects.argoproj.io`
+- `argocdexports.argoproj.io`
+- `argocds.argoproj.io`
+- `imageupdaters.argocd-image-updater.argoproj.io`
+- `namespacemanagements.argoproj.io`
+- `notificationsconfigurations.argoproj.io`
+
+**`operator.yaml`** — 15 Kubernetes resources (non-CRD):
+- Namespace
+- ServiceAccount
+- Role (leader-election)
+- 5x ClusterRole (manager-role, metrics-reader, namespacemanagement-editor/viewer, proxy-role)
+- RoleBinding (leader-election)
+- 2x ClusterRoleBinding (manager, proxy)
+- ConfigMap (manager-config)
+- 2x Service (metrics, webhook)
+- Deployment (controller-manager)
+
+## Update Procedure
+
+### Prerequisites
+
+- Access to the argocd-operator source (clone or local copy)
+- `kustomize` installed (v4+)
+- `controller-gen` available (the operator Makefile can install it)
+
+### Step 1: Generate CRDs from operator source
+
+```bash
+cd <argocd-operator-repo>
+
+# Regenerate CRDs from Go types (ensures they're up to date)
+make manifests
+
+# Build CRDs with kustomize, stripping the conversion webhook
+# (webhook causes issues on clusters without cert-manager)
+kustomize build config/crd | sed '/conversion:/,/- v1beta1/d' > /tmp/operator-crds-clean.yaml
+```
+
+### Step 2: Replace CRD files
+
+```bash
+cd <this-repo>
+cp /tmp/operator-crds-clean.yaml charts/argocd-agent-addon/crds/argocd-operator-crds.yaml
+cp /tmp/operator-crds-clean.yaml internal/addon/charts/argocd-agent-addon/crds/argocd-operator-crds.yaml
+```
+
+### Step 3: Generate and compare operator deployment manifests
+
+```bash
+cd <argocd-operator-repo>
+kustomize build config/default > /tmp/operator-full.yaml
+```
+
+Extract the non-CRD resources and compare with `operator.yaml`:
+
+```bash
+cd <this-repo>
+
+# List resources from operator
+python3 -c "
+import yaml
+with open('/tmp/operator-full.yaml') as f:
+    docs = list(yaml.safe_load_all(f))
+for d in docs:
+    if d and d.get('kind') not in ('CustomResourceDefinition', 'Namespace', None):
+        print(f\"{d['kind']:30s} {d['metadata']['name']}\")
+"
+```
+
+Compare the ClusterRole `argocd-operator-manager-role` rules carefully — this is where
+most RBAC changes happen between operator versions.
+
+### Step 4: Update operator.yaml
+
+Manually update `operator.yaml` in both chart locations to match the new operator output.
+
+**Important:** This repo adds 2 intentional env vars to the Deployment that are NOT
+in the upstream operator. Preserve these when updating:
+
+```yaml
+env:
+- name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
+  value: "*"
+- name: ARGOCD_PRINCIPAL_TLS_SERVER_ALLOW_GENERATE
+  value: "false"
+```
+
+All namespace references use Helm template variables (`{{ .Values.global.argoCDOperatorNamespace }}`
+etc.) instead of hardcoded `argocd-operator-system`. Preserve this templating.
+
+### Step 5: Update argocd.yaml (if needed)
+
+If the ArgoCD CR schema changed (new fields in `argoCDAgent`, `principal`, `agent`), update:
+- `charts/argocd-agent-addon/templates/argocd-operator/argocd.yaml` (hub/principal)
+- `internal/addon/charts/argocd-agent-addon/templates/argocd.yaml` (spoke/agent)
+
+### Step 6: Verify
+
+```bash
+# Verify both operator.yaml files are in sync (ignoring helm templates)
+diff <(grep -v '{{' charts/argocd-agent-addon/templates/argocd-operator/operator.yaml) \
+     <(grep -v '{{' internal/addon/charts/argocd-agent-addon/templates/operator.yaml)
+
+# Verify CRD files are identical
+diff charts/argocd-agent-addon/crds/argocd-operator-crds.yaml \
+     internal/addon/charts/argocd-agent-addon/crds/argocd-operator-crds.yaml
+
+# Run unit tests
+make test
+
+# Run all e2e tests
+make test-e2e-advanced-pull-local
+make test-e2e-advanced-pull-custom-namespace-local
+make test-e2e-basic-pull-local
+```
+
+### Step 7: Update operator image tag
+
+Update the operator image version in:
+- `Makefile` — `ARGOCD_OPERATOR_IMAGE` variable
+- `charts/argocd-agent-addon/values.yaml` — `operatorImageTag`
+- `internal/addon/charts/argocd-agent-addon/values.yaml` — `operatorImageTag`

--- a/internal/addon/charts/argocd-agent-addon/crds/argocd-operator-crds.yaml
+++ b/internal/addon/charts/argocd-agent-addon/crds/argocd-operator-crds.yaml
@@ -110,6 +110,10 @@ spec:
                       a failed sync. If set to 0, no retries will be performed.
                     format: int64
                     type: integer
+                  refresh:
+                    description: 'Refresh indicates if the latest revision should
+                      be used on retry instead of the initial one (default: false)'
+                    type: boolean
                 type: object
               sync:
                 description: Sync contains parameters for the operation
@@ -1438,10 +1442,357 @@ spec:
                     description: DrySource specifies where the dry "don't repeat yourself"
                       manifest source lives.
                     properties:
+                      directory:
+                        description: Directory specifies path/directory specific options
+                        properties:
+                          exclude:
+                            description: Exclude contains a glob pattern to match
+                              paths against that should be explicitly excluded from
+                              being used during manifest generation
+                            type: string
+                          include:
+                            description: Include contains a glob pattern to match
+                              paths against that should be explicitly included during
+                              manifest generation
+                            type: string
+                          jsonnet:
+                            description: Jsonnet holds options specific to Jsonnet
+                            properties:
+                              extVars:
+                                description: ExtVars is a list of Jsonnet External
+                                  Variables
+                                items:
+                                  description: JsonnetVar represents a variable to
+                                    be passed to jsonnet during manifest generation
+                                  properties:
+                                    code:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              libs:
+                                description: Additional library search dirs
+                                items:
+                                  type: string
+                                type: array
+                              tlas:
+                                description: TLAS is a list of Jsonnet Top-level Arguments
+                                items:
+                                  description: JsonnetVar represents a variable to
+                                    be passed to jsonnet during manifest generation
+                                  properties:
+                                    code:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          recurse:
+                            description: Recurse specifies whether to scan a directory
+                              recursively for manifests
+                            type: boolean
+                        type: object
+                      helm:
+                        description: Helm specifies helm specific options
+                        properties:
+                          apiVersions:
+                            description: |-
+                              APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                              Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                            items:
+                              type: string
+                            type: array
+                          fileParameters:
+                            description: FileParameters are file parameters to the
+                              helm template
+                            items:
+                              description: HelmFileParameter is a file parameter that's
+                                passed to helm template during manifest generation
+                              properties:
+                                name:
+                                  description: Name is the name of the Helm parameter
+                                  type: string
+                                path:
+                                  description: Path is the path to the file containing
+                                    the values for the Helm parameter
+                                  type: string
+                              type: object
+                            type: array
+                          ignoreMissingValueFiles:
+                            description: IgnoreMissingValueFiles prevents helm template
+                              from failing when valueFiles do not exist locally by
+                              not appending them to helm template --values
+                            type: boolean
+                          kubeVersion:
+                            description: |-
+                              KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                              uses the Kubernetes version of the target cluster.
+                            type: string
+                          namespace:
+                            description: Namespace is an optional namespace to template
+                              with. If left empty, defaults to the app's destination
+                              namespace.
+                            type: string
+                          parameters:
+                            description: Parameters is a list of Helm parameters which
+                              are passed to the helm template command upon manifest
+                              generation
+                            items:
+                              description: HelmParameter is a parameter that's passed
+                                to helm template during manifest generation
+                              properties:
+                                forceString:
+                                  description: ForceString determines whether to tell
+                                    Helm to interpret booleans and numbers as strings
+                                  type: boolean
+                                name:
+                                  description: Name is the name of the Helm parameter
+                                  type: string
+                                value:
+                                  description: Value is the value for the Helm parameter
+                                  type: string
+                              type: object
+                            type: array
+                          passCredentials:
+                            description: PassCredentials pass credentials to all domains
+                              (Helm's --pass-credentials)
+                            type: boolean
+                          releaseName:
+                            description: ReleaseName is the Helm release name to use.
+                              If omitted it will use the application name
+                            type: string
+                          skipCrds:
+                            description: SkipCrds skips custom resource definition
+                              installation step (Helm's --skip-crds)
+                            type: boolean
+                          skipSchemaValidation:
+                            description: SkipSchemaValidation skips JSON schema validation
+                              (Helm's --skip-schema-validation)
+                            type: boolean
+                          skipTests:
+                            description: SkipTests skips test manifest installation
+                              step (Helm's --skip-tests).
+                            type: boolean
+                          valueFiles:
+                            description: ValuesFiles is a list of Helm value files
+                              to use when generating a template
+                            items:
+                              type: string
+                            type: array
+                          values:
+                            description: Values specifies Helm values to be passed
+                              to helm template, typically defined as a block. ValuesObject
+                              takes precedence over Values, so use one or the other.
+                            type: string
+                          valuesObject:
+                            description: ValuesObject specifies Helm values to be
+                              passed to helm template, defined as a map. This takes
+                              precedence over Values.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          version:
+                            description: Version is the Helm version to use for templating
+                              ("3")
+                            type: string
+                        type: object
+                      kustomize:
+                        description: Kustomize specifies kustomize specific options
+                        properties:
+                          apiVersions:
+                            description: |-
+                              APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                              Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                            items:
+                              type: string
+                            type: array
+                          commonAnnotations:
+                            additionalProperties:
+                              type: string
+                            description: CommonAnnotations is a list of additional
+                              annotations to add to rendered manifests
+                            type: object
+                          commonAnnotationsEnvsubst:
+                            description: CommonAnnotationsEnvsubst specifies whether
+                              to apply env variables substitution for annotation values
+                            type: boolean
+                          commonLabels:
+                            additionalProperties:
+                              type: string
+                            description: CommonLabels is a list of additional labels
+                              to add to rendered manifests
+                            type: object
+                          components:
+                            description: Components specifies a list of kustomize
+                              components to add to the kustomization before building
+                            items:
+                              type: string
+                            type: array
+                          forceCommonAnnotations:
+                            description: ForceCommonAnnotations specifies whether
+                              to force applying common annotations to resources for
+                              Kustomize apps
+                            type: boolean
+                          forceCommonLabels:
+                            description: ForceCommonLabels specifies whether to force
+                              applying common labels to resources for Kustomize apps
+                            type: boolean
+                          ignoreMissingComponents:
+                            description: IgnoreMissingComponents prevents kustomize
+                              from failing when components do not exist locally by
+                              not appending them to kustomization file
+                            type: boolean
+                          images:
+                            description: Images is a list of Kustomize image override
+                              specifications
+                            items:
+                              description: KustomizeImage represents a Kustomize image
+                                definition in the format [old_image_name=]<image_name>:<image_tag>
+                              type: string
+                            type: array
+                          kubeVersion:
+                            description: |-
+                              KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                              uses the Kubernetes version of the target cluster.
+                            type: string
+                          labelIncludeTemplates:
+                            description: LabelIncludeTemplates specifies whether to
+                              apply common labels to resource templates or not
+                            type: boolean
+                          labelWithoutSelector:
+                            description: LabelWithoutSelector specifies whether to
+                              apply common labels to resource selectors or not
+                            type: boolean
+                          namePrefix:
+                            description: NamePrefix is a prefix appended to resources
+                              for Kustomize apps
+                            type: string
+                          nameSuffix:
+                            description: NameSuffix is a suffix appended to resources
+                              for Kustomize apps
+                            type: string
+                          namespace:
+                            description: Namespace sets the namespace that Kustomize
+                              adds to all resources
+                            type: string
+                          patches:
+                            description: Patches is a list of Kustomize patches
+                            items:
+                              properties:
+                                options:
+                                  additionalProperties:
+                                    type: boolean
+                                  type: object
+                                patch:
+                                  type: string
+                                path:
+                                  type: string
+                                target:
+                                  properties:
+                                    annotationSelector:
+                                      type: string
+                                    group:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    labelSelector:
+                                      type: string
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    version:
+                                      type: string
+                                  type: object
+                              type: object
+                            type: array
+                          replicas:
+                            description: Replicas is a list of Kustomize Replicas
+                              override specifications
+                            items:
+                              properties:
+                                count:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number of replicas
+                                  x-kubernetes-int-or-string: true
+                                name:
+                                  description: Name of Deployment or StatefulSet
+                                  type: string
+                              required:
+                              - count
+                              - name
+                              type: object
+                            type: array
+                          version:
+                            description: Version controls which version of Kustomize
+                              to use for rendering manifests
+                            type: string
+                        type: object
                       path:
                         description: Path is a directory path within the Git repository
                           where the manifests are located
                         type: string
+                      plugin:
+                        description: Plugin specifies config management plugin specific
+                          options
+                        properties:
+                          env:
+                            description: Env is a list of environment variable entries
+                            items:
+                              description: EnvEntry represents an entry in the application's
+                                environment
+                              properties:
+                                name:
+                                  description: Name is the name of the variable, usually
+                                    expressed in uppercase
+                                  type: string
+                                value:
+                                  description: Value is the value of the variable
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          parameters:
+                            items:
+                              properties:
+                                array:
+                                  description: Array is the value of an array type
+                                    parameter.
+                                  items:
+                                    type: string
+                                  type: array
+                                map:
+                                  additionalProperties:
+                                    type: string
+                                  description: Map is the value of a map type parameter.
+                                  type: object
+                                name:
+                                  description: Name is the name identifying a parameter.
+                                  type: string
+                                string:
+                                  description: String_ is the value of a string type
+                                    parameter.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
                       repoURL:
                         description: RepoURL is the URL to the git repository that
                           contains the application manifests
@@ -1474,11 +1825,15 @@ spec:
                       path:
                         description: |-
                           Path is a directory path within the git repository where hydrated manifests should be committed to and synced
-                          from. If hydrateTo is set, this is just the path from which hydrated manifests will be synced.
+                          from. The Path should never point to the root of the repo. If hydrateTo is set, this is just the path from which
+                          hydrated manifests will be synced.
+                        minLength: 1
+                        pattern: ^.{2,}|[^./]$
                         type: string
                       targetBranch:
-                        description: TargetBranch is the branch to which hydrated
-                          manifests should be committed
+                        description: |-
+                          TargetBranch is the branch from which hydrated manifests will be synced.
+                          If HydrateTo is not set, this is also the branch to which hydrated manifests are committed.
                         type: string
                     required:
                     - path
@@ -1937,6 +2292,10 @@ spec:
                           a failed sync. If set to 0, no retries will be performed.
                         format: int64
                         type: integer
+                      refresh:
+                        description: 'Refresh indicates if the latest revision should
+                          be used on retry instead of the initial one (default: false)'
+                        type: boolean
                     type: object
                   syncOptions:
                     description: Options allow you to specify whole app sync-options
@@ -2905,6 +3264,11 @@ spec:
                               be performed.
                             format: int64
                             type: integer
+                          refresh:
+                            description: 'Refresh indicates if the latest revision
+                              should be used on retry instead of the initial one (default:
+                              false)'
+                            type: boolean
                         type: object
                       sync:
                         description: Sync contains parameters for the operation
@@ -4841,10 +5205,380 @@ spec:
                             description: DrySource specifies where the dry "don't
                               repeat yourself" manifest source lives.
                             properties:
+                              directory:
+                                description: Directory specifies path/directory specific
+                                  options
+                                properties:
+                                  exclude:
+                                    description: Exclude contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      excluded from being used during manifest generation
+                                    type: string
+                                  include:
+                                    description: Include contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      included during manifest generation
+                                    type: string
+                                  jsonnet:
+                                    description: Jsonnet holds options specific to
+                                      Jsonnet
+                                    properties:
+                                      extVars:
+                                        description: ExtVars is a list of Jsonnet
+                                          External Variables
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        description: Additional library search dirs
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        description: TLAS is a list of Jsonnet Top-level
+                                          Arguments
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    description: Recurse specifies whether to scan
+                                      a directory recursively for manifests
+                                    type: boolean
+                                type: object
+                              helm:
+                                description: Helm specifies helm specific options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  fileParameters:
+                                    description: FileParameters are file parameters
+                                      to the helm template
+                                    items:
+                                      description: HelmFileParameter is a file parameter
+                                        that's passed to helm template during manifest
+                                        generation
+                                      properties:
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        path:
+                                          description: Path is the path to the file
+                                            containing the values for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  ignoreMissingValueFiles:
+                                    description: IgnoreMissingValueFiles prevents
+                                      helm template from failing when valueFiles do
+                                      not exist locally by not appending them to helm
+                                      template --values
+                                    type: boolean
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is an optional namespace
+                                      to template with. If left empty, defaults to
+                                      the app's destination namespace.
+                                    type: string
+                                  parameters:
+                                    description: Parameters is a list of Helm parameters
+                                      which are passed to the helm template command
+                                      upon manifest generation
+                                    items:
+                                      description: HelmParameter is a parameter that's
+                                        passed to helm template during manifest generation
+                                      properties:
+                                        forceString:
+                                          description: ForceString determines whether
+                                            to tell Helm to interpret booleans and
+                                            numbers as strings
+                                          type: boolean
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        value:
+                                          description: Value is the value for the
+                                            Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  passCredentials:
+                                    description: PassCredentials pass credentials
+                                      to all domains (Helm's --pass-credentials)
+                                    type: boolean
+                                  releaseName:
+                                    description: ReleaseName is the Helm release name
+                                      to use. If omitted it will use the application
+                                      name
+                                    type: string
+                                  skipCrds:
+                                    description: SkipCrds skips custom resource definition
+                                      installation step (Helm's --skip-crds)
+                                    type: boolean
+                                  skipSchemaValidation:
+                                    description: SkipSchemaValidation skips JSON schema
+                                      validation (Helm's --skip-schema-validation)
+                                    type: boolean
+                                  skipTests:
+                                    description: SkipTests skips test manifest installation
+                                      step (Helm's --skip-tests).
+                                    type: boolean
+                                  valueFiles:
+                                    description: ValuesFiles is a list of Helm value
+                                      files to use when generating a template
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    description: Values specifies Helm values to be
+                                      passed to helm template, typically defined as
+                                      a block. ValuesObject takes precedence over
+                                      Values, so use one or the other.
+                                    type: string
+                                  valuesObject:
+                                    description: ValuesObject specifies Helm values
+                                      to be passed to helm template, defined as a
+                                      map. This takes precedence over Values.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  version:
+                                    description: Version is the Helm version to use
+                                      for templating ("3")
+                                    type: string
+                                type: object
+                              kustomize:
+                                description: Kustomize specifies kustomize specific
+                                  options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonAnnotations is a list of additional
+                                      annotations to add to rendered manifests
+                                    type: object
+                                  commonAnnotationsEnvsubst:
+                                    description: CommonAnnotationsEnvsubst specifies
+                                      whether to apply env variables substitution
+                                      for annotation values
+                                    type: boolean
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels is a list of additional
+                                      labels to add to rendered manifests
+                                    type: object
+                                  components:
+                                    description: Components specifies a list of kustomize
+                                      components to add to the kustomization before
+                                      building
+                                    items:
+                                      type: string
+                                    type: array
+                                  forceCommonAnnotations:
+                                    description: ForceCommonAnnotations specifies
+                                      whether to force applying common annotations
+                                      to resources for Kustomize apps
+                                    type: boolean
+                                  forceCommonLabels:
+                                    description: ForceCommonLabels specifies whether
+                                      to force applying common labels to resources
+                                      for Kustomize apps
+                                    type: boolean
+                                  ignoreMissingComponents:
+                                    description: IgnoreMissingComponents prevents
+                                      kustomize from failing when components do not
+                                      exist locally by not appending them to kustomization
+                                      file
+                                    type: boolean
+                                  images:
+                                    description: Images is a list of Kustomize image
+                                      override specifications
+                                    items:
+                                      description: KustomizeImage represents a Kustomize
+                                        image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                      type: string
+                                    type: array
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  labelIncludeTemplates:
+                                    description: LabelIncludeTemplates specifies whether
+                                      to apply common labels to resource templates
+                                      or not
+                                    type: boolean
+                                  labelWithoutSelector:
+                                    description: LabelWithoutSelector specifies whether
+                                      to apply common labels to resource selectors
+                                      or not
+                                    type: boolean
+                                  namePrefix:
+                                    description: NamePrefix is a prefix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  nameSuffix:
+                                    description: NameSuffix is a suffix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  namespace:
+                                    description: Namespace sets the namespace that
+                                      Kustomize adds to all resources
+                                    type: string
+                                  patches:
+                                    description: Patches is a list of Kustomize patches
+                                    items:
+                                      properties:
+                                        options:
+                                          additionalProperties:
+                                            type: boolean
+                                          type: object
+                                        patch:
+                                          type: string
+                                        path:
+                                          type: string
+                                        target:
+                                          properties:
+                                            annotationSelector:
+                                              type: string
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            labelSelector:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    type: array
+                                  replicas:
+                                    description: Replicas is a list of Kustomize Replicas
+                                      override specifications
+                                    items:
+                                      properties:
+                                        count:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number of replicas
+                                          x-kubernetes-int-or-string: true
+                                        name:
+                                          description: Name of Deployment or StatefulSet
+                                          type: string
+                                      required:
+                                      - count
+                                      - name
+                                      type: object
+                                    type: array
+                                  version:
+                                    description: Version controls which version of
+                                      Kustomize to use for rendering manifests
+                                    type: string
+                                type: object
                               path:
                                 description: Path is a directory path within the Git
                                   repository where the manifests are located
                                 type: string
+                              plugin:
+                                description: Plugin specifies config management plugin
+                                  specific options
+                                properties:
+                                  env:
+                                    description: Env is a list of environment variable
+                                      entries
+                                    items:
+                                      description: EnvEntry represents an entry in
+                                        the application's environment
+                                      properties:
+                                        name:
+                                          description: Name is the name of the variable,
+                                            usually expressed in uppercase
+                                          type: string
+                                        value:
+                                          description: Value is the value of the variable
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        array:
+                                          description: Array is the value of an array
+                                            type parameter.
+                                          items:
+                                            type: string
+                                          type: array
+                                        map:
+                                          additionalProperties:
+                                            type: string
+                                          description: Map is the value of a map type
+                                            parameter.
+                                          type: object
+                                        name:
+                                          description: Name is the name identifying
+                                            a parameter.
+                                          type: string
+                                        string:
+                                          description: String_ is the value of a string
+                                            type parameter.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
                               repoURL:
                                 description: RepoURL is the URL to the git repository
                                   that contains the application manifests
@@ -4877,11 +5611,15 @@ spec:
                               path:
                                 description: |-
                                   Path is a directory path within the git repository where hydrated manifests should be committed to and synced
-                                  from. If hydrateTo is set, this is just the path from which hydrated manifests will be synced.
+                                  from. The Path should never point to the root of the repo. If hydrateTo is set, this is just the path from which
+                                  hydrated manifests will be synced.
+                                minLength: 1
+                                pattern: ^.{2,}|[^./]$
                                 type: string
                               targetBranch:
-                                description: TargetBranch is the branch to which hydrated
-                                  manifests should be committed
+                                description: |-
+                                  TargetBranch is the branch from which hydrated manifests will be synced.
+                                  If HydrateTo is not set, this is also the branch to which hydrated manifests are committed.
                                 type: string
                             required:
                             - path
@@ -4920,10 +5658,380 @@ spec:
                             description: DrySource specifies where the dry "don't
                               repeat yourself" manifest source lives.
                             properties:
+                              directory:
+                                description: Directory specifies path/directory specific
+                                  options
+                                properties:
+                                  exclude:
+                                    description: Exclude contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      excluded from being used during manifest generation
+                                    type: string
+                                  include:
+                                    description: Include contains a glob pattern to
+                                      match paths against that should be explicitly
+                                      included during manifest generation
+                                    type: string
+                                  jsonnet:
+                                    description: Jsonnet holds options specific to
+                                      Jsonnet
+                                    properties:
+                                      extVars:
+                                        description: ExtVars is a list of Jsonnet
+                                          External Variables
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        description: Additional library search dirs
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        description: TLAS is a list of Jsonnet Top-level
+                                          Arguments
+                                        items:
+                                          description: JsonnetVar represents a variable
+                                            to be passed to jsonnet during manifest
+                                            generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    description: Recurse specifies whether to scan
+                                      a directory recursively for manifests
+                                    type: boolean
+                                type: object
+                              helm:
+                                description: Helm specifies helm specific options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  fileParameters:
+                                    description: FileParameters are file parameters
+                                      to the helm template
+                                    items:
+                                      description: HelmFileParameter is a file parameter
+                                        that's passed to helm template during manifest
+                                        generation
+                                      properties:
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        path:
+                                          description: Path is the path to the file
+                                            containing the values for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  ignoreMissingValueFiles:
+                                    description: IgnoreMissingValueFiles prevents
+                                      helm template from failing when valueFiles do
+                                      not exist locally by not appending them to helm
+                                      template --values
+                                    type: boolean
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is an optional namespace
+                                      to template with. If left empty, defaults to
+                                      the app's destination namespace.
+                                    type: string
+                                  parameters:
+                                    description: Parameters is a list of Helm parameters
+                                      which are passed to the helm template command
+                                      upon manifest generation
+                                    items:
+                                      description: HelmParameter is a parameter that's
+                                        passed to helm template during manifest generation
+                                      properties:
+                                        forceString:
+                                          description: ForceString determines whether
+                                            to tell Helm to interpret booleans and
+                                            numbers as strings
+                                          type: boolean
+                                        name:
+                                          description: Name is the name of the Helm
+                                            parameter
+                                          type: string
+                                        value:
+                                          description: Value is the value for the
+                                            Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  passCredentials:
+                                    description: PassCredentials pass credentials
+                                      to all domains (Helm's --pass-credentials)
+                                    type: boolean
+                                  releaseName:
+                                    description: ReleaseName is the Helm release name
+                                      to use. If omitted it will use the application
+                                      name
+                                    type: string
+                                  skipCrds:
+                                    description: SkipCrds skips custom resource definition
+                                      installation step (Helm's --skip-crds)
+                                    type: boolean
+                                  skipSchemaValidation:
+                                    description: SkipSchemaValidation skips JSON schema
+                                      validation (Helm's --skip-schema-validation)
+                                    type: boolean
+                                  skipTests:
+                                    description: SkipTests skips test manifest installation
+                                      step (Helm's --skip-tests).
+                                    type: boolean
+                                  valueFiles:
+                                    description: ValuesFiles is a list of Helm value
+                                      files to use when generating a template
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    description: Values specifies Helm values to be
+                                      passed to helm template, typically defined as
+                                      a block. ValuesObject takes precedence over
+                                      Values, so use one or the other.
+                                    type: string
+                                  valuesObject:
+                                    description: ValuesObject specifies Helm values
+                                      to be passed to helm template, defined as a
+                                      map. This takes precedence over Values.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  version:
+                                    description: Version is the Helm version to use
+                                      for templating ("3")
+                                    type: string
+                                type: object
+                              kustomize:
+                                description: Kustomize specifies kustomize specific
+                                  options
+                                properties:
+                                  apiVersions:
+                                    description: |-
+                                      APIVersions specifies the Kubernetes resource API versions to pass to Helm when templating manifests. By default,
+                                      Argo CD uses the API versions of the target cluster. The format is [group/]version/kind.
+                                    items:
+                                      type: string
+                                    type: array
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonAnnotations is a list of additional
+                                      annotations to add to rendered manifests
+                                    type: object
+                                  commonAnnotationsEnvsubst:
+                                    description: CommonAnnotationsEnvsubst specifies
+                                      whether to apply env variables substitution
+                                      for annotation values
+                                    type: boolean
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels is a list of additional
+                                      labels to add to rendered manifests
+                                    type: object
+                                  components:
+                                    description: Components specifies a list of kustomize
+                                      components to add to the kustomization before
+                                      building
+                                    items:
+                                      type: string
+                                    type: array
+                                  forceCommonAnnotations:
+                                    description: ForceCommonAnnotations specifies
+                                      whether to force applying common annotations
+                                      to resources for Kustomize apps
+                                    type: boolean
+                                  forceCommonLabels:
+                                    description: ForceCommonLabels specifies whether
+                                      to force applying common labels to resources
+                                      for Kustomize apps
+                                    type: boolean
+                                  ignoreMissingComponents:
+                                    description: IgnoreMissingComponents prevents
+                                      kustomize from failing when components do not
+                                      exist locally by not appending them to kustomization
+                                      file
+                                    type: boolean
+                                  images:
+                                    description: Images is a list of Kustomize image
+                                      override specifications
+                                    items:
+                                      description: KustomizeImage represents a Kustomize
+                                        image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                      type: string
+                                    type: array
+                                  kubeVersion:
+                                    description: |-
+                                      KubeVersion specifies the Kubernetes API version to pass to Helm when templating manifests. By default, Argo CD
+                                      uses the Kubernetes version of the target cluster.
+                                    type: string
+                                  labelIncludeTemplates:
+                                    description: LabelIncludeTemplates specifies whether
+                                      to apply common labels to resource templates
+                                      or not
+                                    type: boolean
+                                  labelWithoutSelector:
+                                    description: LabelWithoutSelector specifies whether
+                                      to apply common labels to resource selectors
+                                      or not
+                                    type: boolean
+                                  namePrefix:
+                                    description: NamePrefix is a prefix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  nameSuffix:
+                                    description: NameSuffix is a suffix appended to
+                                      resources for Kustomize apps
+                                    type: string
+                                  namespace:
+                                    description: Namespace sets the namespace that
+                                      Kustomize adds to all resources
+                                    type: string
+                                  patches:
+                                    description: Patches is a list of Kustomize patches
+                                    items:
+                                      properties:
+                                        options:
+                                          additionalProperties:
+                                            type: boolean
+                                          type: object
+                                        patch:
+                                          type: string
+                                        path:
+                                          type: string
+                                        target:
+                                          properties:
+                                            annotationSelector:
+                                              type: string
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            labelSelector:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    type: array
+                                  replicas:
+                                    description: Replicas is a list of Kustomize Replicas
+                                      override specifications
+                                    items:
+                                      properties:
+                                        count:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number of replicas
+                                          x-kubernetes-int-or-string: true
+                                        name:
+                                          description: Name of Deployment or StatefulSet
+                                          type: string
+                                      required:
+                                      - count
+                                      - name
+                                      type: object
+                                    type: array
+                                  version:
+                                    description: Version controls which version of
+                                      Kustomize to use for rendering manifests
+                                    type: string
+                                type: object
                               path:
                                 description: Path is a directory path within the Git
                                   repository where the manifests are located
                                 type: string
+                              plugin:
+                                description: Plugin specifies config management plugin
+                                  specific options
+                                properties:
+                                  env:
+                                    description: Env is a list of environment variable
+                                      entries
+                                    items:
+                                      description: EnvEntry represents an entry in
+                                        the application's environment
+                                      properties:
+                                        name:
+                                          description: Name is the name of the variable,
+                                            usually expressed in uppercase
+                                          type: string
+                                        value:
+                                          description: Value is the value of the variable
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        array:
+                                          description: Array is the value of an array
+                                            type parameter.
+                                          items:
+                                            type: string
+                                          type: array
+                                        map:
+                                          additionalProperties:
+                                            type: string
+                                          description: Map is the value of a map type
+                                            parameter.
+                                          type: object
+                                        name:
+                                          description: Name is the name identifying
+                                            a parameter.
+                                          type: string
+                                        string:
+                                          description: String_ is the value of a string
+                                            type parameter.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
                               repoURL:
                                 description: RepoURL is the URL to the git repository
                                   that contains the application manifests
@@ -4956,11 +6064,15 @@ spec:
                               path:
                                 description: |-
                                   Path is a directory path within the git repository where hydrated manifests should be committed to and synced
-                                  from. If hydrateTo is set, this is just the path from which hydrated manifests will be synced.
+                                  from. The Path should never point to the root of the repo. If hydrateTo is set, this is just the path from which
+                                  hydrated manifests will be synced.
+                                minLength: 1
+                                pattern: ^.{2,}|[^./]$
                                 type: string
                               targetBranch:
-                                description: TargetBranch is the branch to which hydrated
-                                  manifests should be committed
+                                description: |-
+                                  TargetBranch is the branch from which hydrated manifests will be synced.
+                                  If HydrateTo is not set, this is also the branch to which hydrated manifests are committed.
                                 type: string
                             required:
                             - path
@@ -6279,8 +7391,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -6300,6 +7634,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -6591,6 +7927,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -6961,8 +8299,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -6982,6 +8542,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -7273,6 +8835,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -7644,8 +9208,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -7665,6 +9451,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -7956,6 +9744,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -8305,8 +10095,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -8326,6 +10338,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -8617,6 +10631,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -8991,8 +11007,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -9012,6 +11250,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -9303,6 +11543,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -9673,8 +11915,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -9694,6 +12158,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -9985,6 +12451,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -10356,8 +12824,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -10377,6 +13067,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -10668,6 +13360,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -11017,8 +13711,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -11038,6 +13954,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -11329,6 +14247,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -11686,8 +14606,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -11707,6 +14849,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -11998,6 +15142,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -12153,12 +15299,16 @@ spec:
                                     - project
                                     - repo
                                     type: object
+                                  continueOnRepoNotFoundError:
+                                    type: boolean
                                   filters:
                                     items:
                                       properties:
                                         branchMatch:
                                           type: string
                                         targetBranchMatch:
+                                          type: string
+                                        titleMatch:
                                           type: string
                                       type: object
                                     type: array
@@ -12578,8 +15728,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -12599,6 +15971,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -12890,6 +16264,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -13465,8 +16841,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -13486,6 +17084,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -13777,6 +17377,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -14143,8 +17745,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -14164,6 +17988,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -14455,6 +18281,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -14831,8 +18659,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -14852,6 +18902,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -15143,6 +19195,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -15513,8 +19567,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -15534,6 +19810,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -15825,6 +20103,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -16196,8 +20476,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -16217,6 +20719,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -16508,6 +21012,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -16857,8 +21363,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -16878,6 +21606,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -17169,6 +21899,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -17526,8 +22258,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -17547,6 +22501,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -17838,6 +22794,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -17993,12 +22951,16 @@ spec:
                                     - project
                                     - repo
                                     type: object
+                                  continueOnRepoNotFoundError:
+                                    type: boolean
                                   filters:
                                     items:
                                       properties:
                                         branchMatch:
                                           type: string
                                         targetBranchMatch:
+                                          type: string
+                                        titleMatch:
                                           type: string
                                       type: object
                                     type: array
@@ -18418,8 +23380,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -18439,6 +23623,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -18730,6 +23916,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -19305,8 +24493,230 @@ spec:
                                             properties:
                                               drySource:
                                                 properties:
+                                                  directory:
+                                                    properties:
+                                                      exclude:
+                                                        type: string
+                                                      include:
+                                                        type: string
+                                                      jsonnet:
+                                                        properties:
+                                                          extVars:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          libs:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          tlas:
+                                                            items:
+                                                              properties:
+                                                                code:
+                                                                  type: boolean
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      recurse:
+                                                        type: boolean
+                                                    type: object
+                                                  helm:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      fileParameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      ignoreMissingValueFiles:
+                                                        type: boolean
+                                                      kubeVersion:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            forceString:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                      passCredentials:
+                                                        type: boolean
+                                                      releaseName:
+                                                        type: string
+                                                      skipCrds:
+                                                        type: boolean
+                                                      skipSchemaValidation:
+                                                        type: boolean
+                                                      skipTests:
+                                                        type: boolean
+                                                      valueFiles:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      values:
+                                                        type: string
+                                                      valuesObject:
+                                                        type: object
+                                                        x-kubernetes-preserve-unknown-fields: true
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                  kustomize:
+                                                    properties:
+                                                      apiVersions:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      commonAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      commonAnnotationsEnvsubst:
+                                                        type: boolean
+                                                      commonLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      components:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      forceCommonAnnotations:
+                                                        type: boolean
+                                                      forceCommonLabels:
+                                                        type: boolean
+                                                      ignoreMissingComponents:
+                                                        type: boolean
+                                                      images:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      kubeVersion:
+                                                        type: string
+                                                      labelIncludeTemplates:
+                                                        type: boolean
+                                                      labelWithoutSelector:
+                                                        type: boolean
+                                                      namePrefix:
+                                                        type: string
+                                                      nameSuffix:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      patches:
+                                                        items:
+                                                          properties:
+                                                            options:
+                                                              additionalProperties:
+                                                                type: boolean
+                                                              type: object
+                                                            patch:
+                                                              type: string
+                                                            path:
+                                                              type: string
+                                                            target:
+                                                              properties:
+                                                                annotationSelector:
+                                                                  type: string
+                                                                group:
+                                                                  type: string
+                                                                kind:
+                                                                  type: string
+                                                                labelSelector:
+                                                                  type: string
+                                                                name:
+                                                                  type: string
+                                                                namespace:
+                                                                  type: string
+                                                                version:
+                                                                  type: string
+                                                              type: object
+                                                          type: object
+                                                        type: array
+                                                      replicas:
+                                                        items:
+                                                          properties:
+                                                            count:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            name:
+                                                              type: string
+                                                          required:
+                                                          - count
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      version:
+                                                        type: string
+                                                    type: object
                                                   path:
                                                     type: string
+                                                  plugin:
+                                                    properties:
+                                                      env:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            array:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            map:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                            name:
+                                                              type: string
+                                                            string:
+                                                              type: string
+                                                          type: object
+                                                        type: array
+                                                    type: object
                                                   repoURL:
                                                     type: string
                                                   targetRevision:
@@ -19326,6 +24736,8 @@ spec:
                                               syncSource:
                                                 properties:
                                                   path:
+                                                    minLength: 1
+                                                    pattern: ^.{2,}|[^./]$
                                                     type: string
                                                   targetBranch:
                                                     type: string
@@ -19617,6 +25029,8 @@ spec:
                                                   limit:
                                                     format: int64
                                                     type: integer
+                                                  refresh:
+                                                    type: boolean
                                                 type: object
                                               syncOptions:
                                                 items:
@@ -19987,8 +25401,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -20008,6 +25644,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -20299,6 +25937,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -20655,8 +26295,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -20676,6 +26538,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -20967,6 +26831,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -21122,12 +26988,16 @@ spec:
                           - project
                           - repo
                           type: object
+                        continueOnRepoNotFoundError:
+                          type: boolean
                         filters:
                           items:
                             properties:
                               branchMatch:
                                 type: string
                               targetBranchMatch:
+                                type: string
+                              titleMatch:
                                 type: string
                             type: object
                           type: array
@@ -21547,8 +27417,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -21568,6 +27660,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -21859,6 +27953,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -22434,8 +28530,230 @@ spec:
                                   properties:
                                     drySource:
                                       properties:
+                                        directory:
+                                          properties:
+                                            exclude:
+                                              type: string
+                                            include:
+                                              type: string
+                                            jsonnet:
+                                              properties:
+                                                extVars:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                libs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                tlas:
+                                                  items:
+                                                    properties:
+                                                      code:
+                                                        type: boolean
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            recurse:
+                                              type: boolean
+                                          type: object
+                                        helm:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            fileParameters:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            ignoreMissingValueFiles:
+                                              type: boolean
+                                            kubeVersion:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  forceString:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            passCredentials:
+                                              type: boolean
+                                            releaseName:
+                                              type: string
+                                            skipCrds:
+                                              type: boolean
+                                            skipSchemaValidation:
+                                              type: boolean
+                                            skipTests:
+                                              type: boolean
+                                            valueFiles:
+                                              items:
+                                                type: string
+                                              type: array
+                                            values:
+                                              type: string
+                                            valuesObject:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            version:
+                                              type: string
+                                          type: object
+                                        kustomize:
+                                          properties:
+                                            apiVersions:
+                                              items:
+                                                type: string
+                                              type: array
+                                            commonAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            commonAnnotationsEnvsubst:
+                                              type: boolean
+                                            commonLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            components:
+                                              items:
+                                                type: string
+                                              type: array
+                                            forceCommonAnnotations:
+                                              type: boolean
+                                            forceCommonLabels:
+                                              type: boolean
+                                            ignoreMissingComponents:
+                                              type: boolean
+                                            images:
+                                              items:
+                                                type: string
+                                              type: array
+                                            kubeVersion:
+                                              type: string
+                                            labelIncludeTemplates:
+                                              type: boolean
+                                            labelWithoutSelector:
+                                              type: boolean
+                                            namePrefix:
+                                              type: string
+                                            nameSuffix:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            patches:
+                                              items:
+                                                properties:
+                                                  options:
+                                                    additionalProperties:
+                                                      type: boolean
+                                                    type: object
+                                                  patch:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  target:
+                                                    properties:
+                                                      annotationSelector:
+                                                        type: string
+                                                      group:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      labelSelector:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                      version:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            replicas:
+                                              items:
+                                                properties:
+                                                  count:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - count
+                                                - name
+                                                type: object
+                                              type: array
+                                            version:
+                                              type: string
+                                          type: object
                                         path:
                                           type: string
+                                        plugin:
+                                          properties:
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            parameters:
+                                              items:
+                                                properties:
+                                                  array:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  map:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  string:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
                                         repoURL:
                                           type: string
                                         targetRevision:
@@ -22455,6 +28773,8 @@ spec:
                                     syncSource:
                                       properties:
                                         path:
+                                          minLength: 1
+                                          pattern: ^.{2,}|[^./]$
                                           type: string
                                         targetBranch:
                                           type: string
@@ -22746,6 +29066,8 @@ spec:
                                         limit:
                                           format: int64
                                           type: integer
+                                        refresh:
+                                          type: boolean
                                       type: object
                                     syncOptions:
                                       items:
@@ -22827,6 +29149,8 @@ spec:
                 type: object
               strategy:
                 properties:
+                  deletionOrder:
+                    type: string
                   rollingSync:
                     properties:
                       steps:
@@ -23187,8 +29511,230 @@ spec:
                         properties:
                           drySource:
                             properties:
+                              directory:
+                                properties:
+                                  exclude:
+                                    type: string
+                                  include:
+                                    type: string
+                                  jsonnet:
+                                    properties:
+                                      extVars:
+                                        items:
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        items:
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    type: boolean
+                                type: object
+                              helm:
+                                properties:
+                                  apiVersions:
+                                    items:
+                                      type: string
+                                    type: array
+                                  fileParameters:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        path:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  ignoreMissingValueFiles:
+                                    type: boolean
+                                  kubeVersion:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        forceString:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  passCredentials:
+                                    type: boolean
+                                  releaseName:
+                                    type: string
+                                  skipCrds:
+                                    type: boolean
+                                  skipSchemaValidation:
+                                    type: boolean
+                                  skipTests:
+                                    type: boolean
+                                  valueFiles:
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    type: string
+                                  valuesObject:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  version:
+                                    type: string
+                                type: object
+                              kustomize:
+                                properties:
+                                  apiVersions:
+                                    items:
+                                      type: string
+                                    type: array
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  commonAnnotationsEnvsubst:
+                                    type: boolean
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  components:
+                                    items:
+                                      type: string
+                                    type: array
+                                  forceCommonAnnotations:
+                                    type: boolean
+                                  forceCommonLabels:
+                                    type: boolean
+                                  ignoreMissingComponents:
+                                    type: boolean
+                                  images:
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeVersion:
+                                    type: string
+                                  labelIncludeTemplates:
+                                    type: boolean
+                                  labelWithoutSelector:
+                                    type: boolean
+                                  namePrefix:
+                                    type: string
+                                  nameSuffix:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                  patches:
+                                    items:
+                                      properties:
+                                        options:
+                                          additionalProperties:
+                                            type: boolean
+                                          type: object
+                                        patch:
+                                          type: string
+                                        path:
+                                          type: string
+                                        target:
+                                          properties:
+                                            annotationSelector:
+                                              type: string
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            labelSelector:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    type: array
+                                  replicas:
+                                    items:
+                                      properties:
+                                        count:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        name:
+                                          type: string
+                                      required:
+                                      - count
+                                      - name
+                                      type: object
+                                    type: array
+                                  version:
+                                    type: string
+                                type: object
                               path:
                                 type: string
+                              plugin:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        array:
+                                          items:
+                                            type: string
+                                          type: array
+                                        map:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        name:
+                                          type: string
+                                        string:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
                               repoURL:
                                 type: string
                               targetRevision:
@@ -23208,6 +29754,8 @@ spec:
                           syncSource:
                             properties:
                               path:
+                                minLength: 1
+                                pattern: ^.{2,}|[^./]$
                                 type: string
                               targetBranch:
                                 type: string
@@ -23499,6 +30047,8 @@ spec:
                               limit:
                                 format: int64
                                 type: integer
+                              refresh:
+                                type: boolean
                             type: object
                           syncOptions:
                             items:
@@ -23604,6 +30154,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              resourcesCount:
+                format: int64
+                type: integer
             type: object
         required:
         - metadata
@@ -23668,13 +30221,17 @@ spec:
                 description: ClusterResourceBlacklist contains list of blacklisted
                   cluster level resources
                 items:
-                  description: |-
-                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
-                    concepts during lookup stages without having partially valid types
+                  description: ClusterResourceRestrictionItem is a cluster resource
+                    that is restricted by the project's whitelist or blacklist
                   properties:
                     group:
                       type: string
                     kind:
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the restricted resource. Glob patterns using Go's filepath.Match syntax are supported.
+                        Unlike the group and kind fields, if no name is specified, all resources of the specified group/kind are matched.
                       type: string
                   required:
                   - group
@@ -23685,13 +30242,17 @@ spec:
                 description: ClusterResourceWhitelist contains list of whitelisted
                   cluster level resources
                 items:
-                  description: |-
-                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
-                    concepts during lookup stages without having partially valid types
+                  description: ClusterResourceRestrictionItem is a cluster resource
+                    that is restricted by the project's whitelist or blacklist
                   properties:
                     group:
                       type: string
                     kind:
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the restricted resource. Glob patterns using Go's filepath.Match syntax are supported.
+                        Unlike the group and kind fields, if no name is specified, all resources of the specified group/kind are matched.
                       type: string
                   required:
                   - group
@@ -24214,15 +30775,13 @@ spec:
                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                           If specified, the CSI driver will create or update the volume with the attributes defined
                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                          will be set by the persistentvolume controller if it exists.
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                           exists.
                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                         type: string
                       volumeMode:
                         description: |-
@@ -24275,17 +30834,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: argocds.argoproj.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: webhook-service
-          namespace: system
-          path: /convert
-      conversionReviewVersions:
-      - v1alpha1
-      - v1beta1
   group: argoproj.io
   names:
     kind: ArgoCD
@@ -24343,8 +30891,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -24400,6 +30949,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -24490,7 +31076,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -24768,8 +31354,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -24825,6 +31412,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -24939,8 +31563,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -24996,6 +31621,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -25236,8 +31898,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -25293,6 +31956,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -25387,7 +32087,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -25508,7 +32208,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -25660,7 +32360,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -25852,7 +32552,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -26017,6 +32717,18 @@ spec:
                   - name
                   type: object
                 type: array
+              networkPolicy:
+                description: NetworkPolicy controls whether the operator should create
+                  NetworkPolicy resources for this Argo CD instance.
+                properties:
+                  enabled:
+                    default: true
+                    description: |-
+                      Enabled defines whether NetworkPolicy resources should be created for this Argo CD instance.
+                      When enabled, the operator will reconcile NetworkPolicies for Argo CD components.
+                      When disabled, the operator will remove any previously-created NetworkPolicies.
+                    type: boolean
+                type: object
               nodePlacement:
                 description: NodePlacement defines NodeSelectors and Taints for Argo
                   CD workloads
@@ -26084,8 +32796,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -26141,6 +32854,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -26227,7 +32977,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -26278,6 +33028,13 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  sourceNamespaces:
+                    description: SourceNamespaces is a list of namespaces from which
+                      the notifications controller will watch for ArgoCD Application
+                      resources.
+                    items:
+                      type: string
+                    type: array
                   version:
                     description: Version is the Argo CD Notifications image tag. (optional)
                     type: string
@@ -26293,15 +33050,20 @@ spec:
                   ArgoCD.
                 properties:
                   enabled:
-                    description: Enabled will toggle Prometheus support globally for
-                      ArgoCD.
+                    description: |-
+                      Enabled will toggle Prometheus support globally for ArgoCD.
+                      When set to true, ServiceMonitors and PrometheusRules will be created for Argo CD metrics.
+                      The Prometheus CR, Route, and Ingress are deprecated and will no longer be created.
                     type: boolean
                   host:
-                    description: Host is the hostname to use for Ingress/Route resources.
+                    description: |-
+                      Host is the hostname to use for Ingress/Route resources.
+                      Deprecated: This field is no longer used and will be ignored.
                     type: string
                   ingress:
-                    description: Ingress defines the desired state for an Ingress
-                      for the Prometheus component.
+                    description: |-
+                      Ingress defines the desired state for an Ingress for the Prometheus component.
+                      Deprecated: This field is no longer used and will be ignored.
                     properties:
                       annotations:
                         additionalProperties:
@@ -26353,8 +33115,9 @@ spec:
                     - enabled
                     type: object
                   route:
-                    description: Route defines the desired state for an OpenShift
-                      Route for the Prometheus component.
+                    description: |-
+                      Route defines the desired state for an OpenShift Route for the Prometheus component.
+                      Deprecated: This field is no longer used and will be ignored.
                     properties:
                       annotations:
                         additionalProperties:
@@ -26460,7 +33223,9 @@ spec:
                     - enabled
                     type: object
                   size:
-                    description: Size is the replica count for the Prometheus StatefulSet.
+                    description: |-
+                      Size is the replica count for the Prometheus StatefulSet.
+                      Deprecated: This field is no longer used and will be ignored.
                     format: int32
                     type: integer
                 required:
@@ -26520,7 +33285,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -26592,8 +33357,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -26649,6 +33415,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -26764,8 +33567,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -26821,6 +33625,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -26883,8 +33724,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -26911,8 +33752,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -27589,7 +34431,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -27644,10 +34486,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -27659,6 +34501,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -28187,7 +35082,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -28288,8 +35183,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -28345,6 +35241,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -28407,8 +35340,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -28435,8 +35368,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -29113,7 +36047,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -29168,10 +36102,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -29183,6 +36117,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -30433,15 +37420,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -30623,12 +37608,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -30707,7 +37690,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -31129,6 +38112,111 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -31263,7 +38351,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -31718,8 +38805,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -31775,6 +38863,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -31985,7 +39110,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -32193,7 +39318,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -32274,7 +39399,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -32350,7 +39475,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -32653,8 +39778,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -32710,6 +39836,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -32805,7 +39968,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -33620,15 +40783,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -33810,12 +40971,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -33894,7 +41053,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -34316,6 +41475,111 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -34450,7 +41714,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -34912,6 +42175,13 @@ spec:
                     description: Agent defines configurations for the Agent component
                       of Argo CD Agent.
                     properties:
+                      allowedNamespaces:
+                        description: |-
+                          AllowedNamespaces is a list of additional namespaces the agent is allowed to
+                          manage applications in. Supports glob patterns.
+                        items:
+                          type: string
+                        type: array
                       client:
                         description: Client defines the client options for the Agent
                           component.
@@ -34946,6 +42216,20 @@ spec:
                         description: Creds is the credential identifier for the agent
                           authentication
                         type: string
+                      destinationBasedMapping:
+                        description: DestinationBasedMapping defines the options for
+                          destination based mapping for the Agent component.
+                        properties:
+                          createNamespace:
+                            description: |-
+                              CreateNamespace enables automatic creation of target namespaces on the managed cluster
+                              when destination-based mapping is enabled.
+                            type: boolean
+                          enabled:
+                            description: Enabled is the flag to enable destination
+                              based mapping for the Agent component.
+                            type: boolean
+                        type: object
                       enabled:
                         description: Enabled is the flag to enable the Agent component
                           during Argo CD installation. (optional, default `false`)
@@ -34957,8 +42241,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -35014,6 +42299,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -35116,6 +42438,10 @@ spec:
                         description: Auth is the authentication method for the Principal
                           component.
                         type: string
+                      destinationBasedMapping:
+                        description: DestinationBasedMapping is the flag to enable
+                          destination based mapping for the Principal component.
+                        type: boolean
                       enabled:
                         description: Enabled is the flag to enable the Principal component
                           during Argo CD installation. (optional, default `false`)
@@ -35128,8 +42454,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -35185,6 +42512,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -35440,8 +42804,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -35497,6 +42862,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -35605,8 +43007,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -35662,6 +43065,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -35724,8 +43164,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -35752,8 +43192,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -36430,7 +43871,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -36485,10 +43926,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -36500,6 +43941,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -37043,7 +44537,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -37178,8 +44672,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -37235,6 +44730,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -37297,8 +44829,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -37325,8 +44857,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -38003,7 +45536,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -38058,10 +45591,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -38073,6 +45606,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -39315,15 +46901,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -39505,12 +47089,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -39589,7 +47171,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -40011,6 +47593,111 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -40145,7 +47832,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -40531,7 +48217,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -40723,7 +48409,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -40813,8 +48499,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -40870,6 +48557,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -40935,7 +48659,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -41119,6 +48843,18 @@ spec:
                   - name
                   type: object
                 type: array
+              networkPolicy:
+                description: NetworkPolicy controls whether the operator should create
+                  NetworkPolicy resources for this Argo CD instance.
+                properties:
+                  enabled:
+                    default: true
+                    description: |-
+                      Enabled defines whether NetworkPolicy resources are created for this Argo CD instance.
+                      When enabled, the operator will reconcile NetworkPolicies for Argo CD components.
+                      When disabled, the operator will remove any previously-created NetworkPolicies.
+                    type: boolean
+                type: object
               nodePlacement:
                 description: NodePlacement defines NodeSelectors and Taints for Argo
                   CD workloads
@@ -41186,8 +48922,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -41243,6 +48980,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -41329,7 +49103,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -41380,6 +49154,13 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  sourceNamespaces:
+                    description: SourceNamespaces is a list of namespaces from which
+                      the notifications controller will watch for ArgoCD Notification
+                      resources.
+                    items:
+                      type: string
+                    type: array
                   version:
                     description: Version is the Argo CD Notifications image tag. (optional)
                     type: string
@@ -41395,15 +49176,20 @@ spec:
                   ArgoCD.
                 properties:
                   enabled:
-                    description: Enabled will toggle Prometheus support globally for
-                      ArgoCD.
+                    description: |-
+                      Enabled will toggle Prometheus support globally for ArgoCD.
+                      When set to true, ServiceMonitors and PrometheusRules will be created for Argo CD metrics.
+                      The Prometheus CR, Route, and Ingress are deprecated and will no longer be created.
                     type: boolean
                   host:
-                    description: Host is the hostname to use for Ingress/Route resources.
+                    description: |-
+                      Host is the hostname to use for Ingress/Route resources.
+                      Deprecated: This field is no longer used and will be ignored.
                     type: string
                   ingress:
-                    description: Ingress defines the desired state for an Ingress
-                      for the Prometheus component.
+                    description: |-
+                      Ingress defines the desired state for an Ingress for the Prometheus component.
+                      Deprecated: This field is no longer used and will be ignored.
                     properties:
                       annotations:
                         additionalProperties:
@@ -41455,8 +49241,9 @@ spec:
                     - enabled
                     type: object
                   route:
-                    description: Route defines the desired state for an OpenShift
-                      Route for the Prometheus component.
+                    description: |-
+                      Route defines the desired state for an OpenShift Route for the Prometheus component.
+                      Deprecated: This field is no longer used and will be ignored.
                     properties:
                       annotations:
                         additionalProperties:
@@ -41562,7 +49349,9 @@ spec:
                     - enabled
                     type: object
                   size:
-                    description: Size is the replica count for the Prometheus StatefulSet.
+                    description: |-
+                      Size is the replica count for the Prometheus StatefulSet.
+                      Deprecated: This field is no longer used and will be ignored.
                     format: int32
                     type: integer
                 required:
@@ -41631,7 +49420,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -41712,8 +49501,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -41769,6 +49559,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -41884,8 +49711,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -41941,6 +49769,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -42003,8 +49868,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -42031,8 +49896,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -42709,7 +50575,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -42764,10 +50630,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -42779,6 +50645,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -43317,7 +51236,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -43418,8 +51337,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -43475,6 +51395,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -43537,8 +51494,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -43565,8 +51522,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -44243,7 +52201,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -44298,10 +52256,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -44313,6 +52271,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -44813,6 +52824,237 @@ spec:
                       - name
                       type: object
                     type: array
+                  systemCATrust:
+                    description: Custom certificates to inject into the repo server
+                      container and its plugins to trust source hosting sites
+                    properties:
+                      clusterTrustBundles:
+                        description: ClusterTrustBundles is a list of projected ClusterTrustBundle
+                          volume definitions from where to take the trust certs.
+                        items:
+                          description: |-
+                            ClusterTrustBundleProjection describes how to select a set of
+                            ClusterTrustBundle objects and project their contents into the pod
+                            filesystem.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                Select all ClusterTrustBundles that match this label selector.  Only has
+                                effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                interpreted as "match nothing".  If set but empty, interpreted as "match
+                                everything".
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            name:
+                              description: |-
+                                Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                with signerName and labelSelector.
+                              type: string
+                            optional:
+                              description: |-
+                                If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                aren't available.  If using name, then the named ClusterTrustBundle is
+                                allowed not to exist.  If using signerName, then the combination of
+                                signerName and labelSelector is allowed to match zero
+                                ClusterTrustBundles.
+                              type: boolean
+                            path:
+                              description: Relative path from the volume root to write
+                                the bundle.
+                              type: string
+                            signerName:
+                              description: |-
+                                Select all ClusterTrustBundles that match this signer name.
+                                Mutually-exclusive with name.  The contents of all selected
+                                ClusterTrustBundles will be unified and deduplicated.
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      configMaps:
+                        description: ConfigMaps is a list of projected ConfigMap volume
+                          definitions from where to take the trust certs.
+                        items:
+                          description: |-
+                            Adapts a ConfigMap into a projected volume.
+
+                            The contents of the target ConfigMap's Data field will be presented in a
+                            projected volume as files using the keys in the Data field as the file names,
+                            unless the items element is populated with specific mappings of keys to paths.
+                            Note that this is identical to a configmap volume source without the default
+                            mode.
+                          properties:
+                            items:
+                              description: |-
+                                items if unspecified, each key-value pair in the Data field of the referenced
+                                ConfigMap will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      dropImageCertificates:
+                        description: DropImageCertificates will remove all certs that
+                          are present in the image, leaving only those explicitly
+                          configured here.
+                        type: boolean
+                      secrets:
+                        description: Secrets is a list of projected Secret volume
+                          definitions from where to take the trust certs.
+                        items:
+                          description: |-
+                            Adapts a secret into a projected volume.
+
+                            The contents of the target Secret's Data field will be presented in a
+                            projected volume as files using the keys in the Data field as the file names.
+                            Note that this is identical to a secret volume source without the default
+                            mode.
+                          properties:
+                            items:
+                              description: |-
+                                items if unspecified, each key-value pair in the Data field of the referenced
+                                Secret will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the Secret,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: optional field specify whether the Secret
+                                or its key must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
                   verifytls:
                     description: VerifyTLS defines whether repo server API should
                       be accessed using strict TLS validation
@@ -45563,15 +53805,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -45753,12 +53993,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -45837,7 +54075,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -46259,6 +54497,111 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -46393,7 +54736,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -46852,8 +55194,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -46909,6 +55252,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -47135,8 +55515,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -47192,6 +55573,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -47254,8 +55672,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -47282,8 +55700,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -47960,7 +56379,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -48015,10 +56434,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -48030,6 +56449,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -48563,7 +57035,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -48776,8 +57248,9 @@ spec:
                               present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -48833,6 +57306,43 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -48895,8 +57405,8 @@ spec:
                         envFrom:
                           description: |-
                             List of sources to populate environment variables in the container.
-                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                            will be reported as an event when the container is starting. When a key exists in multiple
+                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                            When a key exists in multiple
                             sources, the value associated with the last source will take precedence.
                             Values defined by an Env with a duplicate key will take precedence.
                             Cannot be updated.
@@ -48923,8 +57433,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: Optional text to prepend to the name
-                                  of each environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -49601,7 +58112,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -49656,10 +58167,10 @@ spec:
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart behavior of individual containers in a pod.
-                            This field may only be set for init containers, and the only allowed value is "Always".
-                            For non-init containers or when this field is not specified,
+                            This overrides the pod-level restart policy. When this field is not specified,
                             the restart behavior is defined by the Pod's restart policy and the container type.
-                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            Additionally, setting the RestartPolicy as "Always" for the init container will
+                            have the following effect:
                             this init container will be continually restarted on
                             exit until all regular containers have terminated. Once all regular
                             containers have completed, all init containers with restartPolicy "Always"
@@ -49671,6 +58182,59 @@ spec:
                             init container is started, or after any startupProbe has successfully
                             completed.
                           type: string
+                        restartPolicyRules:
+                          description: |-
+                            Represents a list of rules to be checked to determine if the
+                            container should be restarted on exit. The rules are evaluated in
+                            order. Once a rule matches a container exit condition, the remaining
+                            rules are ignored. If no rule matches the container exit condition,
+                            the Container-level restart policy determines the whether the container
+                            is restarted or not. Constraints on the rules:
+                            - At most 20 rules are allowed.
+                            - Rules can have the same action.
+                            - Identical rules are not forbidden in validations.
+                            When rules are specified, container MUST set RestartPolicy explicitly
+                            even it if matches the Pod's RestartPolicy.
+                          items:
+                            description: ContainerRestartRule describes how a container
+                              exit is handled.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a container exit if the requirements
+                                  are satisfied. The only possible value is "Restart" to restart the
+                                  container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on
+                                  container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the
+                                      specified values. Possible values are:
+                                      - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      Specifies the set of values to check for container exit codes.
+                                      At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           description: |-
                             SecurityContext defines the security options the container should be run with.
@@ -50913,15 +59477,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -51103,12 +59665,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -51187,7 +59747,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -51609,6 +60169,111 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -51743,7 +60408,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -52052,8 +60716,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -52109,6 +60774,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -52187,7 +60889,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -52988,15 +61690,13 @@ spec:
                                             volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                             If specified, the CSI driver will create or update the volume with the attributes defined
                                             in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
+                                            it can be changed after the claim is created. An empty string or nil value indicates that no
+                                            VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                            this field can be reset to its previous value (including nil) to cancel the modification.
                                             If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                             set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                             exists.
                                             More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                            (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                           type: string
                                         volumeMode:
                                           description: |-
@@ -53178,12 +61878,10 @@ spec:
                               description: |-
                                 glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                                 Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  description: endpoints is the endpoint name that
+                                    details Glusterfs topology.
                                   type: string
                                 path:
                                   description: |-
@@ -53262,7 +61960,7 @@ spec:
                               description: |-
                                 iscsi represents an ISCSI Disk resource that is attached to a
                                 kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                               properties:
                                 chapAuthDiscovery:
                                   description: chapAuthDiscovery defines whether support
@@ -53688,6 +62386,111 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                         type: object
+                                      podCertificate:
+                                        description: |-
+                                          Projects an auto-rotating credential bundle (private key and certificate
+                                          chain) that the pod can use either as a TLS client or server.
+
+                                          Kubelet generates a private key and uses it to send a
+                                          PodCertificateRequest to the named signer.  Once the signer approves the
+                                          request and issues a certificate chain, Kubelet writes the key and
+                                          certificate chain to the pod filesystem.  The pod does not start until
+                                          certificates have been issued for each podCertificate projected volume
+                                          source in its spec.
+
+                                          Kubelet will begin trying to rotate the certificate at the time indicated
+                                          by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                          timestamp.
+
+                                          Kubelet can write a single file, indicated by the credentialBundlePath
+                                          field, or separate files, indicated by the keyPath and
+                                          certificateChainPath fields.
+
+                                          The credential bundle is a single file in PEM format.  The first PEM
+                                          entry is the private key (in PKCS#8 format), and the remaining PEM
+                                          entries are the certificate chain issued by the signer (typically,
+                                          signers will return their certificate chain in leaf-to-root order).
+
+                                          Prefer using the credential bundle format, since your application code
+                                          can read it atomically.  If you use keyPath and certificateChainPath,
+                                          your application must make two separate file reads. If these coincide
+                                          with a certificate rotation, it is possible that the private key and leaf
+                                          certificate you read may not correspond to each other.  Your application
+                                          will need to check for this condition, and re-read until they are
+                                          consistent.
+
+                                          The named signer controls chooses the format of the certificate it
+                                          issues; consult the signer implementation's documentation to learn how to
+                                          use the certificates it issues.
+                                        properties:
+                                          certificateChainPath:
+                                            description: |-
+                                              Write the certificate chain at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          credentialBundlePath:
+                                            description: |-
+                                              Write the credential bundle at this path in the projected volume.
+
+                                              The credential bundle is a single file that contains multiple PEM blocks.
+                                              The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                              key.
+
+                                              The remaining blocks are CERTIFICATE blocks, containing the issued
+                                              certificate chain from the signer (leaf and any intermediates).
+
+                                              Using credentialBundlePath lets your Pod's application code make a single
+                                              atomic read that retrieves a consistent key and certificate chain.  If you
+                                              project them to separate files, your application code will need to
+                                              additionally check that the leaf certificate was issued to the key.
+                                            type: string
+                                          keyPath:
+                                            description: |-
+                                              Write the key at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          keyType:
+                                            description: |-
+                                              The type of keypair Kubelet will generate for the pod.
+
+                                              Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                              "ECDSAP521", and "ED25519".
+                                            type: string
+                                          maxExpirationSeconds:
+                                            description: |-
+                                              maxExpirationSeconds is the maximum lifetime permitted for the
+                                              certificate.
+
+                                              Kubelet copies this value verbatim into the PodCertificateRequests it
+                                              generates for this projection.
+
+                                              If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                              will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                              value is 7862400 (91 days).
+
+                                              The signer implementation is then free to issue a certificate with any
+                                              lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                              seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                              `kubernetes.io` signers will never issue certificates with a lifetime
+                                              longer than 24 hours.
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            description: Kubelet's generated CSRs
+                                              will be addressed to this signer.
+                                            type: string
+                                        required:
+                                        - keyType
+                                        - signerName
+                                        type: object
                                       secret:
                                         description: secret information about the
                                           secret data to project
@@ -53822,7 +62625,6 @@ spec:
                               description: |-
                                 rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                                 Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
                                   description: |-
@@ -54129,7 +62931,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -54232,6 +63034,9 @@ spec:
                   for all ArgoCD components.
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: spec.sso and spec.oidcConfig cannot both be set
+              rule: '!(has(self.sso) && has(self.oidcConfig))'
           status:
             description: ArgoCDStatus defines the observed state of ArgoCD
             properties:
@@ -54388,7 +63193,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: imageupdaters.argocd-image-updater.argoproj.io
 spec:
   group: argocd-image-updater.argoproj.io
@@ -54430,7 +63235,7 @@ spec:
               applicationRefs:
                 description: |-
                   ApplicationRefs indicates the set of applications to be managed.
-                  ApplicationRefs is a list of rules to select Argo CD Applications within the `spec.namespace`.
+                  ApplicationRefs is a list of rules to select Argo CD Applications within the ImageUpdater CR's namespace.
                   Each reference can also provide specific overrides for the global settings defined above.
                 items:
                   description: ApplicationRef contains various criteria by which to
@@ -54440,6 +63245,7 @@ spec:
                       description: |-
                         CommonUpdateSettings overrides the global CommonUpdateSettings for applications
                         matched by this selector.
+                        This field is ignored when UseAnnotations is true.
                       properties:
                         allowTags:
                           description: |-
@@ -54486,6 +63292,7 @@ spec:
                         Images contains a list of configurations that how images should be updated.
                         These rules apply to applications selected by namePattern in ApplicationRefs, and each
                         image can override global/ApplicationRef settings.
+                        This field is ignored when UseAnnotations is true.
                       items:
                         description: |-
                           ImageConfig defines how a specific container image should be discovered, updated,
@@ -54565,25 +63372,23 @@ spec:
                                     description: |-
                                       Name is the dot-separated path to the Helm key for the image repository/name part.
                                       Example: "image.repository", "frontend.deployment.image.name".
-                                      This field is required if the Helm target is used.
+                                      If neither spec nor name/tag are set, defaults to "image.name".
+                                      If spec is set, this field is ignored.
                                     type: string
                                   spec:
                                     description: |-
-                                      Spec is an optional dot-separated path to a Helm key where the full image string
+                                      Spec is the dot-separated path to a Helm key where the full image string
                                       (e.g., "image/name:1.0") should be written.
                                       Use this if your Helm chart expects the entire image reference in a single field,
-                                      rather than separate name/tag fields. If this is set, other Helm parameter-related
-                                      options will be ignored.
+                                      rather than separate name/tag fields. If this is set, name and tag will be ignored.
                                     type: string
                                   tag:
                                     description: |-
                                       Tag is the dot-separated path to the Helm key for the image tag part.
                                       Example: "image.tag", "frontend.deployment.image.version".
-                                      This field is required if the Helm target is used.
+                                      If neither spec nor name/tag are set, defaults to "image.tag".
+                                      If spec is set, this field is ignored.
                                     type: string
-                                required:
-                                - name
-                                - tag
                                 type: object
                               kustomize:
                                 description: |-
@@ -54610,7 +63415,6 @@ spec:
                         - alias
                         - imageName
                         type: object
-                      minItems: 1
                       type: array
                       x-kubernetes-list-map-keys:
                       - alias
@@ -54666,10 +63470,21 @@ spec:
                       description: NamePattern indicates the glob pattern for application
                         name
                       type: string
+                    useAnnotations:
+                      default: false
+                      description: |-
+                        UseAnnotations When true, read image configuration from Application's
+                        argocd-image-updater.argoproj.io/* annotations instead of
+                        requiring explicit Images[] configuration in this CR.
+                        When this field is set to true, only namePattern and labelSelectors are used for
+                        application selection. All other fields (CommonUpdateSettings, WriteBackConfig, Images)
+                        are ignored.
+                      type: boolean
                     writeBackConfig:
                       description: |-
                         WriteBackConfig overrides the global WriteBackConfig settings for applications
                         matched by this selector.
+                        This field is ignored when UseAnnotations is true.
                       properties:
                         gitConfig:
                           description: |-
@@ -54707,9 +63522,13 @@ spec:
                       - method
                       type: object
                   required:
-                  - images
                   - namePattern
                   type: object
+                  x-kubernetes-validations:
+                  - message: Either useAnnotations must be true, or images must be
+                      provided with at least one item
+                    rule: '!(has(self.useAnnotations) && self.useAnnotations == true)
+                      ? (has(self.images) && size(self.images) > 0) : true'
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -54764,8 +63583,10 @@ spec:
               namespace:
                 description: |-
                   Namespace indicates the target namespace of the applications.
-                  This is the namespace where the controller will look for Argo CD Applications
-                  matching the criteria in ApplicationRefs.
+
+                  Deprecated: This field is deprecated and will be removed in a future release.
+                  The controller now uses the ImageUpdater CR's namespace (metadata.namespace)
+                  to determine which namespace to search for applications. This field is ignored.
                 type: string
               writeBackConfig:
                 description: |-
@@ -54809,7 +63630,6 @@ spec:
                 type: object
             required:
             - applicationRefs
-            - namespace
             type: object
           status:
             description: ImageUpdaterStatus defines the observed state of ImageUpdater

--- a/internal/addon/charts/argocd-agent-addon/templates/argocd.yaml
+++ b/internal/addon/charts/argocd-agent-addon/templates/argocd.yaml
@@ -6,9 +6,16 @@ metadata:
 spec:
   server:
     enabled: false
+  sourceNamespaces:
+    - "*"
   argoCDAgent:
     agent:
       enabled: true
+      allowedNamespaces:
+        - "*"
+      destinationBasedMapping:
+        enabled: true
+        createNamespace: true
       creds: "mtls:open-cluster-management:cluster:([^:]+):addon:argocd-agent"
       logLevel: "info"
       logFormat: "text"

--- a/internal/addon/charts/argocd-agent-addon/templates/operator.yaml
+++ b/internal/addon/charts/argocd-agent-addon/templates/operator.yaml
@@ -150,8 +150,17 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - certificates.k8s.io
+  resources:
+  - clustertrustbundles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - config.openshift.io
   resources:
+  - authentications
   - clusterversions
   verbs:
   - get

--- a/test/e2e/advanced_pull_e2e_custom_namespace_test.go
+++ b/test/e2e/advanced_pull_e2e_custom_namespace_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,6 +35,11 @@ import (
 var _ = Describe("ArgoCD Agent Addon Custom Namespace E2E", Label("advanced-pull-custom-namespace"), Ordered, func() {
 	SetDefaultEventuallyTimeout(5 * time.Minute)
 	SetDefaultEventuallyPollingInterval(5 * time.Second)
+
+	const (
+		appSetName      = "test-appset"
+		targetNamespace = "guestbook"
+	)
 
 	var (
 		hubArgoCDNamespace           string
@@ -68,7 +74,6 @@ var _ = Describe("ArgoCD Agent Addon Custom Namespace E2E", Label("advanced-pull
 		fmt.Fprintf(GinkgoWriter, "  Spoke Operator: %s\n", spokeArgoCDOperatorNamespace)
 
 		By("Verifying test environment is ready")
-		// Environment setup is done by Makefile
 		cmd := exec.Command("kubectl", "config", "get-contexts", hubContext)
 		_, err := utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Hub context should exist")
@@ -344,6 +349,205 @@ var _ = Describe("ArgoCD Agent Addon Custom Namespace E2E", Label("advanced-pull
 					"-n", spokeArgoCDNamespace)
 				_, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+		})
+	})
+
+	Context("Application Sync via ApplicationSet in Custom Namespace", func() {
+		var appName string
+
+		It("should sync AppProject from hub to spoke", func() {
+			By("creating AppProject on hub in custom namespace")
+			appProjectYAML := fmt.Sprintf(`apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: default
+  namespace: %s
+  labels:
+    e2e-sync-test: "true"
+spec:
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  destinations:
+  - namespace: '*'
+    server: '*'
+  sourceRepos:
+  - '*'
+  sourceNamespaces:
+  - '*'`, hubArgoCDNamespace)
+			cmd := exec.Command("kubectl", "--context", hubContext, "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(appProjectYAML)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying AppProject synced to spoke cluster")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "appproject", "default",
+					"-n", spokeArgoCDNamespace,
+					"-o", "jsonpath={.metadata.labels.e2e-sync-test}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("true"))
+			}, 60*time.Second).Should(Succeed())
+		})
+
+		It("should create ApplicationSet on hub in custom namespace", func() {
+			By("creating test ApplicationSet on hub using clusterDecisionResource generator")
+			appSetYaml := fmt.Sprintf(`
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  generators:
+  - clusterDecisionResource:
+      configMapRef: ocm-placement-generator
+      labelSelector:
+        matchLabels:
+          cluster.open-cluster-management.io/placement: placement
+      requeueAfterSeconds: 30
+  template:
+    metadata:
+      name: '{{name}}-app'
+    spec:
+      destination:
+        name: '{{name}}'
+        namespace: %s
+      project: default
+      source:
+        path: guestbook
+        repoURL: https://github.com/argoproj/argocd-example-apps.git
+        targetRevision: HEAD
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+`, appSetName, hubArgoCDNamespace, targetNamespace)
+
+			cmd := exec.Command("kubectl", "--context", hubContext, "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(appSetYaml)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying ApplicationSet is created on hub")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "applicationset", appSetName,
+					"-n", hubArgoCDNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "ApplicationSet %s created in %s namespace\n", appSetName, hubArgoCDNamespace)
+		})
+
+		It("should create Application from ApplicationSet in custom namespace", func() {
+			By("verifying Application is created by ApplicationSet")
+			appName = "cluster1-app"
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "application", appName,
+					"-n", hubArgoCDNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("verifying Application is owned by the ApplicationSet")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "application", appName,
+					"-n", hubArgoCDNamespace,
+					"-o", "jsonpath={.metadata.ownerReferences[0].kind}/{.metadata.ownerReferences[0].name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("ApplicationSet/" + appSetName))
+			}).Should(Succeed())
+
+			By("verifying Application destination.name is set to agent cluster name")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "application", appName,
+					"-n", hubArgoCDNamespace,
+					"-o", "jsonpath={.spec.destination.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("cluster1"))
+			}).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "Application %s created by ApplicationSet %s in %s namespace\n", appName, appSetName, hubArgoCDNamespace)
+		})
+
+		It("should sync Application to spoke cluster via argocd-agent", func() {
+			By("verifying Application synced to spoke cluster")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "application", appName,
+					"-n", hubArgoCDNamespace,
+					"-o", "jsonpath={.metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal(appName))
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("verifying Application sync status on spoke")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "application", appName,
+					"-n", hubArgoCDNamespace,
+					"-o", "jsonpath={.status.sync.status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Synced"))
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("verifying Application health status on spoke")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "application", appName,
+					"-n", hubArgoCDNamespace,
+					"-o", "jsonpath={.status.health.status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Healthy"))
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("verifying Application status on hub matches spoke")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "application", appName,
+					"-n", hubArgoCDNamespace,
+					"-o", "jsonpath={.status.sync.status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Synced"))
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "Application %s synced to spoke via argocd-agent with custom namespaces\n", appName)
+		})
+
+		It("should deploy application resources on spoke", func() {
+			By("verifying guestbook namespace is created on spoke")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "namespace", targetNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("verifying guestbook deployment is running on spoke")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "deployment", "guestbook-ui",
+					"-n", targetNamespace,
+					"-o", "jsonpath={.status.availableReplicas}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("1"))
 			}).Should(Succeed())
 		})
 	})

--- a/test/e2e/advanced_pull_e2e_test.go
+++ b/test/e2e/advanced_pull_e2e_test.go
@@ -35,10 +35,13 @@ var _ = Describe("Advanced Pull Model E2E", Label("advanced-pull"), Ordered, fun
 	SetDefaultEventuallyTimeout(5 * time.Minute)
 	SetDefaultEventuallyPollingInterval(5 * time.Second)
 
+	const (
+		appSetName      = "test-appset"
+		targetNamespace = "guestbook"
+	)
+
 	BeforeAll(func() {
 		By("Verifying test environment is ready")
-		// Environment setup is done by Makefile (make test-e2e or make test-e2e-full)
-		// This just verifies the contexts exist
 		cmd := exec.Command("kubectl", "config", "get-contexts", hubContext)
 		_, err := utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Hub context should exist - run 'make test-e2e-full' to set up")
@@ -411,7 +414,9 @@ var _ = Describe("Advanced Pull Model E2E", Label("advanced-pull"), Ordered, fun
 		})
 	})
 
-	Context("ArgoCD Agent Sync Verification", func() {
+	Context("Application Sync via ApplicationSet and argocd-agent", func() {
+		var appName string
+
 		It("should sync AppProject from hub to spoke", func() {
 			By("creating AppProject on hub argocd namespace")
 			appProjectYAML := `apiVersion: argoproj.io/v1alpha1
@@ -419,6 +424,8 @@ kind: AppProject
 metadata:
   name: default
   namespace: argocd
+  labels:
+    e2e-sync-test: "true"
 spec:
   clusterResourceWhitelist:
   - group: '*'
@@ -440,10 +447,10 @@ spec:
 				cmd := exec.Command("kubectl", "--context", cluster1Context,
 					"get", "appproject", "default",
 					"-n", argoCDNamespace,
-					"-o", "jsonpath={.metadata.name}")
+					"-o", "jsonpath={.metadata.labels.e2e-sync-test}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("default"))
+				g.Expect(output).To(Equal("true"))
 			}, 30*time.Second).Should(Succeed())
 
 			By("verifying AppProject spec on spoke")
@@ -458,104 +465,129 @@ spec:
 			}).Should(Succeed())
 		})
 
-		It("should sync Application from hub to spoke and reflect status", func() {
-			By("discovering principal server address from GitOpsCluster")
-			var principalAddr, principalPort string
-			Eventually(func(g Gomega) {
-				cmd := exec.Command("kubectl", "--context", hubContext,
-					"get", "gitopscluster", "gitops-cluster",
-					"-n", argoCDNamespace,
-					"-o", "jsonpath={.spec.argoCDAgentAddon.principalServerAddress}")
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).NotTo(BeEmpty(), "Principal server address should be discovered")
-				principalAddr = output
-			}).Should(Succeed())
-
-			Eventually(func(g Gomega) {
-				cmd := exec.Command("kubectl", "--context", hubContext,
-					"get", "gitopscluster", "gitops-cluster",
-					"-n", argoCDNamespace,
-					"-o", "jsonpath={.spec.argoCDAgentAddon.principalServerPort}")
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).NotTo(BeEmpty(), "Principal server port should be discovered")
-				principalPort = output
-			}).Should(Succeed())
-
-			destinationServer := fmt.Sprintf("https://%s:%s?agentName=cluster1", principalAddr, principalPort)
-			fmt.Fprintf(GinkgoWriter, "Using destination server: %s\n", destinationServer)
-
-			By("creating cluster1 namespace on hub")
-			cmd := exec.Command("kubectl", "--context", hubContext, "create", "namespace", "cluster1")
-			_, _ = utils.Run(cmd)
-
-			By("creating Application on hub in cluster1 namespace")
-			applicationYAML := fmt.Sprintf(`apiVersion: argoproj.io/v1alpha1
-kind: Application
+		It("should create ApplicationSet on hub", func() {
+			By("creating test ApplicationSet on hub using clusterDecisionResource generator")
+			appSetYaml := fmt.Sprintf(`
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
 metadata:
-  name: test-app
-  namespace: cluster1
+  name: %s
+  namespace: %s
 spec:
-  project: default
-  source:
-    repoURL: https://github.com/argoproj/argocd-example-apps
-    targetRevision: HEAD
-    path: guestbook
-  destination:
-    server: %s
-    namespace: guestbook
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-    - CreateNamespace=true`, destinationServer)
-			appCmd := exec.Command("kubectl", "--context", hubContext, "apply", "-f", "-")
-			appCmd.Stdin = strings.NewReader(applicationYAML)
-			_, err := utils.Run(appCmd)
+  generators:
+  - clusterDecisionResource:
+      configMapRef: ocm-placement-generator
+      labelSelector:
+        matchLabels:
+          cluster.open-cluster-management.io/placement: placement
+      requeueAfterSeconds: 30
+  template:
+    metadata:
+      name: '{{name}}-app'
+    spec:
+      destination:
+        name: '{{name}}'
+        namespace: %s
+      project: default
+      source:
+        path: guestbook
+        repoURL: https://github.com/argoproj/argocd-example-apps.git
+        targetRevision: HEAD
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+`, appSetName, argoCDNamespace, targetNamespace)
+
+			cmd := exec.Command("kubectl", "--context", hubContext, "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(appSetYaml)
+			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
+			By("verifying ApplicationSet is created on hub")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "applicationset", appSetName,
+					"-n", argoCDNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "ApplicationSet %s created successfully\n", appSetName)
+		})
+
+		It("should create Application from ApplicationSet in argocd namespace", func() {
+			By("verifying Application is created by ApplicationSet")
+			appName = "cluster1-app"
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "application", appName,
+					"-n", argoCDNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("verifying Application is owned by the ApplicationSet")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "application", appName,
+					"-n", argoCDNamespace,
+					"-o", "jsonpath={.metadata.ownerReferences[0].kind}/{.metadata.ownerReferences[0].name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("ApplicationSet/" + appSetName))
+			}).Should(Succeed())
+
+			By("verifying Application destination.name is set to agent cluster name")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", hubContext,
+					"get", "application", appName,
+					"-n", argoCDNamespace,
+					"-o", "jsonpath={.spec.destination.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("cluster1"))
+			}).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "Application %s created by ApplicationSet %s in %s namespace\n", appName, appSetName, argoCDNamespace)
+		})
+
+		It("should sync Application to spoke cluster via argocd-agent", func() {
 			By("verifying Application synced to spoke cluster argocd namespace")
 			Eventually(func(g Gomega) {
 				cmd := exec.Command("kubectl", "--context", cluster1Context,
-					"get", "application", "test-app",
+					"get", "application", appName,
 					"-n", argoCDNamespace,
 					"-o", "jsonpath={.metadata.name}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("test-app"))
+				g.Expect(output).To(Equal(appName))
 			}, 2*time.Minute, 5*time.Second).Should(Succeed())
 
-			By("verifying Application status on spoke is populated")
-			Eventually(func(g Gomega) {
-				cmd := exec.Command("kubectl", "--context", cluster1Context,
-					"get", "application", "test-app",
-					"-n", argoCDNamespace,
-					"-o", "jsonpath={.status.sync.status}")
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).NotTo(BeEmpty(), "Spoke Application sync status should not be empty")
-			}, 3*time.Minute, 5*time.Second).Should(Succeed())
-
-			By("getting Application status from spoke")
+			By("verifying Application sync status on spoke")
 			var spokeSyncStatus, spokeHealthStatus string
 			Eventually(func(g Gomega) {
 				cmd := exec.Command("kubectl", "--context", cluster1Context,
-					"get", "application", "test-app",
+					"get", "application", appName,
 					"-n", argoCDNamespace,
 					"-o", "jsonpath={.status.sync.status}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).NotTo(BeEmpty())
+				g.Expect(output).To(Equal("Synced"))
 				spokeSyncStatus = output
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
 
-				cmd = exec.Command("kubectl", "--context", cluster1Context,
-					"get", "application", "test-app",
+			By("verifying Application health status on spoke")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "application", appName,
 					"-n", argoCDNamespace,
 					"-o", "jsonpath={.status.health.status}")
-				output, err = utils.Run(cmd)
+				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Healthy"))
 				spokeHealthStatus = output
 			}, 3*time.Minute, 5*time.Second).Should(Succeed())
 
@@ -564,27 +596,46 @@ spec:
 			By("verifying Application status on hub matches spoke")
 			Eventually(func(g Gomega) {
 				cmd := exec.Command("kubectl", "--context", hubContext,
-					"get", "application", "test-app",
-					"-n", "cluster1",
+					"get", "application", appName,
+					"-n", argoCDNamespace,
 					"-o", "jsonpath={.status.sync.status}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).NotTo(BeEmpty(), "Hub Application sync status should not be empty")
-				g.Expect(output).To(Equal(spokeSyncStatus), "Hub and Spoke sync status should match")
+				g.Expect(output).To(Equal("Synced"))
 			}, 3*time.Minute, 5*time.Second).Should(Succeed())
 
 			Eventually(func(g Gomega) {
 				cmd := exec.Command("kubectl", "--context", hubContext,
-					"get", "application", "test-app",
-					"-n", "cluster1",
+					"get", "application", appName,
+					"-n", argoCDNamespace,
 					"-o", "jsonpath={.status.health.status}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).NotTo(BeEmpty(), "Hub Application health status should not be empty")
-				g.Expect(output).To(Equal(spokeHealthStatus), "Hub and Spoke health status should match")
+				g.Expect(output).To(Equal("Healthy"))
 			}, 3*time.Minute, 5*time.Second).Should(Succeed())
 
 			By("Hub and Spoke Application status are in sync")
+		})
+
+		It("should deploy application resources on spoke", func() {
+			By("verifying guestbook namespace is created on spoke")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "namespace", targetNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("verifying guestbook deployment is running on spoke")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "--context", cluster1Context,
+					"get", "deployment", "guestbook-ui",
+					"-n", targetNamespace,
+					"-o", "jsonpath={.status.availableReplicas}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("1"))
+			}).Should(Succeed())
 		})
 	})
 
@@ -615,9 +666,16 @@ spec:
 				g.Expect(err).NotTo(HaveOccurred())
 			}, 1*time.Minute, 5*time.Second).Should(Succeed())
 
+			By("deleting ApplicationSet before placement change")
+			cmd := exec.Command("kubectl", "--context", hubContext,
+				"delete", "applicationset", appSetName,
+				"-n", argoCDNamespace,
+				"--timeout=60s")
+			_, _ = utils.Run(cmd)
+
 			By("updating placement to select non-existent cluster to trigger cleanup")
 			patchYAML := `{"spec":{"predicates":[{"requiredClusterSelector":{"labelSelector":{"matchLabels":{"non-existent-cluster":"true"}}}}]}}`
-			cmd := exec.Command("kubectl", "--context", hubContext,
+			cmd = exec.Command("kubectl", "--context", hubContext,
 				"patch", "placement", "placement",
 				"-n", argoCDNamespace,
 				"--type=merge",
@@ -663,15 +721,6 @@ spec:
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(BeEmpty())
 			}, 2*time.Minute, 5*time.Second).Should(Succeed())
-
-			By("verifying Application still exists on spoke cluster (preserved during cleanup)")
-			Eventually(func(g Gomega) {
-				cmd := exec.Command("kubectl", "--context", cluster1Context,
-					"get", "application", "test-app",
-					"-n", argoCDNamespace)
-				_, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-			}, 30*time.Second, 5*time.Second).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
## Summary

* **New Features**
  * ApplicationSet integration with destination-based mapping producing per-cluster Applications
  * Wildcard namespace support with automatic namespace creation per destination

* **Bug Fixes / Improvements**
  * Expanded operator/controller RBAC to support placement-driven ApplicationSets and trust bundle access
  * Added placement-generator configuration for placement decision discovery

* **Documentation**
  * Added ApplicationSet integration guide and operator sync/maintenance doc

* **Tests**
  * E2E tests for ApplicationSet-driven sync and deployment verification