### PR TITLE
Fix: Argo CD cluster secret TLS configuration

### DIFF
--- a/internal/controller/argocd_agent_clusters.go
+++ b/internal/controller/argocd_agent_clusters.go
@@ -18,16 +18,20 @@ package controller
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
-	"open-cluster-management.io/sdk-go/pkg/certrotation"
 )
 
 const (
@@ -39,12 +43,20 @@ const (
 	ArgoCDSecretTypeValue = "cluster"
 	// The principal server expects this specific label to map agent connections to clusters
 	ArgoCDAgentClusterMappingLabel = "argocd-agent.argoproj-labs.io/agent-name"
+
+	clusterClientCertificateSignerSkew = 2 * time.Second
 )
 
 // ClusterConfig represents the ArgoCD cluster configuration
 type ClusterConfig struct {
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
+	Username        string           `json:"username,omitempty"`
+	Password        string           `json:"password,omitempty"`
+	TLSClientConfig *TLSClientConfig `json:"tlsClientConfig,omitempty"`
+}
+
+// TLSClientConfig represents the TLS client configuration for ArgoCD cluster secrets.
+type TLSClientConfig struct {
+	Insecure bool   `json:"insecure"`
 	CertData []byte `json:"certData,omitempty"`
 	KeyData  []byte `json:"keyData,omitempty"`
 	CAData   []byte `json:"caData,omitempty"`
@@ -225,9 +237,12 @@ func (r *GitOpsClusterReconciler) buildArgoCDClusterSecretData(
 	config := ClusterConfig{
 		Username: cluster.Name,
 		Password: cluster.Name, // Using cluster name as password for simplicity
-		CertData: clientCertPEM,
-		KeyData:  clientKeyPEM,
-		CAData:   caCertPEM,
+		TLSClientConfig: &TLSClientConfig{
+			Insecure: false,
+			CertData: clientCertPEM,
+			KeyData:  clientKeyPEM,
+			CAData:   caCertPEM,
+		},
 	}
 
 	configJSON, err := json.Marshal(config)
@@ -271,27 +286,139 @@ func (r *GitOpsClusterReconciler) ensureClusterClientCertificate(
 		return fmt.Errorf("failed to load CA certificate: %w", err)
 	}
 
-	// Create TargetRotation for the cluster client certificate
-	// Use the cluster name as the Common Name for the client certificate
-	clientRotation := &certrotation.TargetRotation{
-		Namespace: namespace,
-		Name:      secretName,
-		Validity:  TargetCertValidity,
-		HostNames: func() []string {
-			// For client certificates, we use the cluster name as CN
-			return []string{clusterName}
-		}(),
-		Lister: secretLister,
-		Client: kubeClient.CoreV1(),
+	existingSecret, err := secretLister.Secrets(namespace).Get(secretName)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+	if err == nil && hasValidClusterClientCertificate(existingSecret, caBundleCerts, clusterName) {
+		return nil
 	}
 
-	// Ensure the client certificate
-	if err := clientRotation.EnsureTargetCertKeyPair(signingCertKeyPair, caBundleCerts); err != nil {
-		return fmt.Errorf("failed to ensure cluster client certificate: %w", err)
+	var signerCerts []*x509.Certificate
+	if signingCertKeyPair != nil && signingCertKeyPair.Config != nil {
+		signerCerts = signingCertKeyPair.Config.Certs
+	}
+	targetValidity, err := clusterClientCertificateTargetValidity(signerCerts, clusterName, time.Now())
+	if err != nil {
+		return err
+	}
+
+	clientCertConfig, err := signingCertKeyPair.MakeClientCertificateForDuration(&user.DefaultInfo{Name: clusterName}, targetValidity)
+	if err != nil {
+		return fmt.Errorf("failed to create cluster client certificate: %w", err)
+	}
+	clientCertPEM, clientKeyPEM, err := clientCertConfig.GetPEMBytes()
+	if err != nil {
+		return fmt.Errorf("failed to encode cluster client certificate: %w", err)
+	}
+
+	targetSecret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		targetSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      secretName,
+			},
+			Type: corev1.SecretTypeTLS,
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to get cluster client certificate secret: %w", err)
+	}
+
+	targetSecret.Type = corev1.SecretTypeTLS
+	targetSecret.Data = map[string][]byte{
+		"tls.crt": clientCertPEM,
+		"tls.key": clientKeyPEM,
+	}
+
+	if targetSecret.ResourceVersion == "" {
+		if _, err := kubeClient.CoreV1().Secrets(namespace).Create(ctx, targetSecret, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("failed to create cluster client certificate secret: %w", err)
+		}
+	} else {
+		if _, err := kubeClient.CoreV1().Secrets(namespace).Update(ctx, targetSecret, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update cluster client certificate secret: %w", err)
+		}
 	}
 
 	klog.V(2).InfoS("Successfully ensured cluster client certificate",
 		"namespace", namespace, "cluster", clusterName, "secret", secretName)
 
 	return nil
+}
+
+// clusterClientCertificateTargetValidity returns a client certificate validity that does not outlive its signer.
+func clusterClientCertificateTargetValidity(signerCerts []*x509.Certificate, clusterName string, now time.Time) (time.Duration, error) {
+	if len(signerCerts) == 0 || signerCerts[0] == nil {
+		return 0, fmt.Errorf("cannot create cluster client certificate for %q: signing certificate is missing", clusterName)
+	}
+
+	targetValidity := TargetCertValidity
+	signerNotAfter := signerCerts[0].NotAfter
+	remainingSignerValidity := signerNotAfter.Sub(now.Add(clusterClientCertificateSignerSkew))
+	if remainingSignerValidity <= 0 {
+		return 0, fmt.Errorf("cannot create cluster client certificate for %q: signing certificate expired or expires too soon at %s", clusterName, signerNotAfter.Format(time.RFC3339))
+	}
+	if remainingSignerValidity < targetValidity {
+		targetValidity = remainingSignerValidity
+	}
+
+	return targetValidity, nil
+}
+
+// hasValidClusterClientCertificate checks whether the secret contains a usable client certificate and key pair.
+func hasValidClusterClientCertificate(secret *corev1.Secret, caBundleCerts []*x509.Certificate, clusterName string) bool {
+	certData := secret.Data["tls.crt"]
+	if len(certData) == 0 {
+		return false
+	}
+	keyData := secret.Data["tls.key"]
+	if len(keyData) == 0 {
+		return false
+	}
+	if _, err := tls.X509KeyPair(certData, keyData); err != nil {
+		return false
+	}
+
+	certificates, err := cert.ParseCertsPEM(certData)
+	if err != nil || len(certificates) == 0 {
+		return false
+	}
+
+	certificate := certificates[0]
+	if certificate.Subject.CommonName != clusterName {
+		return false
+	}
+	if time.Now().After(certificate.NotAfter) {
+		return false
+	}
+	if time.Now().After(certificate.NotAfter.Add(-certificate.NotAfter.Sub(certificate.NotBefore) / 5)) {
+		return false
+	}
+	if !hasExtKeyUsage(certificate, x509.ExtKeyUsageClientAuth) {
+		return false
+	}
+
+	for _, caCert := range caBundleCerts {
+		if certificate.Issuer.CommonName != caCert.Subject.CommonName {
+			continue
+		}
+		if err := certificate.CheckSignatureFrom(caCert); err != nil {
+			continue
+		}
+		return true
+	}
+
+	return false
+}
+
+// hasExtKeyUsage reports whether the certificate contains the requested extended key usage.
+func hasExtKeyUsage(certificate *x509.Certificate, usage x509.ExtKeyUsage) bool {
+	for _, certificateUsage := range certificate.ExtKeyUsage {
+		if certificateUsage == usage {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/controller/argocd_agent_clusters_test.go
+++ b/internal/controller/argocd_agent_clusters_test.go
@@ -17,11 +17,16 @@ limitations under the License.
 package controller
 
 import (
+	"crypto/x509"
 	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/openshift/library-go/pkg/crypto"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/user"
 
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
@@ -36,9 +41,12 @@ func TestClusterConfig(t *testing.T) {
 			config: ClusterConfig{
 				Username: "cluster1",
 				Password: "cluster1",
-				CertData: []byte("cert-data"),
-				KeyData:  []byte("key-data"),
-				CAData:   []byte("ca-data"),
+				TLSClientConfig: &TLSClientConfig{
+					Insecure: false,
+					CertData: []byte("cert-data"),
+					KeyData:  []byte("key-data"),
+					CAData:   []byte("ca-data"),
+				},
 			},
 		},
 		{
@@ -234,9 +242,12 @@ func TestClusterConfigJSON(t *testing.T) {
 	config := ClusterConfig{
 		Username: "test-cluster",
 		Password: "test-cluster",
-		CertData: []byte("-----BEGIN CERTIFICATE-----\ntest-cert\n-----END CERTIFICATE-----"),
-		KeyData:  []byte("-----BEGIN PRIVATE KEY-----\ntest-key\n-----END PRIVATE KEY-----"),
-		CAData:   []byte("-----BEGIN CERTIFICATE-----\ntest-ca\n-----END CERTIFICATE-----"),
+		TLSClientConfig: &TLSClientConfig{
+			Insecure: false,
+			CertData: []byte("-----BEGIN CERTIFICATE-----\ntest-cert\n-----END CERTIFICATE-----"),
+			KeyData:  []byte("-----BEGIN PRIVATE KEY-----\ntest-key\n-----END PRIVATE KEY-----"),
+			CAData:   []byte("-----BEGIN CERTIFICATE-----\ntest-ca\n-----END CERTIFICATE-----"),
+		},
 	}
 
 	// Marshal to JSON
@@ -259,13 +270,202 @@ func TestClusterConfigJSON(t *testing.T) {
 	if decoded.Password != config.Password {
 		t.Errorf("Password = %v, want %v", decoded.Password, config.Password)
 	}
-	if string(decoded.CertData) != string(config.CertData) {
+	if decoded.TLSClientConfig == nil {
+		t.Fatalf("TLSClientConfig is nil")
+	}
+	if decoded.TLSClientConfig.Insecure != config.TLSClientConfig.Insecure {
+		t.Errorf("TLSClientConfig.Insecure = %v, want %v", decoded.TLSClientConfig.Insecure, config.TLSClientConfig.Insecure)
+	}
+	if string(decoded.TLSClientConfig.CertData) != string(config.TLSClientConfig.CertData) {
 		t.Errorf("CertData mismatch")
 	}
-	if string(decoded.KeyData) != string(config.KeyData) {
+	if string(decoded.TLSClientConfig.KeyData) != string(config.TLSClientConfig.KeyData) {
 		t.Errorf("KeyData mismatch")
 	}
-	if string(decoded.CAData) != string(config.CAData) {
+	if string(decoded.TLSClientConfig.CAData) != string(config.TLSClientConfig.CAData) {
 		t.Errorf("CAData mismatch")
+	}
+}
+
+func TestClusterConfigUsesArgoCDTLSClientConfig(t *testing.T) {
+	config := ClusterConfig{
+		Username: "test-cluster",
+		Password: "test-cluster",
+		TLSClientConfig: &TLSClientConfig{
+			Insecure: false,
+			CertData: []byte("cert-data"),
+			KeyData:  []byte("key-data"),
+			CAData:   []byte("ca-data"),
+		},
+	}
+
+	data, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("Failed to marshal config: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Failed to unmarshal config map: %v", err)
+	}
+
+	if _, ok := raw["tlsClientConfig"]; !ok {
+		t.Fatalf("Expected tlsClientConfig in cluster config")
+	}
+
+	for _, key := range []string{"certData", "keyData", "caData"} {
+		if _, ok := raw[key]; ok {
+			t.Fatalf("Expected %s to be nested under tlsClientConfig, but found it at the top level", key)
+		}
+	}
+
+	tlsClientConfig, ok := raw["tlsClientConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("tlsClientConfig has unexpected type %T", raw["tlsClientConfig"])
+	}
+
+	for _, key := range []string{"certData", "keyData", "caData"} {
+		if _, ok := tlsClientConfig[key]; !ok {
+			t.Fatalf("Expected %s under tlsClientConfig", key)
+		}
+	}
+
+	if insecure, ok := tlsClientConfig["insecure"].(bool); !ok || insecure {
+		t.Fatalf("Expected tlsClientConfig.insecure to be false, got %v", tlsClientConfig["insecure"])
+	}
+}
+
+func TestHasValidClusterClientCertificate(t *testing.T) {
+	caConfig, err := crypto.MakeSelfSignedCAConfigForDuration("test-ca", time.Hour)
+	if err != nil {
+		t.Fatalf("Failed to create CA config: %v", err)
+	}
+	caCertPEM, caKeyPEM, err := caConfig.GetPEMBytes()
+	if err != nil {
+		t.Fatalf("Failed to encode CA config: %v", err)
+	}
+	ca, err := crypto.GetCAFromBytes(caCertPEM, caKeyPEM)
+	if err != nil {
+		t.Fatalf("Failed to load CA: %v", err)
+	}
+
+	clientCertConfig, err := ca.MakeClientCertificateForDuration(&user.DefaultInfo{Name: "test-cluster"}, time.Hour)
+	if err != nil {
+		t.Fatalf("Failed to create client certificate: %v", err)
+	}
+	clientCertPEM, clientKeyPEM, err := clientCertConfig.GetPEMBytes()
+	if err != nil {
+		t.Fatalf("Failed to encode client certificate: %v", err)
+	}
+
+	serverCertConfig, err := ca.MakeServerCertForDuration(sets.New[string]("test-cluster"), time.Hour)
+	if err != nil {
+		t.Fatalf("Failed to create server certificate: %v", err)
+	}
+	serverCertPEM, serverKeyPEM, err := serverCertConfig.GetPEMBytes()
+	if err != nil {
+		t.Fatalf("Failed to encode server certificate: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		certPEM  []byte
+		keyPEM   []byte
+		wantGood bool
+	}{
+		{
+			name:     "accepts client auth certificate",
+			certPEM:  clientCertPEM,
+			keyPEM:   clientKeyPEM,
+			wantGood: true,
+		},
+		{
+			name:     "rejects server auth certificate",
+			certPEM:  serverCertPEM,
+			keyPEM:   serverKeyPEM,
+			wantGood: false,
+		},
+		{
+			name:     "rejects missing private key",
+			certPEM:  clientCertPEM,
+			wantGood: false,
+		},
+		{
+			name:     "rejects invalid private key",
+			certPEM:  clientCertPEM,
+			keyPEM:   []byte("invalid private key"),
+			wantGood: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := &corev1.Secret{
+				Data: map[string][]byte{
+					"tls.crt": tt.certPEM,
+					"tls.key": tt.keyPEM,
+				},
+			}
+
+			gotGood := hasValidClusterClientCertificate(secret, caConfig.Certs, "test-cluster")
+			if gotGood != tt.wantGood {
+				t.Fatalf("hasValidClusterClientCertificate() = %v, want %v", gotGood, tt.wantGood)
+			}
+		})
+	}
+}
+
+func TestClusterClientCertificateTargetValidity(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name         string
+		signerCerts  []*x509.Certificate
+		wantValidity time.Duration
+		wantErr      bool
+	}{
+		{
+			name: "uses target validity when signer is valid longer",
+			signerCerts: []*x509.Certificate{
+				{NotAfter: now.Add(TargetCertValidity + time.Hour)},
+			},
+			wantValidity: TargetCertValidity,
+		},
+		{
+			name: "clamps to remaining signer validity",
+			signerCerts: []*x509.Certificate{
+				{NotAfter: now.Add(time.Hour)},
+			},
+			wantValidity: time.Hour - clusterClientCertificateSignerSkew,
+		},
+		{
+			name: "rejects signer expiring inside safety window",
+			signerCerts: []*x509.Certificate{
+				{NotAfter: now.Add(time.Second)},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "rejects missing signer certificate",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotValidity, err := clusterClientCertificateTargetValidity(tt.signerCerts, "test-cluster", now)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Expected no error, got %v", err)
+			}
+			if gotValidity != tt.wantValidity {
+				t.Fatalf("target validity = %v, want %v", gotValidity, tt.wantValidity)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

This fixes the Argo CD cluster secret generated for managed clusters in the Argo CD Agent pull model.

The generated cluster config now places client certificate data under `tlsClientConfig`, which is the structure Argo CD expects for cluster secrets. The cluster client certificate is also generated as a client-auth certificate instead of a server-auth certificate.

## Problem

##### The current generated config stores TLS data at the top level:

```json
{
  "certData": "...",
  "keyData": "...",
  "caData": "..."
}
```
##### Argo CD expects these fields under tlsClientConfig:
```json
{
  "tlsClientConfig": {
    "insecure": false,
    "certData": "...",
    "keyData": "...",
    "caData": "..."
  }
}
```
When the fields are at the top level, Argo CD does not use the CA/client certificate correctly when accessing the agent resource proxy. This can break live resource reads with TLS verification errors.

The previous client certificate generation also used the server certificate path, producing a certificate with server-auth usage. The resource proxy needs a client-auth certificate for mTLS.

## Testing
- `go test ./internal/controller`
- `go vet ./internal/controller`
- `make test` using Docker `golang:1.26`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * TLS client certificate material is now grouped under a dedicated TLS client config and certificate issuance/rotation and validation have been strengthened to ensure correct client auth and expiry handling.

* **Tests**
  * Added tests covering TLS client config structure, certificate validation (auth/expiry/signature), and target validity selection including expiry clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->