### PR TITLE
:seedling: chore: pin GitHub Actions to digest SHAs and replace setup-kind

### DIFF
--- a/.github/workflows/chart-upload.yml
+++ b/.github/workflows/chart-upload.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: get release version
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: submit advanced chart to OCM chart repo
         if: github.event_name != 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.OCM_BOT_PAT }}
           script: |
@@ -63,7 +63,7 @@ jobs:
             }
       - name: submit basic chart to OCM chart repo
         if: github.event_name != 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.OCM_BOT_PAT }}
           script: |

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
     - name: Get PR Commits
       id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@master
+      uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d # master
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: DCO Check
-      uses: tim-actions/dco@master
+      uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21 # master
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,7 @@ on:
 env:
   # Common versions
   GO_VERSION: '1.26'
+  KUBERNETES_VERSION: 'v1.24.0'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/argocd-pull-integration/argocd-pull-integration/go'
 
@@ -22,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/argocd-pull-integration
 
       - name: install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -40,13 +41,13 @@ jobs:
 
       # Install Helm so make test-e2e can run helm commands
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.15.2  # pin for reproducibility; omit to get latest v3
 
       # Optional: pin kubectl to match your kind/k8s version
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
         with:
           version: v1.29.0
 
@@ -54,16 +55,10 @@ jobs:
         run: make build-images
 
       - name: setup kind (cluster1)
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: v0.14.0
-          name: cluster1
+        run: kind create cluster --name cluster1 --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
 
       - name: setup kind (hub)
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: v0.14.0
-          name: hub
+        run: kind create cluster --name hub --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
 
       - name: Load image on the nodes of the hub
         run: |
@@ -83,13 +78,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/argocd-pull-integration
 
       - name: install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -100,12 +95,12 @@ jobs:
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.15.2
 
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
         with:
           version: v1.29.0
 
@@ -113,16 +108,10 @@ jobs:
         run: make build-images
 
       - name: setup kind (cluster1)
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: v0.14.0
-          name: cluster1
+        run: kind create cluster --name cluster1 --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
 
       - name: setup kind (hub)
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: v0.14.0
-          name: hub
+        run: kind create cluster --name hub --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
 
       - name: Load image on the nodes of the hub
         run: |
@@ -142,13 +131,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/argocd-pull-integration
 
       - name: install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -159,12 +148,12 @@ jobs:
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.15.2
 
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
         with:
           version: v1.29.0
 
@@ -172,16 +161,10 @@ jobs:
         run: make build-images
 
       - name: setup kind (cluster1)
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: v0.14.0
-          name: cluster1
+        run: kind create cluster --name cluster1 --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
 
       - name: setup kind (hub)
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: v0.14.0
-          name: hub
+        run: kind create cluster --name hub --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
 
       - name: Load image on the nodes of the hub
         run: |

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Run FOSSA Scan
-        uses: fossas/fossa-action@v1
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -24,12 +24,12 @@ jobs:
         arch: [ amd64 ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/argocd-pull-integration
       - name: install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/argocd-pull-integration
       - name: install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: build
@@ -39,12 +39,12 @@ jobs:
         arch: [ amd64 ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/argocd-pull-integration
       - name: install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -58,12 +58,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/argocd-pull-integration
       - name: install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: test

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: get release version
@@ -41,11 +41,11 @@ jobs:
         arch: [ amd64 ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -67,7 +67,7 @@ jobs:
     needs: [ env, images ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: create
@@ -88,11 +88,11 @@ jobs:
     needs: [ env, image-manifest ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: setup helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
       - name: prepare advanced chart for release
         run: |
           # Update Chart.yaml appVersion to match release version (without 'v' prefix)
@@ -142,7 +142,7 @@ jobs:
           echo "- **Advanced Pull Model Chart**: \`${{ env.CHART_NAME }}-${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}.tgz\`" >> /home/runner/work/changelog.txt
           echo "- **Basic Pull Model Chart**: \`${{ env.BASIC_CHART_NAME }}-${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}.tgz\`" >> /home/runner/work/changelog.txt
       - name: publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Pin all GitHub Actions to immutable commit SHAs to prevent supply chain issues from moving tags.

Replace `engineerd/setup-kind` with direct `kind create cluster` run steps using the `kind` binary pre-installed on GitHub-hosted runners. The Kubernetes node image version is now explicit via `KUBERNETES_VERSION` env variable set to `v1.24.0` (same version previously used by kind v0.14.0 by default).

Similar to what we did in ocm: https://github.com/open-cluster-management-io/ocm/pull/1572 to get rid of setup-kind which was causing issues.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to pin external action versions to specific commit SHAs for improved build reproducibility and security across multiple CI/CD pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->