### PR TITLE
fix: include advertised principal server address in principal cert SANs

### DIFF
--- a/internal/controller/argocd_agent_certificates.go
+++ b/internal/controller/argocd_agent_certificates.go
@@ -131,9 +131,14 @@ func (r *GitOpsClusterReconciler) EnsureArgoCDAgentCASecret(ctx context.Context,
 	return nil
 }
 
-// EnsurePrincipalCertificate ensures the principal TLS certificate is generated from the CA
-func (r *GitOpsClusterReconciler) EnsurePrincipalCertificate(ctx context.Context, namespace string) error {
-	klog.V(2).InfoS("Ensuring principal TLS certificate", "namespace", namespace)
+// EnsurePrincipalCertificate ensures the principal TLS certificate is generated from the CA.
+// serverAddress is the address the controller advertises to agents
+// (GitOpsCluster.Spec.ArgoCDAgentAddon.PrincipalServerAddress); it is added to the
+// certificate SANs so the cert is valid for exactly what agents dial — whether that is a
+// bare IP (e.g. an internal LoadBalancer VIP) or a DNS name fronting the LB. Pass "" to
+// derive SANs from the principal Service alone.
+func (r *GitOpsClusterReconciler) EnsurePrincipalCertificate(ctx context.Context, namespace, serverAddress string) error {
+	klog.V(2).InfoS("Ensuring principal TLS certificate", "namespace", namespace, "serverAddress", serverAddress)
 
 	// Verify CA secret exists
 	if err := r.verifyCACertificateExists(ctx, namespace); err != nil {
@@ -163,7 +168,7 @@ func (r *GitOpsClusterReconciler) EnsurePrincipalCertificate(ctx context.Context
 		Namespace: namespace,
 		Name:      ArgoCDAgentPrincipalTLSSecretName,
 		Validity:  TargetCertValidity,
-		HostNames: r.getPrincipalHostNames(ctx, namespace),
+		HostNames: r.getPrincipalHostNames(ctx, namespace, serverAddress),
 		Lister:    secretLister,
 		Client:    kubeClient.CoreV1(),
 	}
@@ -327,17 +332,24 @@ func (r *GitOpsClusterReconciler) loadCACertificate(
 
 // getPrincipalHostNames returns the hostnames for the principal certificate.
 // Includes LoadBalancer IPs/hostnames, NodePort node IPs, and internal DNS names.
-func (r *GitOpsClusterReconciler) getPrincipalHostNames(ctx context.Context, namespace string) []string {
+func (r *GitOpsClusterReconciler) getPrincipalHostNames(ctx context.Context, namespace, serverAddress string) []string {
 	hostnames := []string{}
+
+	// The advertised server address is added LAST (see appendServerAddress below), not
+	// first: certrotation derives the certificate's Subject CN from the first HostNames
+	// entry, so we keep the stable service-derived name as the CN and add serverAddress
+	// only as an additional SAN. An operator-set DNS name or an IP LB VIP would otherwise
+	// become the CN, which is undesirable (and could be a long/host:port string).
 
 	service, err := r.findArgoCDAgentPrincipalService(ctx, namespace)
 	if err != nil {
 		klog.V(2).InfoS("Could not find principal service for hostname discovery, using defaults", "error", err)
 		serviceName := "argocd-agent-principal"
-		return []string{
+		hostnames = append(hostnames,
 			fmt.Sprintf("%s.%s.svc", serviceName, namespace),
 			fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace),
-		}
+		)
+		return dedupeHostNames(appendServerAddress(hostnames, serverAddress))
 	}
 
 	// Add LoadBalancer external hostnames/IPs
@@ -375,7 +387,36 @@ func (r *GitOpsClusterReconciler) getPrincipalHostNames(ctx context.Context, nam
 
 	hostnames = append(hostnames, "localhost", "127.0.0.1", "::1")
 
+	return dedupeHostNames(appendServerAddress(hostnames, serverAddress))
+}
+
+// appendServerAddress appends the advertised server address as an additional SAN, if set.
+// This is the address the controller writes into every agent's ARGOCD_AGENT_REMOTE_SERVER,
+// so the principal cert MUST be valid for it. It is appended (not prepended) so the stable
+// service-derived name remains the certificate Subject CN. certrotation classifies the
+// entry as an IP or DNS SAN via crypto.IPAddressesDNSNames, so this is correct whether
+// serverAddress is a bare IP (e.g. an internal LoadBalancer VIP) or a DNS name.
+func appendServerAddress(hostnames []string, serverAddress string) []string {
+	if serverAddress != "" {
+		hostnames = append(hostnames, serverAddress)
+	}
 	return hostnames
+}
+
+// dedupeHostNames removes duplicate SAN entries while preserving order. The advertised
+// server address can coincide with a Service ingress IP/hostname, so the combined list
+// may contain duplicates; a duplicate SAN is harmless but noisy in the issued cert.
+func dedupeHostNames(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, h := range in {
+		if _, ok := seen[h]; ok {
+			continue
+		}
+		seen[h] = struct{}{}
+		out = append(out, h)
+	}
+	return out
 }
 
 // getResourceProxyHostNames returns the hostnames for the resource proxy certificate

--- a/internal/controller/argocd_agent_certificates_test.go
+++ b/internal/controller/argocd_agent_certificates_test.go
@@ -30,6 +30,14 @@ import (
 	appsv1alpha1 "open-cluster-management.io/argocd-pull-integration/api/v1alpha1"
 )
 
+// Example advertised-address values for the principal certificate SAN tests. These are
+// deliberately RFC-reserved documentation values (RFC 5737 TEST-NET-1 for the IP, RFC 2606
+// for the domain) so no real infrastructure address appears in the codebase.
+const (
+	testAdvertisedIP  = "192.0.2.10"            // RFC 5737 TEST-NET-1
+	testAdvertisedDNS = "principal.example.com" // RFC 2606 reserved example domain
+)
+
 func TestGetPrincipalHostNames(t *testing.T) {
 	s := runtime.NewScheme()
 	_ = scheme.AddToScheme(s)
@@ -38,10 +46,17 @@ func TestGetPrincipalHostNames(t *testing.T) {
 	namespace := "argocd"
 
 	tests := []struct {
-		name         string
-		existingObjs []runtime.Object
-		wantMinCount int
-		wantContains string
+		name          string
+		existingObjs  []runtime.Object
+		serverAddress string
+		wantMinCount  int
+		wantContains  string
+		// wantAbsentDup asserts the given SAN appears at most once (dedupe check).
+		wantAbsentDup string
+		// allowFirst skips the "serverAddress must not be the CN" guard for cases where
+		// serverAddress legitimately coincides with a discovered address that is first by
+		// design (e.g. a LoadBalancer ingress IP, or a service-derived fallback name).
+		allowFirst bool
 	}{
 		{
 			name: "with principal service",
@@ -65,6 +80,71 @@ func TestGetPrincipalHostNames(t *testing.T) {
 			wantMinCount: 2, // Returns default hostnames
 			wantContains: "argocd-agent-principal.argocd.svc",
 		},
+		{
+			name: "advertised IP server address is included as a SAN",
+			existingObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "argocd-agent-principal",
+						Namespace: namespace,
+					},
+					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
+				},
+			},
+			serverAddress: testAdvertisedIP,
+			wantMinCount:  3,
+			wantContains:  testAdvertisedIP,
+		},
+		{
+			name: "advertised DNS server address is included as a SAN",
+			existingObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "argocd-agent-principal",
+						Namespace: namespace,
+					},
+					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
+				},
+			},
+			serverAddress: testAdvertisedDNS,
+			wantMinCount:  3,
+			wantContains:  testAdvertisedDNS,
+		},
+		{
+			// serverAddress is DISTINCT from the fallback names, so a pass here proves
+			// the advertised address is genuinely threaded in (not just the fallback).
+			name:          "advertised address without service is still included",
+			existingObjs:  []runtime.Object{},
+			serverAddress: testAdvertisedDNS,
+			wantMinCount:  3, // 2 fallback DNS names + the advertised address
+			wantContains:  testAdvertisedDNS,
+		},
+		{
+			// serverAddress coincides with the Service's LoadBalancer ingress IP, so the
+			// combined list would contain it twice — assert dedupe collapses it to one.
+			// The IP is first here because LB-ingress discovery adds it before the DNS
+			// names (pre-existing ordering), so the CN guard is opted out via allowFirst.
+			name: "advertised address matching a service ingress is deduped to one",
+			existingObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "argocd-agent-principal",
+						Namespace: namespace,
+					},
+					Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: testAdvertisedIP}},
+						},
+					},
+				},
+			},
+			serverAddress: testAdvertisedIP,
+			wantMinCount:  3,
+			wantContains:  testAdvertisedIP,
+			wantAbsentDup: testAdvertisedIP,
+			allowFirst:    true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -74,7 +154,7 @@ func TestGetPrincipalHostNames(t *testing.T) {
 				Scheme: s,
 			}
 
-			hostNames := r.getPrincipalHostNames(context.Background(), namespace)
+			hostNames := r.getPrincipalHostNames(context.Background(), namespace, tt.serverAddress)
 
 			if len(hostNames) < tt.wantMinCount {
 				t.Errorf("getPrincipalHostNames() returned %d hostnames, want at least %d", len(hostNames), tt.wantMinCount)
@@ -82,14 +162,30 @@ func TestGetPrincipalHostNames(t *testing.T) {
 
 			// Verify expected hostname is included
 			found := false
+			count := 0
 			for _, hn := range hostNames {
 				if hn == tt.wantContains {
 					found = true
-					break
+				}
+				if tt.wantAbsentDup != "" && hn == tt.wantAbsentDup {
+					count++
 				}
 			}
 			if !found {
 				t.Errorf("getPrincipalHostNames() should contain %s, got %v", tt.wantContains, hostNames)
+			}
+			if tt.wantAbsentDup != "" && count != 1 {
+				t.Errorf("getPrincipalHostNames() should contain %s exactly once (dedupe), got %d in %v", tt.wantAbsentDup, count, hostNames)
+			}
+			// The advertised serverAddress must be APPENDED, never first: certrotation
+			// derives the Subject CN from the first entry, which must stay the stable
+			// service-derived name, not an operator-set DNS/IP address. Cases where the
+			// address legitimately coincides with a first-by-design discovered value (a
+			// service-derived fallback name, or a LoadBalancer ingress IP) opt out via
+			// allowFirst.
+			if !tt.allowFirst && tt.serverAddress != "" &&
+				len(hostNames) > 0 && hostNames[0] == tt.serverAddress {
+				t.Errorf("serverAddress %q must not be the first (CN) entry; got %v", tt.serverAddress, hostNames)
 			}
 		})
 	}

--- a/internal/controller/gitopscluster_controller.go
+++ b/internal/controller/gitopscluster_controller.go
@@ -151,8 +151,10 @@ func (r *GitOpsClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	r.setCondition(ctx, gitOpsCluster, appsv1alpha1.ConditionCACertificateReady, metav1.ConditionTrue,
 		appsv1alpha1.ReasonSuccess, "CA certificate created successfully")
 
-	// 4) Use the ca secret to generate the principal cert
-	if err := r.EnsurePrincipalCertificate(ctx, argoCDNamespace); err != nil {
+	// 4) Use the ca secret to generate the principal cert. Pass the advertised server
+	// address so it is included in the cert SANs — the cert must be valid for the exact
+	// address agents dial (ARGOCD_AGENT_REMOTE_SERVER), be it an IP or a DNS name.
+	if err := r.EnsurePrincipalCertificate(ctx, argoCDNamespace, serverAddress); err != nil {
 		klog.ErrorS(err, "Failed to ensure principal certificate", "namespace", argoCDNamespace)
 		r.setCondition(ctx, gitOpsCluster, appsv1alpha1.ConditionPrincipalCertificateReady, metav1.ConditionFalse,
 			appsv1alpha1.ReasonFailed, fmt.Sprintf("Failed to generate principal certificate: %v", err))


### PR DESCRIPTION
## Summary

The `GitOpsCluster` controller writes `PrincipalServerAddress` into every managed agent's `ARGOCD_AGENT_REMOTE_SERVER`, but the principal TLS certificate's SANs are derived only from the principal `Service` status (LoadBalancer ingress, NodePort node IPs) plus the internal cluster DNS names. The certificate is therefore **never guaranteed to be valid for the exact address the controller tells agents to dial.**

## Why it matters

This is masked on setups where the advertised address happens to equal a `Service` ingress IP already in the SANs, but it breaks in two common cases:

- **Internal L4 LoadBalancers on some clouds (e.g. GKE)** populate `Status.LoadBalancer.Ingress[].IP` but **not** `.Hostname`. A DNS name fronting the LB can never make it into the SANs, so an agent configured with that name fails TLS hostname verification.
- **An operator pinning `PrincipalServerAddress`** to a stable DNS name or a reserved VIP that differs from what the `Service` reports.

## Change

Thread the advertised `serverAddress` through `EnsurePrincipalCertificate` into `getPrincipalHostNames`, and add it to the SAN set. The underlying `library-go` crypto helper classifies each entry as an IP or DNS SAN via `net.ParseIP`, so this is correct whether the advertised address is a bare IP or a hostname. Duplicate SANs (when the address coincides with a `Service` ingress value) are removed via a small `dedupeHostNames` helper.

## Tests

Adds unit coverage to `TestGetPrincipalHostNames` for:
- advertised **IP** address included as a SAN,
- advertised **DNS** name included as a SAN,
- **dedupe** when the advertised address coincides with an existing SAN.

`go build ./...`, `go vet ./internal/controller/`, and `go test ./internal/controller/` all pass.

## Notes

Backward compatible: passing `""` (the previous behavior for callers that don't have an address yet) derives SANs from the `Service` alone, exactly as before. The single production caller in `gitopscluster_controller.go` now passes the discovered/spec `serverAddress`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Principal certificate SANs now include the configured remote server address (IP or DNS) used by the agent.
  - Hostname/SAN generation now falls back more reliably when the principal service can’t be discovered and deduplicates resulting entries to prevent repeated SANs.
- **Tests**
  - Expanded SAN/hostname generation coverage to validate advertised server address inclusion, missing-service fallback behavior, deduplication, and ordering/CN safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->