### PR TITLE
feat: restart argocd-agent principal when its TLS cert changes

### DIFF
--- a/charts/argocd-agent-addon/Chart.yaml
+++ b/charts/argocd-agent-addon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.28.0
+appVersion: 0.28.1
 description: Argo CD Agent Add-on for Open Cluster Management (Advanced Pull Model)
 name: argocd-agent-addon
 type: application
-version: 0.28.0
+version: 0.28.1

--- a/charts/argocd-pull-integration/Chart.yaml
+++ b/charts/argocd-pull-integration/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.28.0
+appVersion: 0.28.1
 description: Argo CD Pull Integration Add-on for Open Cluster Management (Basic Pull Model)
 name: argocd-pull-integration
 type: application
-version: 0.28.0
+version: 0.28.1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -47,6 +47,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - apps.open-cluster-management.io

--- a/internal/addon/charts/argocd-agent-addon/Chart.yaml
+++ b/internal/addon/charts/argocd-agent-addon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: argocd-agent-addon
 description: Argo CD Agent Addon
 type: application
-version: 0.28.0
-appVersion: 0.28.0
+version: 0.28.1
+appVersion: 0.28.1

--- a/internal/controller/argocd_agent_certificates.go
+++ b/internal/controller/argocd_agent_certificates.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"time"
@@ -25,6 +26,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openshift/library-go/pkg/crypto"
@@ -173,6 +175,16 @@ func (r *GitOpsClusterReconciler) EnsurePrincipalCertificate(ctx context.Context
 		Client:    kubeClient.CoreV1(),
 	}
 
+	// Snapshot the current cert bytes BEFORE rotation so we can tell whether
+	// EnsureTargetCertKeyPair actually changed them. The principal reads its TLS
+	// keypair ONCE at startup (no fsnotify/informer/reload — argocd-agent
+	// principal caches the tls.Config on boot), so it must be restarted whenever
+	// this secret's contents change. certrotation rewrites the secret on the ~30-day
+	// rotation (and on first creation / SAN change); comparing the tls.crt bytes
+	// across the call detects exactly those events and nothing else, so a stable
+	// cert on the 10-minute resync produces NO restart (loop-safe).
+	certBefore, errBefore := r.getPrincipalTLSCertBytes(ctx, kubeClient, namespace)
+
 	// Ensure the principal TLS certificate
 	if err := principalRotation.EnsureTargetCertKeyPair(signingCertKeyPair, caBundleCerts); err != nil {
 		return fmt.Errorf("failed to ensure principal TLS certificate: %w", err)
@@ -184,7 +196,90 @@ func (r *GitOpsClusterReconciler) EnsurePrincipalCertificate(ctx context.Context
 	klog.InfoS("Successfully ensured principal TLS certificate",
 		"namespace", namespace, "secret", ArgoCDAgentPrincipalTLSSecretName)
 
+	// If the cert changed (rotation, first issuance, or SAN change), restart the
+	// principal so it picks up the new keypair. Best-effort: a restart failure must
+	// not fail the reconcile (the cert IS provisioned; the next resync retries).
+	certAfter, errAfter := r.getPrincipalTLSCertBytes(ctx, kubeClient, namespace)
+
+	// A read error (timeout, throttling, forbidden) is NOT a certificate change.
+	// Treating it as one would spuriously restart the principal (error on the before
+	// read) or silently miss a real rotation (error on the after read). Skip the
+	// change decision entirely when either read failed and let the next resync retry —
+	// the cert itself is already provisioned, so this only defers the restart.
+	if errBefore != nil || errAfter != nil {
+		klog.V(2).InfoS("Skipping principal restart decision: could not reliably read cert bytes; will retry next resync",
+			"namespace", namespace, "errBefore", errBefore, "errAfter", errAfter)
+		return nil
+	}
+
+	if !bytes.Equal(certBefore, certAfter) {
+		klog.InfoS("Principal TLS certificate changed — restarting principal to load it",
+			"namespace", namespace, "secret", ArgoCDAgentPrincipalTLSSecretName,
+			"firstIssuance", len(certBefore) == 0)
+		if err := r.restartPrincipalDeployment(ctx, kubeClient, namespace); err != nil {
+			klog.ErrorS(err, "Failed to restart principal after certificate change (non-fatal; will retry next resync)",
+				"namespace", namespace)
+		}
+	}
+
 	return nil
+}
+
+// getPrincipalTLSCertBytes returns the tls.crt bytes of the principal TLS secret. A
+// genuinely absent secret (cold-start, before first issuance) returns (nil, nil); any
+// other GET failure returns a non-nil error so the caller can distinguish "no cert yet"
+// from "couldn't read the cert" and avoid mistaking a transient error for a cert change.
+// Read directly from the API server (not the informer lister) so the value reflects the
+// just-written secret.
+func (r *GitOpsClusterReconciler) getPrincipalTLSCertBytes(
+	ctx context.Context, kubeClient kubernetes.Interface, namespace string) ([]byte, error) {
+
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, ArgoCDAgentPrincipalTLSSecretName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return secret.Data[corev1.TLSCertKey], nil
+}
+
+// restartPrincipalDeployment triggers a rolling restart of the argocd-agent principal
+// Deployment by stamping the conventional restartedAt annotation on its pod template —
+// the same mechanism as `kubectl rollout restart`. This is how the controller keeps the
+// principal's in-memory TLS keypair in sync with the rotated secret WITHOUT any external
+// controller (e.g. Stakater Reloader) or a hand-run `kubectl rollout restart`.
+//
+// Best-effort by design: it patches by name (with the openshift-gitops fallback) and
+// returns an error only for the caller to log — a missing Deployment (the operator hasn't
+// created it yet) or a transient patch failure must not fail cert reconciliation.
+func (r *GitOpsClusterReconciler) restartPrincipalDeployment(
+	ctx context.Context, kubeClient kubernetes.Interface, namespace string) error {
+
+	// Merge-patch the pod-template restartedAt annotation. This is idempotent per
+	// timestamp and rolls the Deployment exactly once per cert change.
+	patch := fmt.Sprintf(
+		`{"spec":{"template":{"metadata":{"annotations":{"argocd-pull-integration/principal-cert-restartedAt":%q}}}}}`,
+		time.Now().UTC().Format(time.RFC3339))
+
+	names := []string{"argocd-agent-principal", "openshift-gitops-agent-principal"}
+	var lastErr error
+	for _, name := range names {
+		_, err := kubeClient.AppsV1().Deployments(namespace).Patch(
+			ctx, name, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+		if err == nil {
+			klog.InfoS("Restarted argocd-agent principal Deployment after certificate change",
+				"namespace", namespace, "deployment", name)
+			return nil
+		}
+		if !k8serrors.IsNotFound(err) {
+			lastErr = fmt.Errorf("failed to patch Deployment %s/%s: %w", namespace, name, err)
+		}
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("argocd-agent principal Deployment not found in namespace %s (tried %v) — operator may not have created it yet", namespace, names)
 }
 
 // EnsureResourceProxyCertificate ensures the resource proxy TLS certificate is generated from the CA

--- a/internal/controller/argocd_agent_principal_restart_test.go
+++ b/internal/controller/argocd_agent_principal_restart_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2025 Open Cluster Management.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+const restartAnnotationKey = "argocd-pull-integration/principal-cert-restartedAt"
+
+func principalDeployment(name, namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		},
+	}
+}
+
+func TestGetPrincipalTLSCertBytes(t *testing.T) {
+	namespace := "argocd"
+
+	tests := []struct {
+		name      string
+		secret    *corev1.Secret
+		injectErr bool // simulate a transient (non-NotFound) GET failure
+		wantNil   bool
+		wantVal   string
+		wantErr   bool
+	}{
+		{
+			name:    "secret missing returns (nil, nil) (cold-start)",
+			secret:  nil,
+			wantNil: true,
+			wantErr: false,
+		},
+		{
+			name: "secret present returns tls.crt bytes",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: ArgoCDAgentPrincipalTLSSecretName, Namespace: namespace},
+				Data:       map[string][]byte{corev1.TLSCertKey: []byte("CERT-A")},
+			},
+			wantNil: false,
+			wantVal: "CERT-A",
+			wantErr: false,
+		},
+		{
+			// A transient GET error must surface as a non-nil error (NOT nil bytes),
+			// so the caller can tell it apart from a genuinely absent secret and avoid
+			// mistaking the read failure for a certificate change.
+			name:      "transient GET error is propagated (not treated as absent)",
+			secret:    nil,
+			injectErr: true,
+			wantNil:   true,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var kube *kubefake.Clientset
+			if tt.secret != nil {
+				kube = kubefake.NewSimpleClientset(tt.secret)
+			} else {
+				kube = kubefake.NewSimpleClientset()
+			}
+			if tt.injectErr {
+				kube.PrependReactor("get", "secrets", func(clienttesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewServerTimeout(schema.GroupResource{Resource: "secrets"}, "get", 1)
+				})
+			}
+			r := &GitOpsClusterReconciler{}
+			got, err := r.getPrincipalTLSCertBytes(context.Background(), kube, namespace)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil bytes, got %q", string(got))
+				}
+				return
+			}
+			if string(got) != tt.wantVal {
+				t.Errorf("got %q, want %q", string(got), tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestRestartPrincipalDeployment(t *testing.T) {
+	namespace := "argocd"
+
+	t.Run("patches argocd-agent-principal by name", func(t *testing.T) {
+		kube := kubefake.NewSimpleClientset(principalDeployment("argocd-agent-principal", namespace))
+		r := &GitOpsClusterReconciler{}
+
+		if err := r.restartPrincipalDeployment(context.Background(), kube, namespace); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		dep, err := kube.AppsV1().Deployments(namespace).Get(context.Background(), "argocd-agent-principal", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get deployment: %v", err)
+		}
+		if _, ok := dep.Spec.Template.ObjectMeta.Annotations[restartAnnotationKey]; !ok {
+			t.Errorf("expected restart annotation %q on pod template, got %v", restartAnnotationKey, dep.Spec.Template.ObjectMeta.Annotations)
+		}
+	})
+
+	t.Run("falls back to openshift-gitops naming", func(t *testing.T) {
+		kube := kubefake.NewSimpleClientset(principalDeployment("openshift-gitops-agent-principal", namespace))
+		r := &GitOpsClusterReconciler{}
+
+		if err := r.restartPrincipalDeployment(context.Background(), kube, namespace); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		dep, err := kube.AppsV1().Deployments(namespace).Get(context.Background(), "openshift-gitops-agent-principal", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get deployment: %v", err)
+		}
+		if _, ok := dep.Spec.Template.ObjectMeta.Annotations[restartAnnotationKey]; !ok {
+			t.Errorf("expected restart annotation on fallback deployment")
+		}
+	})
+
+	t.Run("missing deployment returns error (non-fatal to caller)", func(t *testing.T) {
+		kube := kubefake.NewSimpleClientset() // no deployment
+		r := &GitOpsClusterReconciler{}
+
+		if err := r.restartPrincipalDeployment(context.Background(), kube, namespace); err == nil {
+			t.Errorf("expected an error when the principal Deployment is absent")
+		}
+	})
+}

--- a/internal/controller/gitopscluster_controller.go
+++ b/internal/controller/gitopscluster_controller.go
@@ -62,7 +62,7 @@ type GitOpsClusterReconciler struct {
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placementdecisions,verbs=get;list;watch
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=argoproj.io,resources=argocds,verbs=get;list;watch
 


### PR DESCRIPTION
## Problem

The argocd-agent **principal** reads its TLS keypair **once at startup** and caches the `tls.Config` in memory — no fsnotify, no informer, no reload (argocd-agent principal `WithTLSKeyPairFromSecret` → `ensureTLSConfig`, cached once).

This controller provisions and **rotates** `argocd-agent-principal-tls` via `sdk-go` certrotation with a **30-day** target validity (`TargetCertValidity`), but nothing restarts the principal. So:

1. **Cold-start race** — the secret is created a moment *after* the operator creates the principal pod, so a fresh install can bring the principal up before its cert exists.
2. **Every 30-day rotation** — after certrotation rewrites the secret, the running principal keeps serving the **old** (eventually expired) cert, and spoke agents fail the mTLS handshake.

Both are resolved today only by a manual `kubectl rollout restart deployment/argocd-agent-principal`.

## Fix

Have the controller — which already provisions and rotates the cert — restart the principal when the cert **content** changes. In `EnsurePrincipalCertificate`:

- snapshot `tls.crt` **before** `EnsureTargetCertKeyPair`,
- compare **after**, and
- if it changed (rotation, first issuance, or SAN change), restart the principal Deployment by stamping a pod-template annotation (the same mechanism as `kubectl rollout restart`).

The comparison is **content-gated**, so a stable cert on the 10-minute resync produces **no** restart — loop-safe. The restart is **best-effort**: a missing Deployment (operator hasn't created it yet) or a transient patch error is logged, not fatal to cert reconciliation.

### Details
- `getPrincipalTLSCertBytes` — reads `tls.crt` from the API server; `nil` on NotFound = cold-start (first issuance is treated as a change, covering the race).
- `restartPrincipalDeployment` — strategic-merge patch by name, with the same `openshift-gitops-agent-principal` fallback already used by `findArgoCDAgentPrincipalService`.
- **RBAC** — add `patch` to the `apps/deployments` kubebuilder marker; regenerate `config/rbac/role.yaml`. (The Helm chart controller ClusterRole already grants `deployments: patch`.)
- **Tests** — unit-cover change detection and the restart patch/fallback/missing-Deployment cases with the client-go fake clientset (the two new helpers take `kubernetes.Interface`).

## Validation
`go build ./...`, `go vet ./internal/controller/`, and `go test ./internal/controller/` all pass; `gofmt` clean.

## Notes
- Independent of #219 (the principal-cert SAN work) — this branches from `main` and touches a disjoint code path (`EnsurePrincipalCertificate` post-rotation), so the two compose cleanly.
- Removes the need for an external reload controller (e.g. Stakater Reloader) for the principal: the component that rotates the cert is the natural owner of the restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Automatically rolls out the `argocd-agent` principal when its TLS certificate Secret is created, rotated, or changed to ensure updates take effect reliably.
  - Restart behavior now triggers based on actual certificate changes and supports both standard and OpenShift GitOps deployment naming.

- **Chores**
  - Updated RBAC permissions to include the ability to patch Kubernetes Deployments.
  - Bumped Helm chart versions (to `0.28.1`) for the related agent/addon charts.

- **Tests**
  - Added unit test coverage for principal TLS certificate detection and deployment restart logic, including error and fallback cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->