### PR TITLE
feat: add imagePullSecrets support to argocd-agent-addon chart

### DIFF
--- a/charts/argocd-agent-addon/templates/argocd-operator/_operator-manifests.tpl
+++ b/charts/argocd-agent-addon/templates/argocd-operator/_operator-manifests.tpl
@@ -407,6 +407,10 @@ spec:
       labels:
         control-plane: argocd-operator
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args:
         - --leader-elect

--- a/charts/argocd-agent-addon/templates/controller/deployment.yaml
+++ b/charts/argocd-agent-addon/templates/controller/deployment.yaml
@@ -21,6 +21,10 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/part-of: argocd-agent-addon
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: argocd-pull-integration-controller-manager
       securityContext:
         runAsNonRoot: true

--- a/charts/argocd-agent-addon/values.yaml
+++ b/charts/argocd-agent-addon/values.yaml
@@ -12,6 +12,10 @@ replicas: 1
 operatorImage: quay.io/argoprojlabs/argocd-operator
 operatorImageTag: v0.18.0
 
+# Image pull secrets applied to the controller and argocd-operator
+# Deployments, for pulling images from private registries.
+imagePullSecrets: []
+
 # Principal service type: LoadBalancer for production (cloud LB),
 # NodePort for local dev (e.g. kind) - override via --set principalServiceType=NodePort
 principalServiceType: LoadBalancer

--- a/internal/addon/charts/argocd-agent-addon/templates/_operator-manifests.tpl
+++ b/internal/addon/charts/argocd-agent-addon/templates/_operator-manifests.tpl
@@ -407,6 +407,10 @@ spec:
       labels:
         control-plane: argocd-operator
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args:
         - --leader-elect


### PR DESCRIPTION
Motivation:
The argocd-agent-addon Helm chart hard-codes image references for both
the controller and the bundled argocd-operator Deployments, with no way
to attach imagePullSecrets. Clusters that pull these images from a
private registry have no supported way to authenticate the pull.

Approach:
Add a top-level `imagePullSecrets` Helm value (default `[]`) and render
it into the pod spec of both Deployments (`templates/controller/deployment.yaml`
and the operator manifest defined in
`internal/addon/charts/argocd-agent-addon/templates/_operator-manifests.tpl`,
synced to `charts/argocd-agent-addon/templates/argocd-operator/_operator-manifests.tpl`
via `make sync-operator-chart`), following the exact pattern suggested in
the issue. When unset, no imagePullSecrets field is rendered, so this is
a no-op for existing installs.

Scope note: this covers the hub-side `helm install` of
charts/argocd-agent-addon only (the value flows through Helm's own
render at install/upgrade time). It does not extend to the
managed-cluster-side operator install driven by the addon's `--mode=addon`
reconcile loop (internal/addon/addon_utils.go), which builds its own
values map at runtime and would need separate plumbing to pick up
this value - out of scope for this change. The basic pull model chart
(charts/argocd-pull-integration) is also out of scope; it is not the
model this repo's README documents as primary.

Validation:
- `make test` (fmt, vet, verify-operator-chart-sync, and the full unit
  test suite) passes.
- `helm lint charts/argocd-agent-addon` passes.
- `helm template charts/argocd-agent-addon --set 'imagePullSecrets[0].name=my-secret'`
  renders imagePullSecrets correctly nested under both the controller and
  operator pod specs; with no value set, the field is omitted entirely
  (verified via diff against the unset-value render).

Fixes #192

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring image pull secrets for the Argo CD Agent controller and operator deployments.
  * Helm deployments can now authenticate when pulling images from private container registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->