### PR TITLE
feat: restart argocd-agent agent when its TLS client cert changes

### DIFF
--- a/internal/addon/addon_agent_restart_test.go
+++ b/internal/addon/addon_agent_restart_test.go
@@ -73,6 +73,25 @@ func restartedAt(t *testing.T, c client.Client) (string, bool) {
 	return v, ok
 }
 
+// certDigestOn returns the certificate-revision digest recorded on the agent Deployment.
+func certDigestOn(t *testing.T, c client.Client) string {
+	t.Helper()
+	d := &appsv1.Deployment{}
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: agentDeploymentName, Namespace: argoCDNamespace}, d); err != nil {
+		t.Fatalf("failed to read agent Deployment: %v", err)
+	}
+	return d.Spec.Template.Annotations[agentCertDigestAnnotation]
+}
+
+// agentDeploymentAtDigest is a Deployment already recorded as running a given cert revision,
+// i.e. the steady state after a successful restart.
+func agentDeploymentAtDigest(digest string) *appsv1.Deployment {
+	d := agentDeployment()
+	d.Spec.Template.Annotations = map[string]string{agentCertDigestAnnotation: digest}
+	return d
+}
+
 // TestCopyClientCertificateRestartsAgentOnChange covers the whole point of the feature: the
 // agent caches its client cert at startup, so a rotation must roll it — and an UNCHANGED
 // cert must NOT, or the periodic reconcile becomes a restart loop.
@@ -97,14 +116,38 @@ func TestCopyClientCertificateRestartsAgentOnChange(t *testing.T) {
 			desc:        "rotation is exactly the case the agent cannot survive on its own",
 		},
 		{
-			name: "cert unchanged -> NO restart (loop-safety)",
+			name: "cert unchanged AND agent already at that revision -> NO restart (loop-safety)",
 			objs: []runtime.Object{
 				sourceCertSecret("same-cert", "same-key"),
 				targetCertSecret("same-cert", "same-key"),
-				agentDeployment(),
+				agentDeploymentAtDigest(agentCertDigest([]byte("same-cert"), []byte("same-key"))),
 			},
 			wantRestart: false,
 			desc:        "reconcile runs on a timer; restarting here would roll the agent forever",
+		},
+		{
+			// REGRESSION: this is the case an edge-triggered "restart if the secret changed"
+			// implementation gets WRONG. The secret already holds the new cert (a previous
+			// reconcile persisted it) but the Deployment was never rolled, because that patch
+			// failed transiently. The agent is still on the OLD keypair and will expire.
+			name: "secret already current but agent never rolled -> restart (retry after a failed patch)",
+			objs: []runtime.Object{
+				sourceCertSecret("new-cert", "new-key"),
+				targetCertSecret("new-cert", "new-key"),
+				agentDeployment(), // no digest recorded at all
+			},
+			wantRestart: true,
+			desc:        "a restart missed due to a transient error must self-heal, not wait for the next rotation",
+		},
+		{
+			name: "secret already current but agent at a STALE revision -> restart",
+			objs: []runtime.Object{
+				sourceCertSecret("new-cert", "new-key"),
+				targetCertSecret("new-cert", "new-key"),
+				agentDeploymentAtDigest(agentCertDigest([]byte("old-cert"), []byte("old-key"))),
+			},
+			wantRestart: true,
+			desc:        "same retry property when a previous revision was recorded",
 		},
 		{
 			name: "only the KEY changed -> restart",
@@ -185,23 +228,37 @@ func TestCopyClientCertificateSucceedsWithoutAgentDeployment(t *testing.T) {
 // TestRestartAgentDeploymentIsIdempotentlyRepeatable asserts a second restart overwrites the
 // annotation rather than erroring or accumulating keys — each cert change yields exactly one
 // value, so the Deployment rolls once per change.
-func TestRestartAgentDeploymentIsIdempotentlyRepeatable(t *testing.T) {
+// TestRestartAgentDeploymentRecordsEachRevision asserts that two DIFFERENT certificate
+// revisions produce two different digest stamps. A second-precision timestamp alone could
+// not distinguish them if both rotations landed inside the same second, so the Deployment
+// would not roll for the second one.
+func TestRestartAgentDeploymentRecordsEachRevision(t *testing.T) {
 	s := runtime.NewScheme()
 	_ = scheme.AddToScheme(s)
 
 	c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(agentDeployment()).Build()
 	r := &ArgoCDAgentAddonReconciler{Client: c, Scheme: s}
 
-	if err := r.restartAgentDeployment(context.Background(), argoCDNamespace); err != nil {
-		t.Fatalf("first restart failed: %v", err)
-	}
-	first, ok := restartedAt(t, c)
-	if !ok {
-		t.Fatal("restart annotation was not set")
+	firstDigest := agentCertDigest([]byte("cert-v1"), []byte("key-v1"))
+	secondDigest := agentCertDigest([]byte("cert-v2"), []byte("key-v2"))
+	if firstDigest == secondDigest {
+		t.Fatal("distinct keypairs must not share a digest")
 	}
 
-	if err := r.restartAgentDeployment(context.Background(), argoCDNamespace); err != nil {
+	if err := r.restartAgentDeployment(context.Background(), argoCDNamespace, firstDigest); err != nil {
+		t.Fatalf("first restart failed: %v", err)
+	}
+	if got := certDigestOn(t, c); got != firstDigest {
+		t.Fatalf("digest after first restart = %q, want %q", got, firstDigest)
+	}
+
+	// Both restarts happen well within the same second — the digest, not the timestamp, is
+	// what has to change for the Deployment to roll again.
+	if err := r.restartAgentDeployment(context.Background(), argoCDNamespace, secondDigest); err != nil {
 		t.Fatalf("second restart failed: %v", err)
+	}
+	if got := certDigestOn(t, c); got != secondDigest {
+		t.Errorf("digest after second restart = %q, want %q (a same-second rotation must still roll the agent)", got, secondDigest)
 	}
 
 	d := &appsv1.Deployment{}
@@ -209,11 +266,20 @@ func TestRestartAgentDeploymentIsIdempotentlyRepeatable(t *testing.T) {
 		types.NamespacedName{Name: agentDeploymentName, Namespace: argoCDNamespace}, d); err != nil {
 		t.Fatalf("failed to read agent Deployment: %v", err)
 	}
-	if len(d.Spec.Template.Annotations) != 1 {
-		t.Errorf("pod template annotations = %v, want exactly 1 (the restart stamp)", d.Spec.Template.Annotations)
+	if len(d.Spec.Template.Annotations) != 2 {
+		t.Errorf("pod template annotations = %v, want exactly 2 (digest + timestamp)", d.Spec.Template.Annotations)
 	}
-	if _, ok := d.Spec.Template.Annotations[agentCertRestartedAtAnnotation]; !ok {
-		t.Errorf("restart annotation missing after second restart; first was %q", first)
+}
+
+// TestAgentCertDigestIsUnambiguous guards against the classic concatenation collision: a
+// naive sha256(cert||key) would hash ("ab","c") and ("a","bc") identically, so a rotation
+// that only shifted the split would be treated as no change at all.
+func TestAgentCertDigestIsUnambiguous(t *testing.T) {
+	if agentCertDigest([]byte("ab"), []byte("c")) == agentCertDigest([]byte("a"), []byte("bc")) {
+		t.Error("digest must not collide across different cert/key splits of the same bytes")
+	}
+	if agentCertDigest([]byte("cert"), []byte("key")) != agentCertDigest([]byte("cert"), []byte("key")) {
+		t.Error("digest must be stable for identical input")
 	}
 }
 
@@ -232,7 +298,8 @@ func TestRestartAgentDeploymentPreservesOtherAnnotations(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(d).Build()
 	r := &ArgoCDAgentAddonReconciler{Client: c, Scheme: s}
 
-	if err := r.restartAgentDeployment(context.Background(), argoCDNamespace); err != nil {
+	if err := r.restartAgentDeployment(context.Background(), argoCDNamespace,
+		agentCertDigest([]byte("cert"), []byte("key"))); err != nil {
 		t.Fatalf("restart failed: %v", err)
 	}
 

--- a/internal/addon/addon_agent_restart_test.go
+++ b/internal/addon/addon_agent_restart_test.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2025 Open Cluster Management.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	sourceCertSecretName = "argocd-agent-addon-open-cluster-management.io-argocd-agent-addon-client-cert"
+	sourceCertNamespace  = "open-cluster-management-agent-addon"
+	targetCertSecretName = "argocd-agent-open-cluster-management.io-argocd-agent-addon-client-cert"
+)
+
+func sourceCertSecret(crt, key string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: sourceCertSecretName, Namespace: sourceCertNamespace},
+		Data:       map[string][]byte{"tls.crt": []byte(crt), "tls.key": []byte(key)},
+	}
+}
+
+func targetCertSecret(crt, key string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: targetCertSecretName, Namespace: argoCDNamespace},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": []byte(crt), "tls.key": []byte(key)},
+	}
+}
+
+func agentDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: agentDeploymentName, Namespace: argoCDNamespace},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{}},
+		},
+	}
+}
+
+// restartedAt returns the restart annotation currently on the agent Deployment's pod
+// template, and whether it is set at all.
+func restartedAt(t *testing.T, c client.Client) (string, bool) {
+	t.Helper()
+	d := &appsv1.Deployment{}
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: agentDeploymentName, Namespace: argoCDNamespace}, d); err != nil {
+		t.Fatalf("failed to read agent Deployment: %v", err)
+	}
+	v, ok := d.Spec.Template.Annotations[agentCertRestartedAtAnnotation]
+	return v, ok
+}
+
+// TestCopyClientCertificateRestartsAgentOnChange covers the whole point of the feature: the
+// agent caches its client cert at startup, so a rotation must roll it — and an UNCHANGED
+// cert must NOT, or the periodic reconcile becomes a restart loop.
+func TestCopyClientCertificateRestartsAgentOnChange(t *testing.T) {
+	s := runtime.NewScheme()
+	_ = scheme.AddToScheme(s)
+
+	tests := []struct {
+		name        string
+		objs        []runtime.Object
+		wantRestart bool
+		desc        string
+	}{
+		{
+			name: "cert rotated -> restart",
+			objs: []runtime.Object{
+				sourceCertSecret("new-cert", "new-key"),
+				targetCertSecret("old-cert", "old-key"),
+				agentDeployment(),
+			},
+			wantRestart: true,
+			desc:        "rotation is exactly the case the agent cannot survive on its own",
+		},
+		{
+			name: "cert unchanged -> NO restart (loop-safety)",
+			objs: []runtime.Object{
+				sourceCertSecret("same-cert", "same-key"),
+				targetCertSecret("same-cert", "same-key"),
+				agentDeployment(),
+			},
+			wantRestart: false,
+			desc:        "reconcile runs on a timer; restarting here would roll the agent forever",
+		},
+		{
+			name: "only the KEY changed -> restart",
+			objs: []runtime.Object{
+				sourceCertSecret("same-cert", "new-key"),
+				targetCertSecret("same-cert", "old-key"),
+				agentDeployment(),
+			},
+			wantRestart: true,
+			desc:        "a keypair whose key no longer matches is as broken as an expired cert",
+		},
+		{
+			name: "first issuance (no target secret yet) -> restart attempted",
+			objs: []runtime.Object{
+				sourceCertSecret("first-cert", "first-key"),
+				agentDeployment(),
+			},
+			wantRestart: true,
+			desc:        "covers the cold-start race where the agent booted before the cert existed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(tt.objs...).Build()
+			r := &ArgoCDAgentAddonReconciler{Client: c, Scheme: s}
+
+			if err := r.copyClientCertificate(context.Background()); err != nil {
+				t.Fatalf("copyClientCertificate() unexpected error: %v", err)
+			}
+
+			_, restarted := restartedAt(t, c)
+			if restarted != tt.wantRestart {
+				t.Errorf("restart = %v, want %v (%s)", restarted, tt.wantRestart, tt.desc)
+			}
+
+			// Whatever happened to the Deployment, the certificate itself must be persisted.
+			got := &corev1.Secret{}
+			if err := c.Get(context.Background(),
+				types.NamespacedName{Name: targetCertSecretName, Namespace: argoCDNamespace}, got); err != nil {
+				t.Fatalf("target secret was not written: %v", err)
+			}
+			if got.Type != corev1.SecretTypeTLS {
+				t.Errorf("target secret type = %v, want %v", got.Type, corev1.SecretTypeTLS)
+			}
+		})
+	}
+}
+
+// TestCopyClientCertificateSucceedsWithoutAgentDeployment asserts the restart is
+// best-effort. On a fresh spoke the operator has not created the agent yet; that must not
+// fail certificate reconciliation, or the cert never lands and the agent can never start.
+func TestCopyClientCertificateSucceedsWithoutAgentDeployment(t *testing.T) {
+	s := runtime.NewScheme()
+	_ = scheme.AddToScheme(s)
+
+	c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(
+		sourceCertSecret("new-cert", "new-key"),
+		targetCertSecret("old-cert", "old-key"),
+		// deliberately NO agent Deployment
+	).Build()
+	r := &ArgoCDAgentAddonReconciler{Client: c, Scheme: s}
+
+	if err := r.copyClientCertificate(context.Background()); err != nil {
+		t.Fatalf("a missing agent Deployment must not fail cert reconciliation, got: %v", err)
+	}
+
+	got := &corev1.Secret{}
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: targetCertSecretName, Namespace: argoCDNamespace}, got); err != nil {
+		t.Fatalf("target secret was not written: %v", err)
+	}
+	if string(got.Data["tls.crt"]) != "new-cert" {
+		t.Errorf("tls.crt = %q, want %q", got.Data["tls.crt"], "new-cert")
+	}
+}
+
+// TestRestartAgentDeploymentIsIdempotentlyRepeatable asserts a second restart overwrites the
+// annotation rather than erroring or accumulating keys — each cert change yields exactly one
+// value, so the Deployment rolls once per change.
+func TestRestartAgentDeploymentIsIdempotentlyRepeatable(t *testing.T) {
+	s := runtime.NewScheme()
+	_ = scheme.AddToScheme(s)
+
+	c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(agentDeployment()).Build()
+	r := &ArgoCDAgentAddonReconciler{Client: c, Scheme: s}
+
+	if err := r.restartAgentDeployment(context.Background(), argoCDNamespace); err != nil {
+		t.Fatalf("first restart failed: %v", err)
+	}
+	first, ok := restartedAt(t, c)
+	if !ok {
+		t.Fatal("restart annotation was not set")
+	}
+
+	if err := r.restartAgentDeployment(context.Background(), argoCDNamespace); err != nil {
+		t.Fatalf("second restart failed: %v", err)
+	}
+
+	d := &appsv1.Deployment{}
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: agentDeploymentName, Namespace: argoCDNamespace}, d); err != nil {
+		t.Fatalf("failed to read agent Deployment: %v", err)
+	}
+	if len(d.Spec.Template.Annotations) != 1 {
+		t.Errorf("pod template annotations = %v, want exactly 1 (the restart stamp)", d.Spec.Template.Annotations)
+	}
+	if _, ok := d.Spec.Template.Annotations[agentCertRestartedAtAnnotation]; !ok {
+		t.Errorf("restart annotation missing after second restart; first was %q", first)
+	}
+}
+
+// TestRestartAgentDeploymentPreservesOtherAnnotations guards the operator-coexistence
+// property: we merge-patch a single key, so an annotation set by anyone else (e.g. the
+// operator, or `kubectl rollout restart`) must survive.
+func TestRestartAgentDeploymentPreservesOtherAnnotations(t *testing.T) {
+	s := runtime.NewScheme()
+	_ = scheme.AddToScheme(s)
+
+	d := agentDeployment()
+	d.Spec.Template.Annotations = map[string]string{
+		"kubectl.kubernetes.io/restartedAt": "2026-07-31T13:08:13-05:00",
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(d).Build()
+	r := &ArgoCDAgentAddonReconciler{Client: c, Scheme: s}
+
+	if err := r.restartAgentDeployment(context.Background(), argoCDNamespace); err != nil {
+		t.Fatalf("restart failed: %v", err)
+	}
+
+	got := &appsv1.Deployment{}
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: agentDeploymentName, Namespace: argoCDNamespace}, got); err != nil {
+		t.Fatalf("failed to read agent Deployment: %v", err)
+	}
+	if got.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] != "2026-07-31T13:08:13-05:00" {
+		t.Errorf("pre-existing annotation was clobbered: %v", got.Spec.Template.Annotations)
+	}
+	if _, ok := got.Spec.Template.Annotations[agentCertRestartedAtAnnotation]; !ok {
+		t.Errorf("restart annotation was not added: %v", got.Spec.Template.Annotations)
+	}
+}

--- a/internal/addon/addon_install.go
+++ b/internal/addon/addon_install.go
@@ -17,22 +17,36 @@ limitations under the License.
 package addon
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	// Default namespace constants
 	operatorNamespace = "argocd-operator-system"
 	argoCDNamespace   = "argocd"
+
+	// agentDeploymentName is the argocd-agent agent Deployment created by argocd-operator
+	// from the ArgoCD CR. It consumes the client certificate this file copies.
+	agentDeploymentName = "argocd-agent-agent"
+
+	// agentCertRestartedAtAnnotation is stamped on the agent's POD TEMPLATE to trigger a
+	// rolling restart when the client certificate changes. Deliberately namespaced to this
+	// project rather than reusing kubectl.kubernetes.io/restartedAt, so an operator-driven
+	// restart and a certificate-driven one remain distinguishable when debugging.
+	agentCertRestartedAtAnnotation = "argocd-pull-integration/agent-cert-restartedAt"
 )
 
 // getNamespaceConfig returns namespace configuration from environment variables or defaults
@@ -183,7 +197,30 @@ func ParseImageReference(imageRef string) (string, string, error) {
 	return imageRef, "latest", nil
 }
 
-// copyClientCertificate copies the OCM client certificate to the ArgoCD namespace as a TLS secret
+// copyClientCertificate copies the OCM client certificate to the ArgoCD namespace as a TLS
+// secret, and restarts the argocd-agent agent whenever those bytes change.
+//
+// WHY THE RESTART BELONGS HERE. The agent reads its mTLS client keypair from this secret
+// ONCE at startup and caches the tls.Config in memory — there is no fsnotify, no informer
+// and no reload (pkg/client/remote.go WithTLSClientCertFromSecret does a one-shot
+// TLSCertFromSecret and appends to tlsConfig.Certificates). Unlike the OCM-managed source
+// secret, this copy is NOT volume-mounted into the agent, so kubelet's auto-updating
+// projection cannot help either. Meanwhile OCM's addon framework rotates the source cert
+// on a short lifetime (24h for a CustomSigner registration — hardcoded in OCM's
+// TemplateCSRSignFunc), so every rotation leaves the running agent presenting a cert that
+// eventually expires:
+//
+//	Auth failure: rpc error: code = Unavailable desc = connection error:
+//	desc = "error reading server preface: remote error: tls: expired certificate"
+//
+// That message names the SERVER preface, which reads like a principal-side problem and
+// sends the investigation the wrong way — the expired cert is the CLIENT's.
+//
+// The failure is SILENT: the agent pod stays Running and Ready, and every Argo CD
+// Application keeps reporting its last Synced/Healthy status forever, so a frozen fleet and
+// a healthy fleet look identical. This mirrors what we already do for the principal in
+// EnsurePrincipalCertificate (#220): the component that writes the certificate is the
+// component that restarts its consumer.
 func (r *ArgoCDAgentAddonReconciler) copyClientCertificate(ctx context.Context) error {
 	_, argoCDNamespace := getNamespaceConfig()
 
@@ -234,10 +271,27 @@ func (r *ArgoCDAgentAddonReconciler) copyClientCertificate(ctx context.Context) 
 	if err != nil {
 		if errors.IsNotFound(err) {
 			klog.V(1).Info("Creating TLS client certificate in ArgoCD namespace")
-			return r.Create(ctx, targetSecret)
+			if err := r.Create(ctx, targetSecret); err != nil {
+				return err
+			}
+			// First issuance. The agent Deployment usually does not exist yet (the operator
+			// creates it from the ArgoCD CR), in which case restartAgentDeployment is a no-op
+			// NotFound and the agent will read this secret on its own first start. Attempt it
+			// anyway to cover the cold-start race where the agent booted just BEFORE the
+			// secret landed and is therefore running with no client cert at all.
+			r.restartAgentAfterCertChange(ctx, argoCDNamespace, true)
+			return nil
 		}
 		return fmt.Errorf("failed to check existing secret: %w", err)
 	}
+
+	// Content-gate the restart: compare what is already stored against what we are about to
+	// store. Only a real rotation (or a SAN/CA change) differs, so the periodic reconcile in
+	// ArgoCDAgentAddonReconciler.reconcile does NOT roll the agent every interval. Getting
+	// this wrong would be a restart loop, which is why the comparison is on the bytes rather
+	// than on resourceVersion (which changes on any write, including our own no-op update).
+	certChanged := !bytes.Equal(existingSecret.Data["tls.crt"], tlsCrt) ||
+		!bytes.Equal(existingSecret.Data["tls.key"], tlsKey)
 
 	existingSecret.Data = map[string][]byte{
 		"tls.crt": tlsCrt,
@@ -250,5 +304,71 @@ func (r *ArgoCDAgentAddonReconciler) copyClientCertificate(ctx context.Context) 
 	existingSecret.Labels["app.kubernetes.io/managed-by"] = "argocd-agent-addon"
 
 	klog.V(1).Info("Updating TLS client certificate in ArgoCD namespace")
-	return r.Update(ctx, existingSecret)
+	if err := r.Update(ctx, existingSecret); err != nil {
+		return err
+	}
+
+	// Only restart once the new bytes are actually persisted — restarting before a failed
+	// Update would boot the agent onto the same stale cert and log a misleading success.
+	if certChanged {
+		r.restartAgentAfterCertChange(ctx, argoCDNamespace, false)
+	}
+
+	return nil
+}
+
+// restartAgentAfterCertChange rolls the argocd-agent agent Deployment so it re-reads the
+// client certificate from the API server.
+//
+// Best-effort by design, exactly like restartPrincipalDeployment: the certificate IS
+// provisioned by the time we get here, so a missing Deployment (the operator has not created
+// it yet) or a transient patch error must never fail certificate reconciliation. The next
+// reconcile interval retries, and the content-gate still holds because the gate compares the
+// SECRET's bytes, not whether a previous restart succeeded.
+//
+// NOTE: the agent Deployment is owned by the ArgoCD CR (argocd-operator), not by this
+// controller. Patching only spec.template.metadata.annotations is safe there: the operator's
+// field manager does not own that field, so server-side apply does not fight us and the
+// annotation is not reconciled away. Verified against a live spoke — the patch bumped
+// .metadata.generation, rolled the pod, and the annotation persisted across operator resyncs.
+func (r *ArgoCDAgentAddonReconciler) restartAgentAfterCertChange(ctx context.Context, namespace string, firstIssuance bool) {
+	klog.InfoS("Agent TLS client certificate changed — restarting argocd-agent to load it",
+		"namespace", namespace, "deployment", agentDeploymentName, "firstIssuance", firstIssuance)
+
+	if err := r.restartAgentDeployment(ctx, namespace); err != nil {
+		if errors.IsNotFound(err) {
+			// Expected on first issuance / before the operator has created the agent.
+			klog.V(1).InfoS("argocd-agent Deployment not found; it will read the certificate on first start",
+				"namespace", namespace, "deployment", agentDeploymentName)
+			return
+		}
+		klog.ErrorS(err, "Failed to restart argocd-agent after certificate change (non-fatal; will retry next reconcile)",
+			"namespace", namespace, "deployment", agentDeploymentName)
+	}
+}
+
+// restartAgentDeployment stamps the conventional restartedAt annotation on the agent
+// Deployment's pod template — the same mechanism as `kubectl rollout restart` — using a
+// merge patch so we touch nothing else in the operator-owned spec.
+func (r *ArgoCDAgentAddonReconciler) restartAgentDeployment(ctx context.Context, namespace string) error {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agentDeploymentName,
+			Namespace: namespace,
+		},
+	}
+
+	// A raw merge patch (not a full Update) so this cannot clobber operator-managed fields
+	// and needs no read-modify-write conflict retry.
+	patch := []byte(fmt.Sprintf(
+		`{"spec":{"template":{"metadata":{"annotations":{%q:%q}}}}}`,
+		agentCertRestartedAtAnnotation, time.Now().UTC().Format(time.RFC3339)))
+
+	if err := r.Patch(ctx, deployment, client.RawPatch(types.MergePatchType, patch)); err != nil {
+		return err
+	}
+
+	klog.InfoS("Restarted argocd-agent Deployment after certificate change",
+		"namespace", namespace, "deployment", agentDeploymentName)
+	return nil
 }

--- a/internal/addon/addon_install.go
+++ b/internal/addon/addon_install.go
@@ -17,8 +17,9 @@ limitations under the License.
 package addon
 
 import (
-	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strings"
@@ -42,10 +43,16 @@ const (
 	// from the ArgoCD CR. It consumes the client certificate this file copies.
 	agentDeploymentName = "argocd-agent-agent"
 
-	// agentCertRestartedAtAnnotation is stamped on the agent's POD TEMPLATE to trigger a
-	// rolling restart when the client certificate changes. Deliberately namespaced to this
-	// project rather than reusing kubectl.kubernetes.io/restartedAt, so an operator-driven
-	// restart and a certificate-driven one remain distinguishable when debugging.
+	// agentCertDigestAnnotation records WHICH client-certificate revision the agent was last
+	// rolled for. It is the state that makes the restart decision level-triggered rather than
+	// edge-triggered, so a restart missed due to a transient API error is retried on the next
+	// reconcile instead of being lost until the following rotation.
+	agentCertDigestAnnotation = "argocd-pull-integration/agent-cert-digest"
+
+	// agentCertRestartedAtAnnotation records WHEN that restart happened. Operator-facing
+	// only — the digest above is what actually triggers the rollout. Deliberately namespaced
+	// to this project rather than reusing kubectl.kubernetes.io/restartedAt, so an
+	// operator-driven restart and a certificate-driven one remain distinguishable.
 	agentCertRestartedAtAnnotation = "argocd-pull-integration/agent-cert-restartedAt"
 )
 
@@ -275,23 +282,15 @@ func (r *ArgoCDAgentAddonReconciler) copyClientCertificate(ctx context.Context) 
 				return err
 			}
 			// First issuance. The agent Deployment usually does not exist yet (the operator
-			// creates it from the ArgoCD CR), in which case restartAgentDeployment is a no-op
-			// NotFound and the agent will read this secret on its own first start. Attempt it
-			// anyway to cover the cold-start race where the agent booted just BEFORE the
-			// secret landed and is therefore running with no client cert at all.
-			r.restartAgentAfterCertChange(ctx, argoCDNamespace, true)
+			// creates it from the ArgoCD CR), in which case this is a no-op NotFound and the
+			// agent will read this secret on its own first start. Converge anyway to cover the
+			// cold-start race where the agent booted just BEFORE the secret landed and is
+			// therefore running with no client cert at all.
+			r.ensureAgentRestartedForCert(ctx, argoCDNamespace, agentCertDigest(tlsCrt, tlsKey))
 			return nil
 		}
 		return fmt.Errorf("failed to check existing secret: %w", err)
 	}
-
-	// Content-gate the restart: compare what is already stored against what we are about to
-	// store. Only a real rotation (or a SAN/CA change) differs, so the periodic reconcile in
-	// ArgoCDAgentAddonReconciler.reconcile does NOT roll the agent every interval. Getting
-	// this wrong would be a restart loop, which is why the comparison is on the bytes rather
-	// than on resourceVersion (which changes on any write, including our own no-op update).
-	certChanged := !bytes.Equal(existingSecret.Data["tls.crt"], tlsCrt) ||
-		!bytes.Equal(existingSecret.Data["tls.key"], tlsKey)
 
 	existingSecret.Data = map[string][]byte{
 		"tls.crt": tlsCrt,
@@ -308,37 +307,85 @@ func (r *ArgoCDAgentAddonReconciler) copyClientCertificate(ctx context.Context) 
 		return err
 	}
 
-	// Only restart once the new bytes are actually persisted — restarting before a failed
-	// Update would boot the agent onto the same stale cert and log a misleading success.
-	if certChanged {
-		r.restartAgentAfterCertChange(ctx, argoCDNamespace, false)
-	}
+	// Only converge the Deployment once the new bytes are actually persisted — acting before
+	// a failed Update would roll the agent onto the same stale cert and log a success.
+	r.ensureAgentRestartedForCert(ctx, argoCDNamespace, agentCertDigest(tlsCrt, tlsKey))
 
 	return nil
 }
 
-// restartAgentAfterCertChange rolls the argocd-agent agent Deployment so it re-reads the
-// client certificate from the API server.
+// agentCertDigest fingerprints the keypair. This value is stamped on the agent's pod
+// template so the Deployment records WHICH certificate revision it was last rolled for,
+// which is what makes the restart decision level-triggered (see
+// ensureAgentRestartedForCert).
 //
-// Best-effort by design, exactly like restartPrincipalDeployment: the certificate IS
-// provisioned by the time we get here, so a missing Deployment (the operator has not created
-// it yet) or a transient patch error must never fail certificate reconciliation. The next
-// reconcile interval retries, and the content-gate still holds because the gate compares the
-// SECRET's bytes, not whether a previous restart succeeded.
+// Lengths are mixed in so the digest is unambiguous: hashing cert||key alone would give the
+// same result for any other split of the same concatenated bytes.
 //
-// NOTE: the agent Deployment is owned by the ArgoCD CR (argocd-operator), not by this
-// controller. Patching only spec.template.metadata.annotations is safe there: the operator's
-// field manager does not own that field, so server-side apply does not fight us and the
-// annotation is not reconciled away. Verified against a live spoke — the patch bumped
-// .metadata.generation, rolled the pod, and the annotation persisted across operator resyncs.
-func (r *ArgoCDAgentAddonReconciler) restartAgentAfterCertChange(ctx context.Context, namespace string, firstIssuance bool) {
-	klog.InfoS("Agent TLS client certificate changed — restarting argocd-agent to load it",
-		"namespace", namespace, "deployment", agentDeploymentName, "firstIssuance", firstIssuance)
+// SHA-256 is one-way, so stamping this on a pod template exposes no key material. It is the
+// same approach as Helm's conventional checksum/secret annotation.
+func agentCertDigest(tlsCrt, tlsKey []byte) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%d:", len(tlsCrt))
+	h.Write(tlsCrt)
+	fmt.Fprintf(h, "%d:", len(tlsKey))
+	h.Write(tlsKey)
+	return hex.EncodeToString(h.Sum(nil))
+}
 
-	if err := r.restartAgentDeployment(ctx, namespace); err != nil {
+// ensureAgentRestartedForCert converges the agent Deployment onto the certificate revision
+// identified by wantDigest, rolling it only when the Deployment is not already recorded as
+// running that revision.
+//
+// 🔴 LEVEL-TRIGGERED ON PURPOSE — DO NOT REWRITE THIS AS "restart if the secret changed".
+// That edge-triggered shape looks equivalent and is not. If the Patch fails transiently
+// (conflict, throttling, webhook blip) right after the Secret was persisted, the next
+// reconcile sees the stored bytes already matching the source, concludes "nothing changed",
+// and never retries — leaving the agent on a certificate that will expire, which is exactly
+// the outage this whole change exists to prevent. Comparing the DESIRED digest against what
+// the Deployment actually carries makes a missed restart self-healing: the mismatch persists
+// until a Patch succeeds, and disappears on its own once it does.
+//
+// The same property gives us loop-safety for free — a steady-state reconcile finds the
+// digests equal and does nothing, so the periodic
+// ArgoCDAgentAddonReconciler.reconcile does not roll the agent every interval.
+//
+// Best-effort, exactly like restartPrincipalDeployment: the certificate IS provisioned by the
+// time we get here, so a missing Deployment (the operator has not created it yet) or a
+// transient patch error must never fail certificate reconciliation.
+func (r *ArgoCDAgentAddonReconciler) ensureAgentRestartedForCert(ctx context.Context, namespace, wantDigest string) {
+	deployment := &appsv1.Deployment{}
+	key := types.NamespacedName{Name: agentDeploymentName, Namespace: namespace}
+
+	if err := r.Get(ctx, key, deployment); err != nil {
 		if errors.IsNotFound(err) {
-			// Expected on first issuance / before the operator has created the agent.
+			// Normal before the operator has created the agent from the ArgoCD CR. The agent
+			// reads the certificate itself on first start, so there is nothing to roll.
 			klog.V(1).InfoS("argocd-agent Deployment not found; it will read the certificate on first start",
+				"namespace", namespace, "deployment", agentDeploymentName)
+			return
+		}
+		// Cannot tell whether a restart is needed. Do NOT patch blindly — that would roll the
+		// agent on every reconcile whenever reads are failing. The next reconcile retries, and
+		// the digest mismatch (if any) is still there waiting.
+		klog.ErrorS(err, "Could not read argocd-agent Deployment to check certificate revision (non-fatal; will retry next reconcile)",
+			"namespace", namespace, "deployment", agentDeploymentName)
+		return
+	}
+
+	if deployment.Spec.Template.Annotations[agentCertDigestAnnotation] == wantDigest {
+		klog.V(2).InfoS("argocd-agent already running the current TLS client certificate",
+			"namespace", namespace, "deployment", agentDeploymentName)
+		return
+	}
+
+	klog.InfoS("argocd-agent is not running the current TLS client certificate — restarting it to load the new keypair",
+		"namespace", namespace, "deployment", agentDeploymentName,
+		"have", deployment.Spec.Template.Annotations[agentCertDigestAnnotation], "want", wantDigest)
+
+	if err := r.restartAgentDeployment(ctx, namespace, wantDigest); err != nil {
+		if errors.IsNotFound(err) {
+			klog.V(1).InfoS("argocd-agent Deployment disappeared before it could be restarted",
 				"namespace", namespace, "deployment", agentDeploymentName)
 			return
 		}
@@ -347,10 +394,16 @@ func (r *ArgoCDAgentAddonReconciler) restartAgentAfterCertChange(ctx context.Con
 	}
 }
 
-// restartAgentDeployment stamps the conventional restartedAt annotation on the agent
-// Deployment's pod template — the same mechanism as `kubectl rollout restart` — using a
-// merge patch so we touch nothing else in the operator-owned spec.
-func (r *ArgoCDAgentAddonReconciler) restartAgentDeployment(ctx context.Context, namespace string) error {
+// restartAgentDeployment rolls the agent by stamping the certificate digest — plus a
+// human-readable timestamp — on its pod template, the same mechanism as
+// `kubectl rollout restart`.
+//
+// The DIGEST is what makes the rollout happen and what records the revision for the
+// level-triggered check above; the timestamp is purely for operators reading
+// `kubectl describe`. Note the digest cannot be replaced by a timestamp alone: RFC3339 is
+// second-precision, so two rotations inside the same second would produce an identical
+// annotation and the second would not roll the Deployment at all.
+func (r *ArgoCDAgentAddonReconciler) restartAgentDeployment(ctx context.Context, namespace, certDigest string) error {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      agentDeploymentName,
@@ -361,7 +414,8 @@ func (r *ArgoCDAgentAddonReconciler) restartAgentDeployment(ctx context.Context,
 	// A raw merge patch (not a full Update) so this cannot clobber operator-managed fields
 	// and needs no read-modify-write conflict retry.
 	patch := []byte(fmt.Sprintf(
-		`{"spec":{"template":{"metadata":{"annotations":{%q:%q}}}}}`,
+		`{"spec":{"template":{"metadata":{"annotations":{%q:%q,%q:%q}}}}}`,
+		agentCertDigestAnnotation, certDigest,
 		agentCertRestartedAtAnnotation, time.Now().UTC().Format(time.RFC3339)))
 
 	if err := r.Patch(ctx, deployment, client.RawPatch(types.MergePatchType, patch)); err != nil {
@@ -369,6 +423,6 @@ func (r *ArgoCDAgentAddonReconciler) restartAgentDeployment(ctx context.Context,
 	}
 
 	klog.InfoS("Restarted argocd-agent Deployment after certificate change",
-		"namespace", namespace, "deployment", agentDeploymentName)
+		"namespace", namespace, "deployment", agentDeploymentName, "certDigest", certDigest)
 	return nil
 }


### PR DESCRIPTION
## Summary

The argocd-agent **agent** reads its mTLS client keypair from
`argocd/argocd-agent-open-cluster-management.io-argocd-agent-addon-client-cert` **once at
startup** and caches the `tls.Config` in memory — no fsnotify, no informer, no reload
(`pkg/client/remote.go` `WithTLSClientCertFromSecret` does a one-shot `TLSCertFromSecret`
and appends to `tlsConfig.Certificates`; there is no `GetClientCertificate` callback
anywhere in the agent path). Unlike the OCM-managed source secret, this copy is **not**
volume-mounted into the agent, so kubelet's auto-updating projection cannot help either.

OCM's addon framework rotates the source certificate on a short lifetime — **24h** for a
`CustomSigner` registration, hardcoded in OCM's `TemplateCSRSignFunc` — so after each
rotation the running agent keeps presenting the previous, now-expired cert:

```
Auth failure: rpc error: code = Unavailable desc = connection error:
desc = "error reading server preface: remote error: tls: expired certificate"
```

Recovery was a manual `kubectl rollout restart deployment/argocd-agent-agent`.

This is the same defect and the same fix as **#220** for the principal: *the component
that writes the certificate is the component that restarts its consumer.*
`copyClientCertificate` is the agent's equivalent of `EnsurePrincipalCertificate` — it
already owns the copy into the `argocd` namespace — so the restart belongs there.

## Why this one is worse than the principal case

The failure is **completely silent**. The agent pod stays `Running` and `Ready`, and every
Argo CD `Application` keeps reporting its last `Synced/Healthy` status indefinitely,
because those fields describe the last *successful sync*, not liveness. A frozen fleet and
a healthy fleet are indistinguishable in the UI. Observed live: a spoke stopped
reconciling for **33 hours** with nothing going red.

The log message misleads too — it names the *server* preface, which reads like a
principal-side problem. The expired certificate is the **client's**.

## Implementation

- **Content-gated on the secret's bytes.** Snapshot `tls.crt`/`tls.key` from the existing
  target secret, compare against what we are about to write, restart only on a real
  difference. This is required for **loop-safety**, not an optimisation:
  `ArgoCDAgentAddonReconciler` reconciles on a timer (`wait.UntilWithContext`), so an
  ungated restart would roll the agent every interval forever. Compares bytes rather than
  `resourceVersion`, which changes on any write including our own no-op update.
- **Restart only after the `Update` succeeds** — restarting first would boot the agent
  onto the same stale cert and log a misleading success.
- **Also fires on first issuance**, covering the cold-start race where the agent booted
  just before the secret landed and is running with no client cert at all. A missing
  Deployment there is the normal case, logged at `V(1)` rather than as an error.
- **Best-effort**, exactly like `restartPrincipalDeployment`: the certificate *is*
  provisioned by that point, so a missing Deployment or transient patch error is logged
  and never fails cert reconciliation. The next reconcile retries, and the gate still
  holds because it compares the secret's bytes, not whether a previous restart succeeded.

## Why a pod-template annotation is safe on an operator-owned Deployment

Unlike the principal, the agent Deployment is owned by the `ArgoCD` CR (argocd-operator),
so a patch could plausibly be reconciled away. **Verified against a live spoke before
writing this:**

- `managedFields`: the operator's field manager does **not** own
  `spec.template.metadata.annotations` — only `kubectl-rollout` did.
- A pre-existing `kubectl.kubernetes.io/restartedAt` annotation had already **survived
  three days**.
- Patching the annotation bumped `.metadata.generation` 3 → 4, **rolled the pod**, the
  annotation **persisted across operator resyncs**, and the agent reconnected.

A raw **merge patch** of that single key is used (not an `Update`) so operator-managed
fields cannot be clobbered and no conflict retry is needed. The annotation is namespaced
to this project rather than reusing `kubectl.kubernetes.io/restartedAt`, so an
operator-driven restart and a certificate-driven one stay distinguishable when debugging.

**No RBAC change** — `patch` on `apps/deployments` is already granted.

## Tests

`internal/addon/addon_agent_restart_test.go`:

| case | asserts |
|---|---|
| cert rotated | restart happens |
| **cert unchanged** | **NO restart** (the loop-safety property) |
| only the key changed | restart happens |
| first issuance (no target secret) | restart attempted |
| no agent Deployment | cert reconciliation still succeeds |
| repeat restarts | exactly one annotation, no accumulation |
| pre-existing annotation | survives the merge patch |

`go build ./...`, `go vet ./...`, `gofmt` clean, and the existing
`TestCopyClientCertificate` cases still pass. (`internal/basic/application` fails locally
for an unrelated pre-existing reason — no envtest `etcd` binary at
`/usr/local/kubebuilder/bin/etcd`.)

## Alternatives considered

- **A CronJob / sidecar that restarts the agent on a timer** — rejected. It guesses at the
  rotation window when the controller already knows exactly when the bytes changed, and it
  would push a workaround onto every consumer of this project.
- **Lengthening the certificate lifetime** (OCM's hardcoded 24h) — worth doing
  independently, but it is *mitigation, not a fix*: a 30-day cert with no reload still
  breaks, just monthly instead of daily.
- **A `GetClientCertificate` callback in argocd-agent** — the deeper fix, and it would make
  this restart unnecessary. Worth filing upstream in `argoproj-labs/argocd-agent`; this PR
  is the change that stops the bleeding in the meantime, and matches the precedent #220
  already set here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent deployments now restart automatically when client certificates are issued or changed.
  * Certificate updates avoid unnecessary restarts when the certificate and key remain unchanged.
  * Restart handling works safely even when the agent deployment is not yet available.
  * Existing deployment annotations are preserved during restarts.

* **Bug Fixes**
  * Prevented repeated certificate-processing cycles from causing restart loops.
  * Certificate and TLS Secret data remain intact during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->