### PR TITLE
ci: publish multi-arch (amd64 + arm64) images via docker buildx

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -19,9 +19,8 @@ jobs:
   images:
     name: images
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ amd64 ]
+    permissions:
+      contents: read
     steps:
       - name: checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -32,13 +31,9 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: install imagebuilder
-        run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
-      - name: pull base image
-        run: docker pull registry.access.redhat.com/ubi9/ubi-minimal:latest --platform=linux/${{ matrix.arch }}
-      - name: images
-        run: make docker-build
-      - name: push
-        run: |
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
-          docker push quay.io/open-cluster-management/argocd-pull-integration:latest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Login to Quay.io
+        run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
+      - name: Build and push multi-arch image
+        run: make docker-buildx PLATFORMS=linux/amd64,linux/arm64

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -34,9 +34,8 @@ jobs:
   images:
     name: images
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ amd64 ]
+    permissions:
+      contents: read
     steps:
       - name: checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -47,12 +46,13 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: install imagebuilder
-        run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
-      - name: pull base image
-        run: docker pull registry.access.redhat.com/ubi9/ubi-minimal:latest --platform=linux/${{ matrix.arch }}
-      - name: images
-        run: make docker-build
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Build multi-arch image (verify only)
+        run: |
+          sed -e '1 s/\(^FROM\)/FROM --platform=\$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+          docker buildx build --platform=linux/amd64,linux/arm64 -f Dockerfile.cross .
+          rm Dockerfile.cross
   test:
     name: test
     runs-on: ubuntu-latest

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -36,9 +36,8 @@ jobs:
     name: images
     runs-on: ubuntu-latest
     needs: [ env ]
-    strategy:
-      matrix:
-        arch: [ amd64 ]
+    permissions:
+      contents: read
     steps:
       - name: checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -48,44 +47,21 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: install imagebuilder
-        run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
-      - name: pull base image
-        run: docker pull registry.access.redhat.com/ubi9/ubi-minimal:latest --platform=linux/${{ matrix.arch }}
-      - name: images
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Login to Quay.io
+        run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
+      - name: Build and push multi-arch image
+        env:
+          IMAGE_TAG: ${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}
         run: |
-          IMG=quay.io/open-cluster-management/argocd-pull-integration:${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}-${{ matrix.arch }} \
-          IMAGE_BUILD_EXTRA_FLAGS="--build-arg OS=linux --build-arg ARCH=${{ matrix.arch }}" \
-            make docker-build
-      - name: push
-        run: |
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
-          docker push quay.io/open-cluster-management/argocd-pull-integration:${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}-${{ matrix.arch }}
-  image-manifest:
-    name: image manifest
-    runs-on: ubuntu-latest
-    needs: [ env, images ]
-    steps:
-      - name: checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 1
-      - name: create
-        run: |
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
-          docker manifest create quay.io/open-cluster-management/argocd-pull-integration:${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }} \
-            quay.io/open-cluster-management/argocd-pull-integration:${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}-amd64
-      - name: annotate
-        run: |
-          docker manifest annotate quay.io/open-cluster-management/argocd-pull-integration:${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }} \
-            quay.io/open-cluster-management/argocd-pull-integration:${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}-amd64 --arch amd64
-      - name: push
-        run: |
-          docker manifest push quay.io/open-cluster-management/argocd-pull-integration:${{ needs.env.outputs.TRIMMED_RELEASE_VERSION }}
+          make docker-buildx \
+            "IMG=quay.io/open-cluster-management/argocd-pull-integration:${IMAGE_TAG}" \
+            PLATFORMS=linux/amd64,linux/arm64
   release:
     name: release
     runs-on: ubuntu-latest
-    needs: [ env, image-manifest ]
+    needs: [ env, images ]
     steps:
       - name: checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name argocd-pull-integration-builder
 	$(CONTAINER_TOOL) buildx use argocd-pull-integration-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg ARGOCD_OPERATOR_IMAGE=$(ARGOCD_OPERATOR_IMAGE) --tag ${IMG} -f Dockerfile.cross .
+	$(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg ARGOCD_OPERATOR_IMAGE=$(ARGOCD_OPERATOR_IMAGE) --tag ${IMG} -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm argocd-pull-integration-builder
 	rm Dockerfile.cross
 


### PR DESCRIPTION
Fixes #179

  ## Summary - Files changed
  - **go-presubmit.yml**: Replace single-arch `docker build` with multi-arch `docker buildx build` (amd64 + arm64, verify only, no push)
  - **go-postsubmit.yml**: Replace single-arch build+push with `make docker-buildx` to build and push a multi-arch manifest for `:latest`
  - **go-release.yml**: Replace single-arch build+push and separate `image-manifest` job with a single `make docker-buildx` step that builds, creates the manifest, and pushes atomically

  ## Tests made
  - [x] Verified multi-arch buildx build locally (both amd64 and arm64 compile successfully)
  - [x] Pushed to a local registry and confirmed the manifest list contains both architectures
  - [x] Tests made with (`make test`) all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container images are now published as multi-architecture images supporting AMD64 and ARM64.
  * Release images are built and delivered together for a more consistent experience across platforms.

* **Bug Fixes**
  * Image validation now verifies successful multi-architecture builds before changes are merged.
  * Image publishing now uses the same multi-architecture build process for more consistent tested and released images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->